### PR TITLE
Avoid continuosly handling events due to leader election annotations

### DIFF
--- a/ovn_k8s/common/exceptions.py
+++ b/ovn_k8s/common/exceptions.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2016 Nicira, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class OvnK8sException(Exception):
+
+    def __init__(self, **kwargs):
+        self.message = self.message % kwargs
+
+
+class NotFound(OvnK8sException):
+    message = "%(resource_type)s %(resource_id)s not found"


### PR DESCRIPTION
Leader election causes a lot of endpoint updates (see kubernetes
issue #23812). This implies that roughly every 2 seconds an endpoint
MODIFIED event is sent for processing, for every endpoint where
leader election is enabled (examples: kube-scheduler or
kube-controller-manager).

This patch leverages the so far unused object cache in the endpoint
watcher, sending the event only when ip changes are detected in the
endpoint data structure. To this aim, the logic for extracting ips
from the endpoint object has been moved from overlay.py into
endpoint_watcher.py

Also, tt is not to be taken for granted that given and endpoint,
there will always be a service with that name. This patch therefore
also adds explicit handling of 404 errors.
This is however a rather minor point as the final result of this
error handling is the interruption of endpoint processing in any
case.