### PR TITLE
fix the wrong description of the installing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Since you share a NIC for both mgmt and North-South connectivity, you will
 have to start a separate daemon to de-multiplex the traffic.
 
 ```
-ovn-gateway-helper --physical-bridge=breth0 --physical-interface=eth0 \
+ovn-k8s-gateway-helper --physical-bridge=breth0 --physical-interface=eth0 \
     --pidfile --detach
 ```
 


### PR DESCRIPTION
   According to my test, i think it should be 'ovn-k8s-gateway-helper', thank you!

   Signed-off-by: chentao1596 <chen.tao3@zte.com.cn>