### PR TITLE
overlay.py: Don't delete logical switch port before creating it.

### DIFF
--- a/ovn_k8s/modes/overlay.py
+++ b/ovn_k8s/modes/overlay.py
@@ -151,9 +151,9 @@ class OvnNB(object):
             return
 
         try:
-            ovn_nbctl("--", "--if-exists", "lsp-del", logical_port,
-                      "--", "lsp-add", logical_switch, logical_port,
-                      "--", "lsp-set-addresses", logical_port, "dynamic")
+            ovn_nbctl("--", "--may-exist", "lsp-add", logical_switch,
+                      logical_port, "--", "lsp-set-addresses",
+                      logical_port, "dynamic")
         except Exception as e:
             vlog.err("_create_logical_port: lsp-add (%s)" % (str(e)))
             return


### PR DESCRIPTION
If we delete and re-create the logical port, dynamic addresses change.
So that breaks connectivity. This issue fixes it.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>