### PR TITLE
vagrant: Update and clarify examples

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -20,32 +20,28 @@ Bringup the Vagrant setup
 
 * vagrant up
 
-Create a pod
-------------
+Run some containers
+-------------------
 
-Create apache.yaml as follows:
+The Vagrant will create some sample yaml files for configuring a pod
+running Apache, as well as yaml for creating an east-west service and
+a north-south service. To try these out, follow these instructions.
 
-```
-apiVersion: v1
-kind: Pod
-metadata:
-  name: apache
-  labels:
-    name: apache
-spec:
-  containers:
-  - name: apache
-    image: fedora/apache
-```
+* cd ~/k8s/server/kubernetes/server/bin
+* ./kubectl create -f ~/apache-pod.yaml
+* ./kubectl create -f ~/apache-e-w.yaml
+* ./kubectl create -f ~/apache-n-s.yaml
 
-Run that as follows:
+You can verify the services are up and running now:
 
-* kubectl create -f ~/apache.yaml
+* ./kubectl get pods
+* ./kubectl get svc
 
-Look at this deployment:
+You can now get to the service from the host running Virtualbox by using
+the Nodeport and the IP 10.10.0.11 (the public-ip for the master found in
+the vagrant/provisioning/virtualbox.conf.yml file).
 
-* kubectl get pods,svc
-* kubectl describe pod apache
+* curl 10.10.0.11:[nodeport]
 
 Launch a busybox pod:
 

--- a/vagrant/provisioning/setup-k8s-master.sh
+++ b/vagrant/provisioning/setup-k8s-master.sh
@@ -68,5 +68,56 @@ sudo ovn-k8s-overlay gateway-init --cluster-ip-subnet="192.168.0.0/16" --physica
 sleep 5
 popd
 
+# Setup some example yaml files
+cat << APACHEPOD >> ~/apache-pod.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: apachetwin
+  labels:
+    name: apache
+spec:
+  containers:
+  - name: apachetwin
+    image: fedora/apache
+APACHEPOD
+
+cat << APACHEEW >> ~/apache-e-w.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: apacheservice
+    role: service
+  name: apacheservice
+spec:
+  ports:
+    - port: 8800
+      targetPort: 80
+      protocol: TCP
+      name: tcp
+  selector:
+    name: apache
+APACHEEW
+
+cat << APACHENS >> ~/apache-n-s.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: apacheexternal
+    role: service
+  name: apacheexternal
+spec:
+  ports:
+    - port: 8800
+      targetPort: 80
+      protocol: TCP
+      name: tcp
+  selector:
+    name: apache
+  type: NodePort
+APACHENS
+
 # Restore xtrace
 $XTRACE


### PR DESCRIPTION
Add some logic to generate yaml files to bringup a simple Apache
pod, as well as both east-west and north-south load balancing
for the pod.

Signed-off-by: Kyle Mestery <mestery@mestery.com>