### PR TITLE
overlay.py: Change a log statement from dbg to info

### DIFF
--- a/ovn_k8s/modes/overlay.py
+++ b/ovn_k8s/modes/overlay.py
@@ -215,7 +215,7 @@ class OvnNB(object):
             vlog.err("_delete_logical_port: lsp-add (%s)" % (str(e)))
             return
 
-        vlog.dbg("deleted logical port %s" % (logical_port))
+        vlog.info("deleted logical port %s" % (logical_port))
 
     def _update_vip(self, service_data, ips):
         service_type = service_data['spec'].get('type')


### PR DESCRIPTION
When a logical port is created we write the log as info.
When we delete a logical port, it makese sense to apply
the same standard.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>