### PR TITLE
Sync K8s objects with OVN objects.

### DIFF
--- a/ovn_k8s/common/kubernetes.py
+++ b/ovn_k8s/common/kubernetes.py
@@ -87,16 +87,31 @@ def set_pod_annotation(server, namespace, pod, key, value):
     return annotations
 
 
-def get_service(server, namespace, service):
-    url = ("http://%s/api/v1/namespaces/%s/services/%s"
-           % (server, namespace, service))
+def _get_objects(url, namespace, resource_type, resource_id):
     response = requests.get(url)
     if not response:
         if response.status_code == 404:
-            raise exceptions.NotFound(resource_type='service',
-                                      resource_id=service)
+            raise exceptions.NotFound(resource_type=resource_type,
+                                      resource_id=resource_id)
         else:
-            raise Exception("Failed to fetch service (%d) :%s" % (
-                response.status_code, response.text))
+            raise Exception("Failed to fetch %s:%s in namespace %s (%d) :%s"
+                            % (resource_type, resource_id, namespace,
+                               response.status_code, response.text))
 
     return response.json()
+
+
+def get_service(server, namespace, service):
+    url = "http://%s/api/v1/namespaces/%s/services/%s" \
+            % (server, namespace, service)
+    return _get_objects(url, namespace, 'service', service)
+
+
+def get_all_pods(server):
+    url = "http://%s/api/v1/pods" % (server)
+    return _get_objects(url, 'all', 'pod', "all_pods")
+
+
+def get_all_services(server):
+    url = "http://%s/api/v1/services" % (server)
+    return _get_objects(url, 'all', 'service', "all_services")

--- a/ovn_k8s/modes/overlay.py
+++ b/ovn_k8s/modes/overlay.py
@@ -28,7 +28,6 @@ class OvnNB(object):
     def __init__(self):
         self.service_cache = {}
         self.logical_switch_cache = {}
-        self.gateway_ip_cache = {}
         self.physical_gateway_ips = []
 
     def _get_physical_gateway_ips(self):

--- a/ovn_k8s/watcher/service_watcher.py
+++ b/ovn_k8s/watcher/service_watcher.py
@@ -62,6 +62,10 @@ class ServiceWatcher(object):
         cached_service = self.service_cache.get(cache_key, {})
         self._update_service_cache(event_type, cache_key, service_data)
 
+        # TODO: A service can be patched (i.e modified) and its ports
+        # and external_ips can be changed.  We need a way to handle it.
+        # One way would be to send a delete and create connectivity events.
+
         has_conn_event = False
         if not cached_service:
             has_conn_event = True


### PR DESCRIPTION
    When the watcher dies, it is possible that some
    objects in k8s get deleted. When the watcher starts
    again, we will miss those events and stale entries
    will remain in the OVN database.

    With this commit, we do the following steps.
    1. Make a connection to k8s API server to get any
    events from that time on. But we do not process
    any of the events till step 3.

    2. We connect to k8s API server and get all the
    pod and services objects. We then compare it
    with OVN database to sync them.

    3. We now start processing new events from K8s API
    server.