### PR TITLE
vagrant: Update CNI to the latest version.

### DIFF
--- a/vagrant/provisioning/setup-k8s-minion.sh
+++ b/vagrant/provisioning/setup-k8s-minion.sh
@@ -13,11 +13,11 @@ echo "MASTER_IP=$MASTER_IP" >> setup_minion_args.sh
 
 # Install CNI
 pushd ~/
-wget https://github.com/containernetworking/cni/releases/download/v0.2.0/cni-v0.2.0.tgz
+wget https://github.com/containernetworking/cni/releases/download/v0.5.2/cni-amd64-v0.5.2.tgz
 popd
 sudo mkdir -p /opt/cni/bin
 pushd /opt/cni/bin
-sudo tar xvzf ~/cni-v0.2.0.tgz
+sudo tar xvzf ~/cni-amd64-v0.5.2.tgz
 popd
 
 # Start k8s daemons
@@ -25,7 +25,8 @@ pushd k8s/server/kubernetes/server/bin
 echo "Starting kubelet ..."
 nohup sudo ./kubelet --api-servers=http://$MASTER_IP:8080 --v=2 --address=0.0.0.0 \
                      --enable-server=true --network-plugin=cni \
-                     --network-plugin-dir=/etc/cni/net.d 2>&1 0<&- &>/dev/null &
+                     --cni-conf-dir=/etc/cni/net.d \
+                     --cni-bin-dir="/opt/cni/bin/" 2>&1 0<&- &>/dev/null &
 sleep 5
 popd
 


### PR DESCRIPTION
Kubernetes 1.6 expects a newer CNI.

Also, the --network-plugin-dir does not work with
k8s 1.6.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>