### PR TITLE
create_logical_port: return if pod name not specified

### DIFF
--- a/ovn_k8s/modes/overlay.py
+++ b/ovn_k8s/modes/overlay.py
@@ -135,7 +135,7 @@ class OvnNB(object):
         pod_name = data['metadata']['name']
         namespace = data['metadata']['namespace']
         logical_port = "%s_%s" % (namespace, pod_name)
-        if not logical_switch or not logical_port:
+        if not logical_switch or not pod_name:
             vlog.err("absent node name or pod name in pod %s. "
                      "Not creating logical port" % (data))
             return


### PR DESCRIPTION
Code will try to create a logical port even if the pod name
is not found in pod data. While this is however extremely
unlikely to occurr, if not impossible, this patch simply ensures
the if condition actually tests what we want to test.

The logical_port variable is indeed built from namespace and pod
name and will never be false in a test.

Signed-off-by: Salvatore Orlando <salv.orlando@gmail.com>