### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ ovn-k8s-gateway-helper --physical-bridge=breth0 --physical-interface=eth0 \
 In case of multiple gateways, when the traffic is originated from the
 pods, you can pin the pod subnet traffic to go out of a particular
 gateway.  For e.g., if you want the pods belonging to subnet 192.168.1.0/24
-and 192.168.1.0/24 to go out of gateway1, when you initialize gateway1, you
+and 192.168.2.0/24 to go out of gateway1, when you initialize gateway1, you
 can provide --rampout-ip-subnets="192.168.1.0/24,192.168.2.0/24" option to
 the 'gateway-init' command.
 


### PR DESCRIPTION
According to the following parameter --rampout-ip-subnets, the subnet ip address should be 192.168.1.0/24 and 192.168.2.0/24.

Signed-off-by: mozhuli <weidonglee27@gmail.com>