### PR TITLE
ovn-k8s-gateway-helper: Fix traffic multiplexing.

### DIFF
--- a/bin/ovn-k8s-gateway-helper
+++ b/bin/ovn-k8s-gateway-helper
@@ -42,6 +42,7 @@ node_ports_cache = set()
 physical_bridge = ""
 br_int_ofport = 0
 physical_interface_ofport = 0
+conntrack_zone = 64000
 
 
 def _unixctl_exit(conn, unused_argv, unused_aux):
@@ -64,6 +65,32 @@ def _unixctl_run():
         poller = ovs.poller.Poller()
         unixctl_server.wait(poller)
         poller.block()
+
+
+def add_conntrack_rules():
+    # table 0, packets coming from pods headed externally. Commit connections
+    # so that reverse direction goes back to the pods.
+    ovs_ofctl("add-flow", physical_bridge,
+              "priority=100, in_port=%d, ip, "
+              "actions=ct(commit, zone=%d), output:%d"
+              % (br_int_ofport, conntrack_zone, physical_interface_ofport))
+    # table 0, packets coming from external. Send it through conntrack and
+    # resubmit to table 1 to know the state of the connection.
+    ovs_ofctl("add-flow", physical_bridge,
+              "priority=50, in_port=%d, ip, actions=ct(zone=%d, table=1)"
+              % (physical_interface_ofport, conntrack_zone))
+
+    # table 1, established and related connections go to pod.
+    ovs_ofctl("add-flow", physical_bridge,
+              "priority=100, table=1, ct_state=+trk+est, actions=output:%d"
+              % (br_int_ofport))
+    ovs_ofctl("add-flow", physical_bridge,
+              "priority=100, table=1, ct_state=+trk+rel, actions=output:%d"
+              % (br_int_ofport))
+
+    # All other connections get the 'NORMAL' treatment.
+    ovs_ofctl("add-flow", physical_bridge,
+              "priority=0, table=1, actions=NORMAL")
 
 
 def _update_service_cache(event_type, cache_key, service_data):
@@ -259,6 +286,8 @@ def main():
 
     pool = greenpool.GreenPool()
     pool.spawn(_unixctl_run)
+
+    add_conntrack_rules()
 
     sync_services()
 


### PR DESCRIPTION
When you share the same NIC for both mgmt and data
traffic, you need to track connections that are
initiated from the pods so that reverse connections
go back to the pods.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>