### PR TITLE
INSTALL.K8S.md: Update docs about upstream CNI plugin requirements.

### DIFF
--- a/docs/INSTALL.K8S.md
+++ b/docs/INSTALL.K8S.md
@@ -26,12 +26,21 @@ nohup ./kube-controller-manager --master=127.0.0.1:8080 \
 nohup ./kube-scheduler --master=127.0.0.1:8080 --v=2 2>&1 > /dev/null &
 ```
 
-On the minions, start the kubelet specifying that the network plugin is of type
-CNI. e.g:
+On the minions, you need to download a few upstream CNI plugins (as root or
+using sudo)
+
+```
+mkdir -p /opt/cni/bin && cd /opt/cni/bin
+wget https://github.com/containernetworking/cni/releases/download/v0.2.0/cni-v0.2.0.tgz
+tar xfz cni-v0.2.0.tgz
+```
+
+On minions, start the kubelet specifying that the network plugin is of type
+CNI and the network plugin directory to be /etc/cni/net.d. e.g:
 
 ```
 nohup ./kubelet --api-servers=http://10.33.74.22:8080 --v=2 --address=0.0.0.0 \
---enable-server=true --network-plugin=cni 2>&1 > /dev/null &
+--enable-server=true --network-plugin=cni --network-plugin-dir=/etc/cni/net.d  2>&1 > /dev/null &
 ```
 
 You can then verify that all your nodes are registered by running the following


### PR DESCRIPTION
Based on the bug https://github.com/kubernetes/kubernetes/issues/30681,
we should download CNI plugins from upstream repo for k8s to work.

And we now should also specify the --network-plugin-dir for kubelet.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>