### PR TITLE
ovn-k8s-overlay: Update CNI configuration file path

### DIFF
--- a/bin/ovn-k8s-overlay
+++ b/bin/ovn-k8s-overlay
@@ -26,7 +26,7 @@ from ovn_k8s.common.util import ovs_vsctl
 from ovn_k8s.common.util import ovn_nbctl
 from ovn_k8s.common import variables
 
-CNI_CONF_PATH = "/usr/libexec/kubernetes/kubelet-plugins/net/exec"
+CNI_CONF_PATH = "/etc/cni/net.d"
 CNI_LINK_PATH = "/opt/cni/bin/"
 CNI_PLUGIN = "ovn-k8s-cni-overlay"
 


### PR DESCRIPTION
The latest kubernetes CNI integration [1] changed where the default CNI
configuration files are read from. This updates ovn-k8s-overlay to
generate it's configuration file in this new location.

[1] https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/network/cni/cni.go#L38

Signed-off-by: Kyle Mestery <mestery@mestery.com>