### PR TITLE
config: Change setup.cfg config file location

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifier =
 [files]
 packages = ovn_k8s
 data_files =
-    /etc/openvswitch =
+    etc/openvswitch =
         etc/ovn_k8s.conf
 scripts = 
     bin/ovn-k8s-cni-overlay


### PR DESCRIPTION
Having "/etc/openvswitch" instead of "etc/openvswitch" in setup.cfg
would not place the config file in the expected location.

The fix consists in changing "/etc/openvswitch" to "etc/openvswitch"
in setup.cfg.

Signed-off-by: Alin-Gheorghe Balutoiu <abalutoiu@cloudbasesolutions.com>