### PR TITLE
vagrant: Store arguments in file.

### DIFF
--- a/vagrant/provisioning/setup-k8s-master.sh
+++ b/vagrant/provisioning/setup-k8s-master.sh
@@ -13,6 +13,12 @@ PUBLIC_IP=$1
 PUBLIC_SUBNET_MASK=$2
 GW_IP=$3
 
+cat > setup_k8s_master_args.sh <<EOL
+PUBLIC_IP=$1
+PUBLIC_SUBNET_MASK=$2
+GW_IP=$3
+EOL
+
 # Install k8s
 
 # Install an etcd cluster

--- a/vagrant/provisioning/setup-k8s-minion.sh
+++ b/vagrant/provisioning/setup-k8s-minion.sh
@@ -9,6 +9,8 @@ set -o xtrace
 
 MASTER_IP=$1
 
+echo "MASTER_IP=$MASTER_IP" >> setup_minion_args.sh
+
 # Install CNI
 pushd ~/
 wget https://github.com/containernetworking/cni/releases/download/v0.2.0/cni-v0.2.0.tgz

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -15,6 +15,13 @@ GW_IP=$2
 MASTER_NAME=$3
 MASTER_SUBNET=$4
 
+cat > setup_master_args.sh <<EOL
+OVERLAY_IP=$1
+GW_IP=$2
+MASTER_NAME=$3
+MASTER_SUBNET=$4
+EOL
+
 # Comment out the next line, if you prefer TCP instead of SSL.
 SSL="true"
 

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -19,6 +19,16 @@ MINION_NAME=$5
 MINION_SUBNET=$6
 GW_IP=$7
 
+cat > setup_minion_args.sh <<EOL
+MASTER_OVERLAY_IP=$1
+MINION_OVERLAY_IP=$2
+PUBLIC_IP=$3
+PUBLIC_SUBNET_MASK=$4
+MINION_NAME=$5
+MINION_SUBNET=$6
+GW_IP=$7
+EOL
+
 # Comment out the next line if you prefer TCP instead of SSL.
 SSL="true"
 


### PR DESCRIPTION
Sometimes when vagrant environment is slow and some commands
fail, it is useful to run the commands manually again. Sometimes
while developement, it is useful to change scripts and re-run them.
In those cases, it is useful to store the passed arguments for reuse.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>