### PR TITLE
Do not assume pod is always in cache on delete

### DIFF
--- a/ovn_k8s/modes/overlay.py
+++ b/ovn_k8s/modes/overlay.py
@@ -53,7 +53,7 @@ class OvnNB(object):
     def _update_service_cache(self, event_type, cache_key, service_data):
         # Remove item from cache if it was deleted.
         if event_type == 'DELETED':
-            del self.service_cache[cache_key]
+            service_cache.pop(cache_key, None)
         else:
             # Update cache
             self.service_cache[cache_key] = service_data

--- a/ovn_k8s/watcher/pod_watcher.py
+++ b/ovn_k8s/watcher/pod_watcher.py
@@ -37,7 +37,10 @@ class PodWatcher(object):
     def _update_pod_cache(self, event_type, cache_key, pod_data):
         # Remove item from cache if it was deleted
         if event_type == 'DELETED':
-            del self.pod_cache[cache_key]
+            # Do not take for granted that the pod is in the key, as there are
+            # some corner cases in which a pod could be deleted without ever
+            # making it to local cache
+            self.pod_cache.pop(cache_key, None)
         else:
             # Update cache
             self.pod_cache[cache_key] = pod_data

--- a/ovn_k8s/watcher/service_watcher.py
+++ b/ovn_k8s/watcher/service_watcher.py
@@ -38,7 +38,7 @@ class ServiceWatcher(object):
     def _update_service_cache(self, event_type, cache_key, service_data):
         # Remove item from cache if it was deleted
         if event_type == 'DELETED':
-            del self.service_cache[cache_key]
+            service_cache.pop(cache_key, None)
         else:
             # Update cache
             self.service_cache[cache_key] = service_data


### PR DESCRIPTION
Replace del statement with pop method, in order to avoid watcher
failures due to KeyError when deleting a pod.
There is at least one corner case where a pod is never processed
and therefore never stored in cache, and that would be when the
kube scheduler is down and does not come up before the pod is deleted.

It is worth noting however that the observed failure is not
critical as the watcher is restarted.

Signed-off-by: Salvatore Orlando <salv.orlando@gmail.com>