### PR TITLE
ovn-k8s-overlay: Set the MTU of internal interface lower.

### DIFF
--- a/bin/ovn-k8s-overlay
+++ b/bin/ovn-k8s-overlay
@@ -99,6 +99,7 @@ def create_management_port(node_name, local_subnet, cluster_subnet):
     ovs_vsctl("--", "--may-exist", "add-port", "br-int",
               interface_name, "--", "set", "interface",
               interface_name, "type=internal",
+              "mtu_request=1400",
               "external-ids:iface-id=k8s-" + node_name)
 
     mac_address = ovs_vsctl("--if-exists", "get", "interface",


### PR DESCRIPTION
Because we use tunnels, the MTU of the internal interface
should be low. We set the container network interface to
have a MTU of 1400, so we can do the same here.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>