### PR TITLE
Use pyroute2 in CNI plugin

### DIFF
--- a/bin/ovn-k8s-cni-overlay
+++ b/bin/ovn-k8s-cni-overlay
@@ -22,6 +22,8 @@ import sys
 import time
 
 import ovs.vlog
+import pyroute2
+
 from ovn_k8s.common import kubernetes
 from ovn_k8s.common.util import ovs_vsctl
 from ovn_k8s.common.util import call_popen
@@ -60,82 +62,62 @@ def setup_interface(container_id, cni_netns, cni_ifname,
         raise OVNCNIException(100, "failure in creation of netns directory")
 
     try:
+        ipdb = pyroute2.IPDB(mode='explicit')
         vlog.dbg("Creating veth pair for container %s" % container_id)
         veth_outside = container_id[:15]
         veth_inside = container_id[:13] + "_c"
-        command = "ip link add %s type veth peer name %s" \
-                  % (veth_outside, veth_inside)
-        call_popen(shlex.split(command))
-    except Exception as e:
-        vlog.warn("failed to create veth pairs")
-        raise OVNCNIException(100, "failed to create veth pair")
-
-    try:
-        # Up the outer interface
-        vlog.dbg("Bringing up veth outer interface %s" % veth_outside)
-        command = "ip link set %s up" % veth_outside
-        call_popen(shlex.split(command))
+        ipdb.create(ifname=veth_outside, kind='veth', peer=veth_inside)
+        with ipdb.interfaces[veth_outside] as veth_outside_iface:
+            # Up the outer interface
+            vlog.dbg("Bringing up veth outer interface %s" % veth_outside)
+            veth_outside_iface.up()
+            veth_outside_idx = veth_outside_iface.index
 
         # Create a link for the container namespace
+        # This is necessary also when using pyroute2
+        # See https://github.com/svinota/pyroute2/issues/290
         vlog.dbg("Create a link for container namespace")
         netns_dst = "/var/run/netns/%s" % container_id
         if not os.path.isfile(netns_dst):
             command = "ln -s %s %s" % (cni_netns, netns_dst)
             call_popen(shlex.split(command))
 
-        # Move the inner veth inside the container namespace
-        vlog.dbg("Adding veth inner interface to namespace for container %s"
-                 % container_id)
-        command = "ip link set %s netns %s" % (veth_inside, container_id)
-        call_popen(shlex.split(command))
+        with ipdb.interfaces[veth_inside] as veth_inside_iface:
+            # Move the inner veth inside the container namespace
+            vlog.dbg("Adding veth inner interface to namespace for "
+                     "container %s" % container_id)
+            veth_inside_iface.net_ns_fd = container_id
 
+    except Exception as e:
+        vlog.warn("failed to create veth pairs")
+        raise OVNCNIException(100, "veth pair setup failure")
+
+    try:
         # Change the name of veth_inside to $cni_ifname
-        vlog.dbg("Renaming veth inner interface '%s' to '%s'"
-                 % (veth_inside, cni_ifname))
-        command = "ip netns exec %s ip link set dev %s name %s" \
-                  % (container_id, veth_inside, cni_ifname)
-        call_popen(shlex.split(command))
-
-        # Up the inner interface
-        vlog.dbg("Bringing veth inner interface '%s' up" % cni_ifname)
-        command = "ip netns exec %s ip link set %s up" % (container_id,
-                                                          cni_ifname)
-        call_popen(shlex.split(command))
-
-        # Set the mtu to handle tunnels
-        vlog.dbg("Adjusting veth interface '%s' MTU for tunneling to %d"
-                 % (cni_ifname, 1400))
-        command = "ip netns exec %s ip link set dev %s mtu %s" \
-                  % (container_id, cni_ifname, 1400)
-        call_popen(shlex.split(command))
-
-        # Set the ip address
-        vlog.dbg("Setting IP address for container:%s interface:%s"
-                 % (container_id, cni_ifname))
-        command = "ip netns exec %s ip addr add %s dev %s" \
-                  % (container_id, ip_address, cni_ifname)
-        call_popen(shlex.split(command))
-
-        # Set the mac address
-        vlog.dbg("Setting MAC address for container:%s interface:%s"
-                 % (container_id, cni_ifname))
-        command = "ip netns exec %s ip link set dev %s address %s" \
-                  % (container_id, cni_ifname, mac_address)
-        call_popen(shlex.split(command))
+        ns_ipdb = pyroute2.IPDB(nl=pyroute2.NetNS(container_id),
+                                mode='explicit')
+        # Configure veth_inside: set name, mtu, mac address, ip, and bring up
+        vlog.dbg("Configuring and bringing up veth inner interface %s. "
+                 "New name:'%s',MAC address:'%s', MTU:'%s', IP:%s" %
+                 (veth_inside, cni_ifname, mac_address, 1400, ip_address))
+        with ns_ipdb.interfaces[veth_inside] as veth_inside_iface:
+            veth_inside_iface.ifname = cni_ifname
+            veth_inside_iface.address = mac_address
+            veth_inside_iface.mtu = 1400
+            veth_inside_iface.add_ip(ip_address)
+            veth_inside_iface.up()
 
         # Set the gateway
         vlog.dbg("Setting gateway_ip %s for container:%s"
                  % (gateway_ip, container_id))
-        command = "ip netns exec %s ip route add default via %s" \
-                  % (container_id, gateway_ip)
-        call_popen(shlex.split(command))
+        ns_ipdb.routes.add(dst='default', gateway=gateway_ip).commit()
 
         return veth_outside
     except Exception as e:
         vlog.warn("Failed to setup veth pair for pod: %s" % str(e))
-        command = "ip link delete %s" % (veth_outside)
-        call_popen(shlex.split(command))
-        raise OVNCNIException(100, "veth setup failure")
+        if veth_outside_idx:
+            pyroute2.IPRoute().link('del', index=veth_outside_idx)
+        raise OVNCNIException(100, "container interface setup failure")
 
 
 def cni_add(cni_ifname, cni_netns, namespace, pod_name, container_id):

--- a/bin/ovn-k8s-cni-overlay
+++ b/bin/ovn-k8s-cni-overlay
@@ -17,7 +17,6 @@ import argparse
 import ast
 import json
 import os
-import re
 import shlex
 import sys
 import time
@@ -51,8 +50,8 @@ class OVNCNIException(Exception):
         return json.dumps(error_data)
 
 
-def setup_interface(pid, container_id, cni_ifname, mac_address,
-                    ip_address, gateway_ip):
+def setup_interface(container_id, cni_netns, cni_ifname,
+                    mac_address, ip_address, gateway_ip):
     try:
         if not os.path.exists("/var/run/netns"):
             os.makedirs("/var/run/netns")
@@ -79,56 +78,56 @@ def setup_interface(pid, container_id, cni_ifname, mac_address,
 
         # Create a link for the container namespace
         vlog.dbg("Create a link for container namespace")
-        netns_dst = "/var/run/netns/%s" % pid
+        netns_dst = "/var/run/netns/%s" % container_id
         if not os.path.isfile(netns_dst):
-            netns_src = "/proc/%s/ns/net" % pid
-            command = "ln -s %s %s" % (netns_src, netns_dst)
+            command = "ln -s %s %s" % (cni_netns, netns_dst)
             call_popen(shlex.split(command))
 
         # Move the inner veth inside the container namespace
         vlog.dbg("Adding veth inner interface to namespace for container %s"
                  % container_id)
-        command = "ip link set %s netns %s" % (veth_inside, pid)
+        command = "ip link set %s netns %s" % (veth_inside, container_id)
         call_popen(shlex.split(command))
 
         # Change the name of veth_inside to $cni_ifname
         vlog.dbg("Renaming veth inner interface '%s' to '%s'"
                  % (veth_inside, cni_ifname))
         command = "ip netns exec %s ip link set dev %s name %s" \
-                  % (pid, veth_inside, cni_ifname)
+                  % (container_id, veth_inside, cni_ifname)
         call_popen(shlex.split(command))
 
         # Up the inner interface
         vlog.dbg("Bringing veth inner interface '%s' up" % cni_ifname)
-        command = "ip netns exec %s ip link set %s up" % (pid, cni_ifname)
+        command = "ip netns exec %s ip link set %s up" % (container_id,
+                                                          cni_ifname)
         call_popen(shlex.split(command))
 
         # Set the mtu to handle tunnels
         vlog.dbg("Adjusting veth interface '%s' MTU for tunneling to %d"
                  % (cni_ifname, 1400))
         command = "ip netns exec %s ip link set dev %s mtu %s" \
-                  % (pid, cni_ifname, 1400)
+                  % (container_id, cni_ifname, 1400)
         call_popen(shlex.split(command))
 
         # Set the ip address
         vlog.dbg("Setting IP address for container:%s interface:%s"
                  % (container_id, cni_ifname))
         command = "ip netns exec %s ip addr add %s dev %s" \
-                  % (pid, ip_address, cni_ifname)
+                  % (container_id, ip_address, cni_ifname)
         call_popen(shlex.split(command))
 
         # Set the mac address
         vlog.dbg("Setting MAC address for container:%s interface:%s"
                  % (container_id, cni_ifname))
         command = "ip netns exec %s ip link set dev %s address %s" \
-                  % (pid, cni_ifname, mac_address)
+                  % (container_id, cni_ifname, mac_address)
         call_popen(shlex.split(command))
 
         # Set the gateway
         vlog.dbg("Setting gateway_ip %s for container:%s"
                  % (gateway_ip, container_id))
         command = "ip netns exec %s ip route add default via %s" \
-                  % (pid, gateway_ip)
+                  % (container_id, gateway_ip)
         call_popen(shlex.split(command))
 
         return veth_outside
@@ -146,12 +145,6 @@ def cni_add(cni_ifname, cni_netns, namespace, pod_name, container_id):
         raise OVNCNIException(100, "failed to get K8S_API_SERVER")
     if not k8s_api_server.startswith("http"):
         k8s_api_server = "http://%s" % k8s_api_server
-
-    pid_match = re.match("^/proc/(.\d*)/ns/net$", cni_netns)
-    if not pid_match:
-        raise OVNCNIException(100,
-                              "unable to extract container pid from namespace")
-    pid = pid_match.groups()[0]
 
     # Get the IP address and MAC address from the API server.
     # Wait for a maximum of 3 seconds with a retry every 0.1 second.
@@ -183,7 +176,7 @@ def cni_add(cni_ifname, cni_netns, namespace, pod_name, container_id):
     except Exception as e:
         OVNCNIException(100, "failed in pod annotation key extract")
 
-    veth_outside = setup_interface(pid, container_id, cni_ifname,
+    veth_outside = setup_interface(container_id, cni_netns, cni_ifname,
                                    mac_address, ip_address,
                                    gateway_ip)
 
@@ -205,19 +198,14 @@ def cni_add(cni_ifname, cni_netns, namespace, pod_name, container_id):
     print(output)
 
 
-def cni_del(cni_netns, container_id):
+def cni_del(container_id):
     try:
         ovs_vsctl("del-port", container_id[:15])
     except Exception:
         message = "failed to delete OVS port %s" % container_id[:15]
         vlog.err(message)
 
-    pid_match = re.match("^/proc/(.\d*)/ns/net$", cni_netns)
-    if not pid_match:
-        raise OVNCNIException(100,
-                              "unable to extract container pid from namespace")
-    pid = pid_match.groups()[0]
-    command = "rm -f /var/run/netns/%s" % pid
+    command = "rm -f /var/run/netns/%s" % container_id
     call_popen(shlex.split(command))
 
 
@@ -256,7 +244,7 @@ def main():
     if cni_command == "ADD":
         cni_add(cni_ifname, cni_netns, namespace, pod_name, container_id)
     elif cni_command == "DEL":
-        cni_del(cni_netns, container_id)
+        cni_del(container_id)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.9.1
 ovs>=2.6.0
 six
 eventlet
+pyroute2>=0.4.6


### PR DESCRIPTION
Having to shell out is not nice just like having to worry about privsep.
Using pyroute solves the first problem, even if it does not really solve the latter (But with the current plugin execution model the responsibility of setting the right capabilities are on the kubelet)

Anyway, there are two commits in this PR.
The first is just about leveraging CNI_NETNS for the namespace path
The second introduces pyroute. 
