### PR TITLE
ovn-k8s-overlay: Use the gateway router for North-South LB.

### DIFF
--- a/bin/ovn-k8s-overlay
+++ b/bin/ovn-k8s-overlay
@@ -330,24 +330,25 @@ def gateway_init(args):
     ovn_nbctl("--may-exist", "lr-route-add", k8s_cluster_router,
               "0.0.0.0/0", "100.64.1.2")
 
-    # Create the external switch for the physical interface to connect to.
-    external_switch = "ext_%s" % (node_name)
-    ovn_nbctl("--may-exist", "ls-add", external_switch)
-
-    # Add north-south load-balancers to that switch.
+    # Add north-south load-balancers to the gateway router.
     k8s_ns_lb_tcp = ovn_nbctl("--data=bare", "--no-heading",
                               "--columns=_uuid", "find", "load_balancer",
                               "external_ids:k8s-ns-lb-tcp=yes")
     if k8s_ns_lb_tcp:
-        ovn_nbctl("set", "logical_switch", external_switch,
+        ovn_nbctl("set", "logical_router", gateway_router,
                   "load_balancer=" + k8s_ns_lb_tcp)
 
     k8s_ns_lb_udp = ovn_nbctl("--data=bare", "--no-heading",
                               "--columns=_uuid", "find", "load_balancer",
                               "external_ids:k8s-ns-lb-udp=yes")
     if k8s_ns_lb_udp:
-        ovn_nbctl("add", "logical_switch", external_switch,
+        ovn_nbctl("add", "logical_router", gateway_router,
                   "load_balancer", k8s_ns_lb_udp)
+
+
+    # Create the external switch for the physical interface to connect to.
+    external_switch = "ext_%s" % (node_name)
+    ovn_nbctl("--may-exist", "ls-add", external_switch)
 
     # Connect physical interface to br-int. Get its mac address
     iface_id = "%s_%s" % (args.physical_interface, node_name)


### PR DESCRIPTION
The load-balancer on the external switch does not work when
there is a SNAT rule in the gateway router.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>