### PR TITLE
ovn-k8s-cni-overlay:log print missing a parameter

### DIFF
--- a/bin/ovn-k8s-cni-overlay
+++ b/bin/ovn-k8s-cni-overlay
@@ -133,7 +133,7 @@ def setup_interface(pid, container_id, cni_ifname, mac_address,
 
         return veth_outside
     except Exception as e:
-        vlog.warn("Failed to setup veth pair for pod" % str(e))
+        vlog.warn("Failed to setup veth pair for pod: %s" % str(e))
         command = "ip link delete %s" % (veth_outside)
         call_popen(shlex.split(command))
         raise OVNCNIException(100, "veth setup failure")


### PR DESCRIPTION
commit e7310ccc442a2639aad6d88af482d117b3051fd0
Author: zhou Huijing <zhou.huijing@zte.com.cn>
Date:   Tue Nov 29 07:01:17 2016 +0000

    ovn-k8s-cni-overlay:log print missing a parameter
    
    Signed-off-by: zhou Huijing <zhou.huijing@zte.com.cn>

diff --git a/bin/ovn-k8s-cni-overlay b/bin/ovn-k8s-cni-overlay
index 5562c8d..6b2a375 100755
--- a/bin/ovn-k8s-cni-overlay
+++ b/bin/ovn-k8s-cni-overlay
@@ -133,7 +133,7 @@ def setup_interface(pid, container_id, cni_ifname, mac_address,
 
         return veth_outside
     except Exception as e:
        - vlog.warn("Failed to setup veth pair for pod" % str(e))
        +vlog.warn("Failed to setup veth pair for pod: %s" % str(e))
         command = "ip link delete %s" % (veth_outside)
         call_popen(shlex.split(command))
         raise OVNCNIException(100, "veth setup failure")
