### PR TITLE
vagrant: Add nginx pod to show OVN load balancing

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -29,6 +29,7 @@ a north-south service. To try these out, follow these instructions.
 
 * cd ~/k8s/server/kubernetes/server/bin
 * ./kubectl create -f ~/apache-pod.yaml
+* ./kubectl create -f ~/nginx-pod.yaml
 * ./kubectl create -f ~/apache-e-w.yaml
 * ./kubectl create -f ~/apache-n-s.yaml
 
@@ -42,6 +43,9 @@ the Nodeport and the IP 10.10.0.11 (the public-ip for the master found in
 the vagrant/provisioning/virtualbox.conf.yml file).
 
 * curl 10.10.0.11:[nodeport]
+
+You should see OVN doing load-balancing between the pods, which means you will
+both the apache example page and the nginx example page.
 
 Launch a busybox pod:
 

--- a/vagrant/provisioning/setup-k8s-master.sh
+++ b/vagrant/provisioning/setup-k8s-master.sh
@@ -75,12 +75,25 @@ kind: Pod
 metadata:
   name: apachetwin
   labels:
-    name: apache
+    name: webserver
 spec:
   containers:
   - name: apachetwin
     image: fedora/apache
 APACHEPOD
+
+cat << NGINXPOD >> ~/nginx-pod.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginxtwin
+  labels:
+    name: webserver
+spec:
+  containers:
+  - name: nginxtwin
+    image: nginx
+NGINXPOD
 
 cat << APACHEEW >> ~/apache-e-w.yaml
 apiVersion: v1
@@ -97,7 +110,7 @@ spec:
       protocol: TCP
       name: tcp
   selector:
-    name: apache
+    name: webserver
 APACHEEW
 
 cat << APACHENS >> ~/apache-n-s.yaml
@@ -115,7 +128,7 @@ spec:
       protocol: TCP
       name: tcp
   selector:
-    name: apache
+    name: webserver
   type: NodePort
 APACHENS
 


### PR DESCRIPTION
Add the creation of an nginx pod to show OVN load balancing
between different pods.

Signed-off-by: Kyle Mestery <mestery@mestery.com>