### PR TITLE
Fix typo inside sync_pods function

### DIFF
--- a/ovn_k8s/modes/overlay.py
+++ b/ovn_k8s/modes/overlay.py
@@ -513,7 +513,7 @@ class OvnNB(object):
                                 "--data=bare", "--no-heading",
                                 "--columns=name", "find",
                                 "logical_switch_port",
-                                "external_id:pod=true").split()
+                                "external-ids:pod=true").split()
             existing_logical_ports = set(existing_logical_ports)
         except Exception as e:
             vlog.err("sync_pods: find failed %s" % (str(e)))


### PR DESCRIPTION
There is a typo inside the sync_pods function.

When the logical port is created, it will have "external-ids:pod=true",
but inside the sync_pods function it will try to fetch existing logical
ports based on "external_id:pod=true" which will always return nothing
since the logical ports are not created with this tag.

The fix consists in changing the query to retrieve all the logical
ports having "external-ids:pod=true" instead of "external_id:pod=true".

Signed-off-by: Alin Balutoiu <abalutoiu@cloudbasesolutions.com>