### PR TITLE
lint and gofmt tools; not yet added to travis

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -2,9 +2,12 @@
 OUT_DIR = _output
 export OUT_DIR
 
+.PHONY: all build
+
 # Example:
 #   make
 #   make all
+
 all build:
 	hack/build-go.sh cmd/ovnkube/ovnkube.go
 	cp -f pkg/cluster/bin/ovnkube-setup-* ${OUT_DIR}/go/bin/
@@ -14,4 +17,20 @@ install:
 
 clean:
 	rm -rf ${OUT_DIR}
-.PHONY: all build
+
+.PHONY: check-gopath install.tools lint gofmt
+
+check-gopath:
+ifndef GOPATH
+	$(error GOPATH is not set)
+endif
+
+install.tools: check-gopath
+	go get -u github.com/alecthomas/gometalinter; \
+	$(GOPATH)/bin/gometalinter --install;
+
+lint:
+	@./hack/lint.sh
+
+gofmt:
+	@./hack/verify-gofmt.sh

--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -2,68 +2,6 @@
 
 source "$(dirname "${BASH_SOURCE}")/init.sh"
 
-OUT_DIR=${OUT_DIR:-_output}
-
-init_source="$( dirname "${BASH_SOURCE}" )/.."
-OVN_KUBE_ROOT="$( os::util::absolute_path "${init_source}" )"
-export OVN_KUBE_ROOT
-cd ${OVN_KUBE_ROOT}
-OVN_KUBE_GO_PACKAGE="github.com/openvswitch/ovn-kubernetes/go-controller"
-OVN_KUBE_OUTPUT=${OVN_KUBE_ROOT}/${OUT_DIR}
-
-# Output Vars:
-#   export GOPATH - A modified GOPATH to our created tree along with extra
-#     stuff.
-#   export GOBIN - This is actively unset if already set as we want binaries
-#     placed in a predictable place.
-function setup_env() {
-  if [[ -z "$(which go)" ]]; then
-    cat <<EOF
-
-Can't find 'go' in PATH, please fix and retry.
-See http://golang.org/doc/install for installation instructions.
-
-EOF
-    exit 2
-  fi
-
-  # Travis continuous build uses a head go release that doesn't report
-  # a version number, so we skip this check on Travis.  It's unnecessary
-  # there anyway.
-  if [[ "${TRAVIS:-}" != "true" ]]; then
-    local go_version
-    go_version=($(go version))
-    if [[ "${go_version[2]}" < "go1.5" ]]; then
-      cat <<EOF
-
-Detected Go version: ${go_version[*]}.
-ovn-kube builds require Go version 1.6 or greater.
-
-EOF
-      exit 2
-    fi
-  fi
-
-  unset GOBIN
-
-  # create a local GOPATH in _output
-  GOPATH="${OVN_KUBE_OUTPUT}/go"
-  OVN_KUBE_OUTPUT_BINPATH=${GOPATH}/bin
-  local go_pkg_dir="${GOPATH}/src/${OVN_KUBE_GO_PACKAGE}"
-  local go_pkg_basedir=$(dirname "${go_pkg_dir}")
-
-  mkdir -p "${go_pkg_basedir}"
-  rm -f "${go_pkg_dir}"
-
-  # TODO: This symlink should be relative.
-  ln -s "${OVN_KUBE_ROOT}" "${go_pkg_dir}"
-
-  # lots of tools "just don't work" unless we're in the GOPATH
-  cd "${go_pkg_dir}"
-
-  export GOPATH
-}
-readonly -f setup_env
 
 # Build binary targets specified. Should always be run in a sub-shell so we don't leak GOBIN
 #
@@ -74,6 +12,8 @@ build_binaries() {
     # Check for `go` binary and set ${GOPATH}.
     setup_env
 
+    local go_pkg_dir="${GOPATH}/src/${OVN_KUBE_GO_PACKAGE}"
+    cd ${go_pkg_dir}
     mkdir -p "${OVN_KUBE_OUTPUT_BINPATH}"
     export GOBIN="${OVN_KUBE_OUTPUT_BINPATH}"
 

--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+echo $GOPATH
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -not -iwholename '*vendor*' -a -not -iname '_output'); do
+	${GOPATH}/bin/gometalinter \
+		 --exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
+		 --exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \
+		 --exclude='duplicate of.*_test.go.*\(dupl\)$' \
+		 --exclude='cmd\/client\/.*\.go.*\(dupl\)$' \
+		 --exclude='vendor\/.*' \
+		 --exclude='server\/seccomp\/.*\.go.*$' \
+		 --disable=aligncheck \
+		 --disable=gotype \
+		 --disable=gas \
+		 --cyclo-over=60 \
+		 --dupl-threshold=100 \
+		 --tests \
+		 --deadline=30s "${d}"
+done

--- a/go-controller/hack/verify-gofmt.sh
+++ b/go-controller/hack/verify-gofmt.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename '*/vendor/*' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+GOFMT="gofmt -s"
+bad_files=$(find_files | xargs $GOFMT -l)
+if [[ -n "${bad_files}" ]]; then
+  echo "!!! '$GOFMT' needs to be run on the following files: "
+  echo "${bad_files}"
+  exit 1
+fi


### PR DESCRIPTION
Signed-off-by: Rajat Chopra <rchopra@redhat.com>

Two things in the PR:
1. Re-org hack/build-go.sh so that lint tools can re-use the symlink based GOPATH setup
2. hack/lint.sh and hack/verify-gofmt.sh

Ultimately we should run hack/{lint,verify-gofmt}.sh with travis, but it cannot be done right now since travis does not support multiple language installs (doing it manually will slow everything).