### PR TITLE
ovn-k8s-overlay: Flush the IP address of physical interface.

### DIFF
--- a/bin/ovn-k8s-overlay
+++ b/bin/ovn-k8s-overlay
@@ -359,6 +359,10 @@ def gateway_init(args):
     mac_address = ovs_vsctl("--if-exists", "get", "interface",
                             args.physical_interface, "mac_in_use").strip('"')
 
+    # Flush the IP address of the physical interface.
+    command = "ip addr flush dev %s" % (args.physical_interface)
+    util.call_popen(shlex.split(command))
+
     # Add physical_interface as a logical port to external_switch. This is
     # a learning switch port with "unknown" address.  The external world
     # is accessed via this port.


### PR DESCRIPTION
When we add a physical interface for a gateway, we copy
its IP address and MAC address and make it the IP address
and MAC address of the gateway router port in the logical space.

In the physical space, we add that interface as a port of br-int.
Once we do that, we should flush its IP address.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>