### PR TITLE
Vagrant: Add support to try this with Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .eggs
 *.pyc
+
+vagrant/k8s/
+vagrant/.vagrant/
+vagrant/ubuntu-xenial-16.04-cloudimg-console.log
+

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,70 @@
+Kubernetes and OVN
+==================
+
+This contains a Vagrant setup for Kubernetes and OVN integration.
+
+Howto
+-----
+
+Pull down Kubernetes (it's big)
+
+* mkdir k8s
+* cd k8s
+* wget https://github.com/kubernetes/kubernetes/releases/download/v1.3.7/kubernetes.tar.gz
+* tar xvzf kubernetes.tar.gz
+* mkdir server
+* cd server
+* tar xvzf ../kubernetes/server/kubernetes-server-linux-amd64.tar.gz
+
+Bringup the Vagrant setup
+
+* vagrant up
+
+Create a pod
+------------
+
+Create apache.yaml as follows:
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: apache
+  labels:
+    name: apache
+spec:
+  containers:
+  - name: apache
+    image: fedora/apache
+```
+
+Run that as follows:
+
+* kubectl create -f ~/apache.yaml
+
+Look at this deployment:
+
+* kubectl get pods,svc
+* kubectl describe pod apache
+
+Launch a busybox pod:
+
+* kubectl run -i --tty busybox --image=busybox -- sh
+
+Verify this pod:
+
+* kubectl get pods
+* kubectl describe pod <busybox pod name>
+
+You can now login to the busybox pod on the minion host and ping across pods.
+
+[1]: https://hub.docker.com/r/google/nodejs-hello/
+[2]: http://kubernetes.io/docs/hellonode/
+
+References
+----------
+
+https://github.com/openvswitch/ovn-kubernetes
+http://kubernetes.io/docs/hellonode/
+http://kubernetes.io/docs/user-guide/kubectl-cheatsheet/
+https://blog.jetstack.io/blog/k8s-getting-started-part2/

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,101 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+require 'ipaddr'
+
+vagrant_config = YAML.load_file("provisioning/virtualbox.conf.yml")
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.synced_folder File.expand_path("k8s"), "/home/ubuntu/k8s"
+
+  # Use the ipaddr library to calculate the netmask of a given network
+  net = IPAddr.new vagrant_config['public_network']
+  netmask = net.inspect().split("/")[1].split(">")[0]
+
+  # Bring up the Devstack ovsdb/ovn-northd node on Virtualbox
+  config.vm.define "k8s-master" do |k8smaster|
+    k8smaster.vm.host_name = vagrant_config['k8smaster']['host_name']
+    k8smaster.vm.network "private_network", ip: vagrant_config['k8smaster']['overlay-ip']
+    k8smaster.vm.network "private_network", ip: vagrant_config['k8smaster']['public-ip'], netmask: netmask
+    k8smaster.vm.provision "shell", path: "provisioning/setup-master.sh", privileged: false,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['public-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8smaster']['master-switch-subnet']}"
+    k8smaster.vm.provision "shell", path: "provisioning/setup-k8s-master.sh", privileged: false,
+      :args => "#{vagrant_config['k8smaster']['public-ip']} #{netmask} #{vagrant_config['public_gateway']}"
+    k8smaster.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['short_name']}"
+    k8smaster.vm.provider "virtualbox" do |vb|
+       vb.name = vagrant_config['k8smaster']['short_name']
+       vb.memory = 2048
+       vb.cpus = 2
+       vb.customize [
+           'modifyvm', :id,
+           '--nicpromisc3', "allow-all"
+          ]
+       vb.customize [
+           "guestproperty", "set", :id,
+           "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000
+          ]
+    end
+  end
+
+  config.vm.define "k8s-minion1" do |k8sminion1|
+    k8sminion1.vm.host_name = vagrant_config['k8sminion1']['host_name']
+    k8sminion1.vm.host_name = "k8sminion1"
+    k8sminion1.vm.network "private_network", ip: vagrant_config['k8sminion1']['overlay-ip']
+    k8sminion1.vm.network "private_network", ip: vagrant_config['k8sminion1']['public-ip'], netmask: netmask
+    k8sminion1.vm.provision "shell", path: "provisioning/setup-minion.sh", privileged: false,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8smaster']['public-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion1']['minion-switch-subnet']}"
+    k8sminion1.vm.provision "shell", path: "provisioning/setup-k8s-minion.sh", privileged: false,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']}"
+    k8sminion1.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['short_name']}"
+    k8sminion1.vm.provider "virtualbox" do |vb|
+       vb.name = vagrant_config['k8sminion1']['short_name']
+       vb.memory = 2048
+       vb.cpus = 2
+       vb.customize [
+           'modifyvm', :id,
+           '--nicpromisc3', "allow-all"
+          ]
+       vb.customize [
+           "guestproperty", "set", :id,
+           "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000
+          ]
+    end
+  end
+
+  config.vm.define "k8s-minion2" do |k8sminion2|
+    k8sminion2.vm.host_name = vagrant_config['k8sminion2']['host_name']
+    k8sminion2.vm.host_name = "k8sminion2"
+    k8sminion2.vm.network "private_network", ip: vagrant_config['k8sminion2']['overlay-ip']
+    k8sminion2.vm.network "private_network", ip: vagrant_config['k8sminion2']['public-ip'], netmask: netmask
+    k8sminion2.vm.provision "shell", path: "provisioning/setup-minion.sh", privileged: false,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8smaster']['public-ip']} #{vagrant_config['k8sminion2']['short_name']} #{vagrant_config['k8sminion2']['minion-switch-subnet']}"
+    k8sminion2.vm.provision "shell", path: "provisioning/setup-k8s-minion.sh", privileged: false,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']}"
+    k8sminion2.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['short_name']}"
+    k8sminion2.vm.provider "virtualbox" do |vb|
+       vb.name = vagrant_config['k8sminion2']['short_name']
+       vb.memory = 2048
+       vb.cpus = 2
+       vb.customize [
+           'modifyvm', :id,
+           '--nicpromisc3', "allow-all"
+          ]
+       vb.customize [
+           "guestproperty", "set", :id,
+           "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000
+          ]
+    end
+  end
+
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    v.customize ["modifyvm", :id, "--nictype1", "virtio"]
+  end
+end

--- a/vagrant/provisioning/setup-hostnames.sh
+++ b/vagrant/provisioning/setup-hostnames.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Save trace setting
+XTRACE=$(set +o | grep xtrace)
+set -o xtrace
+
+# ARGS:
+# $1: Master IP
+# $2: Master hostname
+# $3: Minion1 IP
+# $4: Minion1 hostname
+# $5: Minion2 IP
+# $6: Minion2 hostname
+
+MASTER_IP=$1
+MASTER_HOSTNAME=$2
+MINION1_IP=$3
+MINION1_HOSTNAME=$4
+MINION2_IP=$5
+MINION2_HOSTNAME=$6
+
+cat << HOSTEOF >> /etc/hosts
+$MASTER_IP $MASTER_HOSTNAME
+$MINION1_IP $MINION1_HOSTNAME
+$MINION2_IP $MINION2_HOSTNAME
+HOSTEOF
+
+# Restore xtrace
+$XTRACE

--- a/vagrant/provisioning/setup-k8s-master.sh
+++ b/vagrant/provisioning/setup-k8s-master.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Save trace setting
+XTRACE=$(set +o | grep xtrace)
+set -o xtrace
+
+# args:
+# $1: The gateway IP to use
+# $2: The gateway subnet mask
+# $3: The default GW for the GW device
+
+PUBLIC_IP=$1
+PUBLIC_SUBNET_MASK=$2
+GW_IP=$3
+
+# First, install docker
+sudo apt-get update
+sudo apt-get install -y apt-transport-https ca-certificates
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo su -c "echo \"deb https://apt.dockerproject.org/repo ubuntu-xenial main\" >> /etc/apt/sources.list.d/docker.list"
+sudo apt-get update
+sudo apt-get purge lxc-docker
+sudo apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual
+sudo apt-get install -y docker-engine
+sudo service docker start
+
+# Install k8s
+
+# Install an etcd cluster
+sudo docker run --net=host -d gcr.io/google_containers/etcd:2.0.12 /usr/local/bin/etcd \
+                --addr=127.0.0.1:4001 --bind-addr=0.0.0.0:4001 --data-dir=/var/etcd/data
+
+# Download Kubernetes ... yes, it's huge
+#mkdir k8s
+#pushd k8s
+#wget https://github.com/kubernetes/kubernetes/releases/download/v1.3.7/kubernetes.tar.gz
+#tar xvzf kubernetes.tar.gz
+
+# Now untar kubernetes-server-linux-amd64.tar.gz
+#mkdir server
+#cd server
+#tar xvzf ../kubernetes/server/linux/kubernetes-server-linux-amd64.tar.gz
+#popd
+
+# Start k8s daemons
+pushd k8s/server/kubernetes/server/bin
+echo "Starting kube-apiserver ..."
+nohup sudo ./kube-apiserver --service-cluster-ip-range=192.168.200.0/24 \
+                            --address=0.0.0.0 --etcd-servers=http://127.0.0.1:4001 \
+                            --v=2 2>&1 0<&- &>/dev/null &
+sleep 5
+
+echo "Starting kube-controller-manager ..."
+nohup sudo ./kube-controller-manager --master=127.0.0.1:8080 --v=2 2>&1 0<&- &>/dev/null &
+sleep 5
+
+echo "Starting kube-scheduler ..."
+nohup sudo ./kube-scheduler --master=127.0.0.1:8080 --v=2 2>&1 0<&- &>/dev/null &
+sleep 5
+
+echo "Starting ovn-k8s-watcher ..."
+sudo ovn-k8s-watcher --overlay --pidfile --log-file -vfile:info -vconsole:emer --detach
+
+# Setup the GW node on the master
+sudo ovn-k8s-overlay gateway-init --cluster-ip-subnet="192.168.0.0/16" --physical-interface enp0s9 \
+                                  --physical-ip $PUBLIC_IP/$PUBLIC_SUBNET_MASK \
+                                  --node-name="kube-gateway-node1" --default-gw $GW_IP
+sleep 5
+popd
+
+# Restore xtrace
+$XTRACE

--- a/vagrant/provisioning/setup-k8s-minion.sh
+++ b/vagrant/provisioning/setup-k8s-minion.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Save trace setting
+XTRACE=$(set +o | grep xtrace)
+set -o xtrace
+
+# args
+# $1: IP of master host
+
+MASTER_IP=$1
+
+# First, install docker
+sudo apt-get update
+sudo apt-get install -y apt-transport-https ca-certificates
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo su -c "echo \"deb https://apt.dockerproject.org/repo ubuntu-xenial main\" >> /etc/apt/sources.list.d/docker.list"
+sudo apt-get update
+sudo apt-get purge lxc-docker
+sudo apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual
+sudo apt-get install -y docker-engine
+sudo service docker start
+
+# Install k8s
+
+# Download Kubernetes ... yes, it's huge
+#mkdir k8s
+#pushd k8s
+#wget https://github.com/kubernetes/kubernetes/releases/download/v1.3.7/kubernetes.tar.gz
+#tar xvzf kubernetes.tar.gz
+
+# Now untar kubernetes-server-linux-amd64.tar.gz
+#mkdir server
+#cd server
+#tar xvzf ../kubernetes/server/linux/kubernetes-server-linux-amd64.tar.gz
+#popd
+
+# Install CNI
+pushd ~/
+wget https://github.com/containernetworking/cni/releases/download/v0.2.0/cni-v0.2.0.tgz
+popd
+sudo mkdir -p /opt/cni/bin
+pushd /opt/cni/bin
+sudo tar xvzf ~/cni-v0.2.0.tgz
+popd
+
+# Start k8s daemons
+pushd k8s/server/kubernetes/server/bin
+echo "Starting kubelet ..."
+nohup sudo ./kubelet --api-servers=http://$MASTER_IP:8080 --v=2 --address=0.0.0.0 \
+                     --enable-server=true --network-plugin=cni \
+                     --network-plugin-dir=/etc/cni/net.d 2>&1 0<&- &>/dev/null &
+sleep 5
+popd
+
+# Restore xtrace
+$XTRACE

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Save trace setting
+XTRACE=$(set +o | grep xtrace)
+set -o xtrace
+
+# ARGS:
+# $1: IP of second interface of master
+# $2: IP of third interface of master
+# $3: Hostname of the master
+# $4: Master switch subnet
+
+OVERLAY_IP=$1
+GW_IP=$2
+MASTER_NAME=$3
+MASTER_SUBNET=$4
+
+# Install OVS and dependencies
+# FIXME(mestery): Remove once Vagrant boxes allow apt-get to work again
+sudo rm -rf /var/lib/apt/lists/*
+sudo apt-get update
+sudo apt-get install -y graphviz autoconf automake bzip2 debhelper dh-autoreconf \
+                        libssl-dev libtool openssl procps python-all \
+                        python-twisted-conch python-zopeinterface python-six
+
+git clone https://github.com/openvswitch/ovs.git
+pushd ovs/
+sudo DEB_BUILD_OPTIONS='nocheck parallel=2' fakeroot debian/rules binary
+
+# Install OVS/OVN debs
+popd
+sudo dpkg -i openvswitch-switch_2.6.90-1_amd64.deb openvswitch-common_2.6.90-1_amd64.deb \
+             ovn-central_2.6.90-1_amd64.deb ovn-common_2.6.90-1_amd64.deb \
+             python-openvswitch_2.6.90-1_all.deb ovn-docker_2.6.90-1_amd64.deb \
+             ovn-host_2.6.90-1_amd64.deb
+
+# Start the daemons
+sudo /etc/init.d/openvswitch-switch stop
+sudo /etc/init.d/openvswitch-switch start
+sudo /usr/share/openvswitch/scripts/ovn-ctl stop_northd
+sudo /usr/share/openvswitch/scripts/ovn-ctl start_northd
+
+sudo ovs-vsctl set Open_vSwitch . external_ids:ovn-remote="tcp:$OVERLAY_IP:6642" \
+                                  external_ids:ovn-nb="tcp:$OVERLAY_IP:6641" \
+                                  external_ids:ovn-encap-ip=$OVERLAY_IP \
+                                  external_ids:ovn-encap-type=geneve
+
+# Re-start OVN controller
+sudo /usr/share/openvswitch/scripts/ovn-ctl stop_controller
+sudo /usr/share/openvswitch/scripts/ovn-ctl start_controller
+
+# Set k8s API server IP
+sudo ovs-vsctl set Open_vSwitch . external_ids:k8s-api-server="0.0.0.0:8080"
+
+# Create br-int
+sudo ovs-vsctl add-br --may-exist br-int
+
+# Install OVN+K8S Integration
+sudo apt-get install -y python-pip
+sudo -H pip install --upgrade pip
+git clone https://github.com/openvswitch/ovn-kubernetes
+pushd ovn-kubernetes
+sudo -H pip install .
+popd
+
+# Initialize the master
+sudo ovn-k8s-overlay master-init --cluster-ip-subnet="192.168.0.0/16" \
+                                 --master-switch-subnet="$MASTER_SUBNET" \
+                                 --node-name="$MASTER_NAME"
+
+# Restore xtrace
+$XTRACE

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -19,9 +19,10 @@ MASTER_SUBNET=$4
 # FIXME(mestery): Remove once Vagrant boxes allow apt-get to work again
 sudo rm -rf /var/lib/apt/lists/*
 sudo apt-get update
+sudo apt-get build-dep dkms
 sudo apt-get install -y graphviz autoconf automake bzip2 debhelper dh-autoreconf \
                         libssl-dev libtool openssl procps python-all \
-                        python-twisted-conch python-zopeinterface python-six
+                        python-twisted-conch python-zopeinterface python-six dkms
 
 git clone https://github.com/openvswitch/ovs.git
 pushd ovs/
@@ -29,14 +30,14 @@ sudo DEB_BUILD_OPTIONS='nocheck parallel=2' fakeroot debian/rules binary
 
 # Install OVS/OVN debs
 popd
+sudo dpkg -i openvswitch-datapath-dkms_2.6.90-1_all.deb
 sudo dpkg -i openvswitch-switch_2.6.90-1_amd64.deb openvswitch-common_2.6.90-1_amd64.deb \
              ovn-central_2.6.90-1_amd64.deb ovn-common_2.6.90-1_amd64.deb \
              python-openvswitch_2.6.90-1_all.deb ovn-docker_2.6.90-1_amd64.deb \
              ovn-host_2.6.90-1_amd64.deb
 
 # Start the daemons
-sudo /etc/init.d/openvswitch-switch stop
-sudo /etc/init.d/openvswitch-switch start
+sudo /etc/init.d/openvswitch-switch force-reload-kmod
 sudo /usr/share/openvswitch/scripts/ovn-ctl stop_northd
 sudo /usr/share/openvswitch/scripts/ovn-ctl start_northd
 
@@ -51,9 +52,6 @@ sudo /usr/share/openvswitch/scripts/ovn-ctl start_controller
 
 # Set k8s API server IP
 sudo ovs-vsctl set Open_vSwitch . external_ids:k8s-api-server="0.0.0.0:8080"
-
-# Create br-int
-sudo ovs-vsctl add-br --may-exist br-int
 
 # Install OVN+K8S Integration
 sudo apt-get install -y python-pip

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Save trace setting
+XTRACE=$(set +o | grep xtrace)
+set -o xtrace
+
+# ARGS:
+# $1: IP of second interface of master
+# $2: IP of second interface of minion
+# $3: IP of third interface of master
+# $4: Hostname of specific minion
+# $5: Subnet to use
+
+MASTER_OVERLAY_IP=$1
+MINION_OVERLAY_IP=$2
+GW_IP=$3
+MINION_NAME=$4
+MINION_SUBNET=$5
+
+# Install OVS and dependencies
+# FIXME(mestery): Remove once Vagrant boxes allow apt-get to work again
+sudo rm -rf /var/lib/apt/lists/*
+sudo apt-get update
+sudo apt-get install -y graphviz autoconf automake bzip2 debhelper dh-autoreconf \
+                        libssl-dev libtool openssl procps python-all \
+                        python-twisted-conch python-zopeinterface python-six
+
+git clone https://github.com/openvswitch/ovs.git
+pushd ovs/
+sudo DEB_BUILD_OPTIONS='nocheck parallel=2' fakeroot debian/rules binary
+
+# Install OVS/OVN debs
+popd
+sudo dpkg -i openvswitch-switch_2.6.90-1_amd64.deb openvswitch-common_2.6.90-1_amd64.deb \
+             ovn-common_2.6.90-1_amd64.deb python-openvswitch_2.6.90-1_all.deb \
+             ovn-docker_2.6.90-1_amd64.deb ovn-host_2.6.90-1_amd64.deb
+
+# Start the daemons
+sudo /etc/init.d/openvswitch-switch stop
+sudo /etc/init.d/openvswitch-switch start
+
+sudo ovs-vsctl set Open_vSwitch . external_ids:ovn-remote="tcp:$MASTER_OVERLAY_IP:6642" \
+                                  external_ids:ovn-nb="tcp:$MASTER_OVERLAY_IP:6641" \
+                                  external_ids:ovn-encap-ip=$MINION_OVERLAY_IP \
+                                  external_ids:ovn-encap-type=geneve
+
+# Re-start OVN controller
+sudo /usr/share/openvswitch/scripts/ovn-ctl stop_controller
+sudo /usr/share/openvswitch/scripts/ovn-ctl start_controller
+
+# Set k8s API server IP
+sudo ovs-vsctl set Open_vSwitch . external_ids:k8s-api-server="$MASTER_OVERLAY_IP:8080"
+
+# Create br-int
+sudo ovs-vsctl add-br --may-exist br-int
+
+# Install OVN+K8S Integration
+sudo apt-get install -y python-pip
+sudo -H pip install --upgrade pip
+git clone https://github.com/openvswitch/ovn-kubernetes
+pushd ovn-kubernetes
+sudo -H pip install .
+popd
+
+# Initialize the minion
+sudo ovn-k8s-overlay minion-init --cluster-ip-subnet="192.168.0.0/16" \
+                                 --minion-switch-subnet="$MINION_SUBNET" \
+                                 --node-name="$MINION_NAME"
+
+# Restore xtrace
+$XTRACE

--- a/vagrant/provisioning/virtualbox.conf.yml
+++ b/vagrant/provisioning/virtualbox.conf.yml
@@ -1,0 +1,28 @@
+---
+box: "ubuntu/xenial64"
+public_network: "10.10.0.0/16"
+public_gateway: "10.10.0.1"
+k8smaster:
+  short_name: "k8smaster"
+  host_name: "k8smaster.ovn"
+  overlay-ip: "192.168.33.11"
+  public-ip: "10.10.0.11"
+  master-switch-subnet: "192.168.1.0/24"
+  memory: 2048
+  cpus: 2
+k8sminion1:
+  short_name: "k8sminion1"
+  host_name: "k8sminion1.ovn"
+  overlay-ip: "192.168.33.12"
+  public-ip: "10.10.0.12"
+  minion-switch-subnet: "192.168.2.0/24"
+  memory: 2048
+  cpus: 2
+k8sminion2:
+  short_name: "k8sminion2"
+  host_name: "k8sminion2.ovn"
+  overlay-ip: "192.168.33.13"
+  public-ip: "10.10.0.13"
+  minion-switch-subnet: "192.168.3.0/24"
+  memory: 2048
+  cpus: 2


### PR DESCRIPTION
This commit adds a handy Vagrant setup to easily try out OVN integration with
Kubernetes. It allows a user to create a master node and 2 minion nodes, with
OVN configured with the latest upstream master code.

Signed-off-by: Kyle Mestery <mestery@mestery.com>