### PR TITLE
 ovn-k8s-cni-overlay:when Exception,the string is missing a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,14 @@ kernel version of 3.18 for geneve.  There is no stt support in upstream Linux.
 You can verify whether you have the support in your kernel by doing a `lsmod |
 grep $ENCAP_TYPE`.)
 
+$SYSTEM_ID is a unique identifier to identify each Open vSwitch in an OVN 
+deployment.If you start Open vSwitch manually, you should set one.
 ```
 ovs-vsctl set Open_vSwitch . external_ids:ovn-remote="tcp:$CENTRAL_IP:6642" \
   external_ids:ovn-nb="tcp:$CENTRAL_IP:6641" \
   external_ids:ovn-encap-ip=$LOCAL_IP \
-  external_ids:ovn-encap-type="$ENCAP_TYPE"
+  external_ids:ovn-encap-type="$ENCAP_TYPE" \
+  external_ids:system-id=$SYSTEM_ID
 ```
 
 And finally, start the ovn-controller.  (You need to run the below command on

--- a/bin/ovn-k8s-cni-overlay
+++ b/bin/ovn-k8s-cni-overlay
@@ -133,7 +133,7 @@ def setup_interface(pid, container_id, cni_ifname, mac_address,
 
         return veth_outside
     except Exception as e:
-        vlog.warn("Failed to setup veth pair for pod" % str(e))
+        vlog.warn("Failed to setup veth pair for pod: %s" % str(e))
         command = "ip link delete %s" % (veth_outside)
         call_popen(shlex.split(command))
         raise OVNCNIException(100, "veth setup failure")


### PR DESCRIPTION
commit 9b3c6822ee9e4dba8f38df2b5fdbdb4af2d75530
Author: zhou Huijing <zhou.huijing@zte.com.cn>
Date:   Mon Nov 28 04:58:59 2016 +0000

    ovn-k8s-cni-overlay:when Exception,the string is missing a parameter
    
    Signed-off-by: zhou Huijing <zhou.huijing@zte.com.cn>

diff --git a/bin/ovn-k8s-cni-overlay b/bin/ovn-k8s-cni-overlay
index 5562c8d..6b2a375 100755
--- a/bin/ovn-k8s-cni-overlay
+++ b/bin/ovn-k8s-cni-overlay
@@ -133,7 +133,7 @@ def setup_interface(pid, container_id, cni_ifname, mac_address,

         return veth_outside
     except Exception as e:
-       - vlog.warn("Failed to setup veth pair for pod" % str(e))
+       + vlog.warn("Failed to setup veth pair for pod: %s" % str(e))
         command = "ip link delete %s" % (veth_outside)
         call_popen(shlex.split(command))
         raise OVNCNIException(100, "veth setup failure")