### PR TITLE
Kube server binary is no longer bundled in repo

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -17,6 +17,7 @@ Pull down Kubernetes (it's big)
 * cd k8s
 * wget https://github.com/kubernetes/kubernetes/releases/download/v1.3.7/kubernetes.tar.gz
 * tar xvzf kubernetes.tar.gz
+* ./kubernetes/cluster/get-kube-binaries.sh
 * mkdir server
 * cd server
 * tar xvzf ../kubernetes/server/kubernetes-server-linux-amd64.tar.gz

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -15,7 +15,7 @@ Pull down Kubernetes (it's big)
 
 * mkdir k8s
 * cd k8s
-* wget https://github.com/kubernetes/kubernetes/releases/download/v1.3.7/kubernetes.tar.gz
+* wget https://github.com/kubernetes/kubernetes/releases/download/v1.5.3/kubernetes.tar.gz
 * tar xvzf kubernetes.tar.gz
 * ./kubernetes/cluster/get-kube-binaries.sh
 * mkdir server


### PR DESCRIPTION
In latest kubernetes releases like 1.5.3 the server binaries
are no longer present in the repo. Instead on needs to get
them using get-kube-binaries.sh script. This patch updates the
vagrant README to reflect the changes in installation process.