### PR TITLE
go-controller: Create go routines for pod and endpoint watcher.

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -40,11 +40,11 @@ func (factory *Factory) CreateOvnController() *ovn.Controller {
 	return &ovn.Controller{
 		StartPodWatch: func(handler cache.ResourceEventHandler) {
 			podInformer.Informer().AddEventHandler(handler)
-			podInformer.Informer().Run(utilwait.NeverStop)
+			go podInformer.Informer().Run(utilwait.NeverStop)
 		},
 		StartEndpointWatch: func(handler cache.ResourceEventHandler) {
 			endpointsInformer.Informer().AddEventHandler(handler)
-			endpointsInformer.Informer().Run(utilwait.NeverStop)
+			go endpointsInformer.Informer().Run(utilwait.NeverStop)
 		},
 		Kube: &kube.Kube{KClient: factory.KClient},
 	}


### PR DESCRIPTION
Without this change, the pod watcher would block and endpoint
watcher would never run.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>