### PR TITLE
README.md: Update documentation for OVS 2.7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ database.
 /usr/share/openvswitch/scripts/ovn-ctl start_northd
 ```
 
+In Open vSwitch 2.7, you need to additionally run the following commands
+to open up TCP ports to access the OVN databases.
+
+```
+ovn-nbctl set-connection ptcp:6641
+ovn-sbctl set-connection ptcp:6642
+```
+
 ### One time setup.
 
 On each host, you will need to run the following command once.  (You need to

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -41,6 +41,9 @@ sudo /etc/init.d/openvswitch-switch force-reload-kmod
 sudo /usr/share/openvswitch/scripts/ovn-ctl stop_northd
 sudo /usr/share/openvswitch/scripts/ovn-ctl start_northd
 
+sudo ovn-nbctl set-connection ptcp:6641
+sudo ovn-sbctl set-connection ptcp:6642
+
 sudo ovs-vsctl set Open_vSwitch . external_ids:ovn-remote="tcp:$OVERLAY_IP:6642" \
                                   external_ids:ovn-nb="tcp:$OVERLAY_IP:6641" \
                                   external_ids:ovn-encap-ip=$OVERLAY_IP \


### PR DESCRIPTION
With OVS 2.7, one can no longer connect automatically to
TCP ports of OVN databases. You need to clearly specify
the connection type of either TCP or SSL. This commit
only provides information about TCP connection.  SSL
information is TBA.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>