### PR TITLE
ovn-k8s-watcher: Add support for run-time commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ You then start a watcher on the master node to listen for Kubernetes events.
 This watcher is responsible to create logical ports and load-balancer entries.
 
 ```
-ovn-k8s-watcher --overlay --detach
+ovn-k8s-watcher --overlay --pidfile --log-file \
+ -vfile:info -vconsole:emer --detach
 ```
 
 The "underlay" mode

--- a/bin/ovn-k8s-watcher
+++ b/bin/ovn-k8s-watcher
@@ -15,6 +15,7 @@
 
 import argparse
 import eventlet
+import os
 import sys
 
 import ovs.dirs
@@ -49,6 +50,17 @@ def main():
     parser.add_argument('--overlay', action='store_true')
     parser.add_argument('--underlay', action='store_true')
     parser.add_argument('--openstack', action='store_true')
+
+    # Since our instructions asks to do a 'pip install ovs',
+    # for python libraries, we do not know how OVS core
+    # utilities have been installed.  So we try to do a best
+    # guess.
+    if os.path.isfile("/usr/bin/ovs-vsctl"):
+        ovs.dirs.RUNDIR = "/var/run/openvswitch"
+        ovs.dirs.LOGDIR = "/var/log/openvswitch"
+    else:
+        ovs.dirs.RUNDIR = "/usr/local/var/run/openvswitch"
+        ovs.dirs.LOGDIR = "/usr/local/var/log/openvswitch"
 
     # Handle OVS logging and daemonization arguments.
     ovs.vlog.add_args(parser)


### PR DESCRIPTION
We can now ask the watcher to exit with the run-time
command:
ovs-appctl -t ovn-k8s-watcher exit

We can list all the vlog modules:
ovs-appctl -t ovn-k8s-watcher vlog/list

We can run-time change the logging level of a particular module:
ovs-appctl -t ovn-k8s-watcher vlog/set overlay:file:DBG

Signed-off-by: Gurucharan Shetty <guru@ovn.org>