### PR TITLE
Log traceback when watcher fails

### DIFF
--- a/ovn_k8s/watcher/watcher.py
+++ b/ovn_k8s/watcher/watcher.py
@@ -58,8 +58,9 @@ def _process_func(watcher, watcher_recycle_func):
             watcher.process()
         except Exception as e:
             # Recycle watcher
-            vlog.warn("Regenerating watcher because of %s and reconnecting to "
-                      "stream using function %s"
+            vlog.exception("Failure in watcher %s" % type(watcher).__name__)
+            vlog.warn("Regenerating watcher because of \"%s\" and "
+                      "reconnecting to stream using function %s"
                       % (str(e), watcher_recycle_func.__name__))
             watcher = watcher_recycle_func()
 


### PR DESCRIPTION
A full traceback could be quite useful for debugging and troubleshooting.
This patch add an additional vlog.exception statement, preserving the
original vlog.warn statement, which has been only slightly changed to
enclose the exception reason in double quotes

Signed-off-by: Salvatore Orlando <salv.orlando@gmail.com>