### PR TITLE
python3: Use next().

### DIFF
--- a/ovn_k8s/common/util.py
+++ b/ovn_k8s/common/util.py
@@ -63,7 +63,7 @@ def generate_mac(prefix="00:00:00"):
 def process_stream(data_stream, event_callback):
     # StopIteration should be caught in the routine that sets up the stream
     # and reconnects it
-    line = data_stream.next()
+    line = next(data_stream)
     if not line:
         return
 


### PR DESCRIPTION
Use the next() function to be compatible with Python 3.

Signed-off-by: Russell Bryant <russell@ovn.org>