### PR TITLE
Add support for multiple gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ in the master node.
 System Initialization
 =====================
 
-OVN in "overlay" mode needs a minimum Open vSwitch version of 2.6.
+OVN in "overlay" mode needs a minimum Open vSwitch version of 2.6.  It needs
+Open vSwitch version 2.7 for multi-gateway support.
 
 * Start the central components.
 
@@ -232,11 +233,11 @@ ovn-k8s-overlay minion-init \
 
 * k8s gateway node initialization
 
-Gateway nodes are needed for North-South connectivity.  OVN does have support
-for multiple gateway nodes, but this documentation only talks about one
-gateway node.
+Gateway nodes are needed for North-South connectivity.  OVN has support
+for multiple gateway nodes.
 
-On any minions (or a separate node), you need to initialize the gateway node.
+On any minions (or separate nodes, which would be the case for a DPDK
+based OVN gateway), you need to initialize the gateway node.
 
 Set the k8s API server address in the Open vSwitch database for the
 initialization scripts (and later daemons) to pick from.

--- a/README.md
+++ b/README.md
@@ -321,6 +321,13 @@ ovn-gateway-helper --physical-bridge=breth0 --physical-interface=eth0 \
     --pidfile --detach
 ```
 
+In case of multiple gateways, when the traffic is originated from the
+pods, you can pin the pod subnet traffic to go out of a particular
+gateway.  For e.g., if you want the pods belonging to subnet 192.168.1.0/24
+and 192.168.1.0/24 to go out of gateway1, when you initialize gateway1, you
+can provide --rampout-ip-subnets="192.168.1.0/24,192.168.2.0/24" option to
+the 'gateway-init' command.
+
 * Watchers on master node.
 
 Once the above initializations are done, you can start your Kubernetes daemons

--- a/bin/ovn-k8s-overlay
+++ b/bin/ovn-k8s-overlay
@@ -355,7 +355,7 @@ def gateway_init(args):
         ovn_nbctl("--may-exist", "lr-route-add", gateway_router,
                   "0.0.0.0/0", str(default_gw.ip))
 
-    # Add a default route in distributed router with GR as the nexthop.
+    # Add a default route in distributed router with first GR as the nexthop.
     ovn_nbctl("--may-exist", "lr-route-add", k8s_cluster_router,
               "0.0.0.0/0", "100.64.1.2")
 
@@ -453,6 +453,26 @@ def gateway_init(args):
         ovn_nbctl("set", "logical_router", gateway_router,
                   "options:lb_force_snat_ip=" + str(ip.ip))
 
+        if args.rampout_ip_subnets:
+            try:
+                rampout_ip_subnets = args.rampout_ip_subnets.split(',')
+                for rampout_ip_subnet in rampout_ip_subnets:
+                    try:
+                        netaddr.IPNetwork(rampout_ip_subnet)
+                    except Exception as e:
+                        sys.stderr.write("warning: %s is not valid subnet (%s)"
+                                         % (rampout_ip_subnet, str(e)))
+                        continue
+
+                    # Add source IP address based routes in distributed router
+                    # for this gateway router.
+                    ovn_nbctl("--may-exist", "--policy=src-ip", "lr-route-add",
+                              k8s_cluster_router, rampout_ip_subnet,
+                              str(ip.ip))
+            except Exception as e:
+                raise Exception("Failed to split args.rampout_ip_subnets %s"
+                                % str(e))
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -512,6 +532,12 @@ def main():
     parser_gateway_init.add_argument('--node-name',
                                      required=True,
                                      help="A unique node name.")
+    parser_gateway_init.add_argument('--rampout-ip-subnets',
+                                     help="Uses this gateway to rampout "
+                                     "traffic originating from the specified "
+                                     "comma separated ip subnets.  Used to "
+                                     "distribute outgoing traffic via "
+                                     "multiple gateways.")
     parser_gateway_init.set_defaults(func=gateway_init)
 
     args = parser.parse_args()

--- a/bin/ovn-k8s-overlay
+++ b/bin/ovn-k8s-overlay
@@ -220,8 +220,10 @@ def master_init(args):
                            "rtoj-" + node_name, "mac").strip('"')
     if not router_mac:
         router_mac = util.generate_mac()
-        ovn_nbctl("--may-exist", "lrp-add", node_name,
-                  "rtoj-" + node_name, router_mac, "100.64.1.1/24")
+        ovn_nbctl("--", "--may-exist", "lrp-add", node_name,
+                  "rtoj-" + node_name, router_mac, "100.64.1.1/24",
+                  "--", "set", "logical_router_port", "rtoj-" + node_name,
+                  "external_ids:connect_to_join=yes")
 
     # Connect the switch "join" to the router.
     ovn_nbctl("--", "--may-exist", "lsp-add", "join",
@@ -280,6 +282,24 @@ def minion_init(args):
                            args.cluster_ip_subnet)
 
 
+def generate_gateway_ip():
+    # All the routers connected to "join" switch are in 100.64.1.0/24
+    # network and they have their external_ids:connect_to_join set.
+    ips = ovn_nbctl("--data=bare", "--no-heading", "--columns=network",
+                    "find", "logical_router_port",
+                    "external_ids:connect_to_join=yes").split()
+
+    ip_start = netaddr.IPNetwork("100.64.1.0/24")
+    ip_max = netaddr.IPNetwork("100.64.1.255/24")
+
+    while ip_start.value != ip_max.value:
+        ip_start.value = ip_start.value + 1
+        if str(ip_start) not in ips:
+            return str(ip_start)
+
+    raise Exception("Ran out of IPs for gateway routers")
+
+
 def gateway_init(args):
     if not args.node_name or not args.cluster_ip_subnet \
        or not args.physical_ip:
@@ -309,14 +329,16 @@ def gateway_init(args):
               "logical_router", gateway_router, "options:chassis=" + system_id)
 
     # Connect gateway router to switch "join".
-    # TODO: IP address allocation needs to become general purpose
-    # once we support multiple gateway routers.
+    router_ip = None
     router_mac = ovn_nbctl("--if-exist", "get", "logical_router_port",
                            "rtoj-" + gateway_router, "mac").strip('"')
     if not router_mac:
         router_mac = util.generate_mac()
-        ovn_nbctl("--may-exist", "lrp-add", gateway_router,
-                  "rtoj-" + gateway_router, router_mac, "100.64.1.2/24")
+        router_ip = generate_gateway_ip()
+        ovn_nbctl("--", "--may-exist", "lrp-add", gateway_router,
+                  "rtoj-" + gateway_router, router_mac, router_ip,
+                  "--", "set", "logical_router_port", "rtoj-" + gateway_router,
+                  "external_ids:connect_to_join=yes")
 
     # Connect the switch "join" to the router.
     ovn_nbctl("--", "--may-exist", "lsp-add", "join",
@@ -421,6 +443,15 @@ def gateway_init(args):
               "logical_ip=" + args.cluster_ip_subnet,
               "external_ip=" + str(physical_ip.ip),
               "--", "add", "logical_router", gateway_router, "nat", "@nat")
+
+    # When there are multiple gateway routers (which would be the likely
+    # default for any sane deployment), we need to SNAT traffic heading
+    # to the logical space with the Gateway router's IP so that return
+    # traffic comes back to the same gateway router.
+    if router_ip:
+        ip = netaddr.IPNetwork(router_ip)
+        ovn_nbctl("set", "logical_router", gateway_router,
+                  "options:lb_force_snat_ip=" + str(ip.ip))
 
 
 def main():

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -44,6 +44,12 @@ the vagrant/provisioning/virtualbox.conf.yml file).
 
 * curl 10.10.0.11:[nodeport]
 
+Since the vagrant initializes gateway node on the minions too, you should be
+able to access the same service via the IP addresses of the minion nodes too.
+
+* curl 10.10.0.12:[nodeport]
+* curl 10.10.0.13:[nodeport]
+
 You should see OVN doing load-balancing between the pods, which means you will
 both the apache example page and the nginx example page.
 

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -63,14 +63,3 @@ Verify this pod:
 * kubectl describe pod <busybox pod name>
 
 You can now login to the busybox pod on the minion host and ping across pods.
-
-[1]: https://hub.docker.com/r/google/nodejs-hello/
-[2]: http://kubernetes.io/docs/hellonode/
-
-References
-----------
-
-https://github.com/openvswitch/ovn-kubernetes
-http://kubernetes.io/docs/hellonode/
-http://kubernetes.io/docs/user-guide/kubectl-cheatsheet/
-https://blog.jetstack.io/blog/k8s-getting-started-part2/

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure(2) do |config|
     k8sminion1.vm.network "private_network", ip: vagrant_config['k8sminion1']['overlay-ip']
     k8sminion1.vm.network "private_network", ip: vagrant_config['k8sminion1']['public-ip'], netmask: netmask
     k8sminion1.vm.provision "shell", path: "provisioning/setup-minion.sh", privileged: false,
-      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8smaster']['public-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion1']['minion-switch-subnet']}"
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['public-ip']} #{netmask} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion1']['minion-switch-subnet']} #{vagrant_config['public_gateway']}"
     k8sminion1.vm.provision "shell", path: "provisioning/setup-k8s-minion.sh", privileged: false,
       :args => "#{vagrant_config['k8smaster']['overlay-ip']}"
     k8sminion1.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,
@@ -73,7 +73,7 @@ Vagrant.configure(2) do |config|
     k8sminion2.vm.network "private_network", ip: vagrant_config['k8sminion2']['overlay-ip']
     k8sminion2.vm.network "private_network", ip: vagrant_config['k8sminion2']['public-ip'], netmask: netmask
     k8sminion2.vm.provision "shell", path: "provisioning/setup-minion.sh", privileged: false,
-      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8smaster']['public-ip']} #{vagrant_config['k8sminion2']['short_name']} #{vagrant_config['k8sminion2']['minion-switch-subnet']}"
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['public-ip']} #{netmask} #{vagrant_config['k8sminion2']['short_name']} #{vagrant_config['k8sminion2']['minion-switch-subnet']} #{vagrant_config['public_gateway']}"
     k8sminion2.vm.provision "shell", path: "provisioning/setup-k8s-minion.sh", privileged: false,
       :args => "#{vagrant_config['k8smaster']['overlay-ip']}"
     k8sminion2.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,


### PR DESCRIPTION
This commit adds support for as many gateways as possible.  This needs a feature in OVN that will only be available with OVS 2.7. So we should consider creating a branch in ovn-kubernetes too.

This commit will likely need a rebase depending on the review of #54 as it includes changes from there. Only the last 3 commits in this series are relevant as the first 2 commits are actually part of #54 