### PR TITLE
go-controller: Watcher to handle service delete events.

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -35,12 +35,17 @@ func NewDefaultFactory(c kubernetes.Interface) *Factory {
 func (factory *Factory) CreateOvnController() *ovn.Controller {
 
 	podInformer := factory.IFactory.Core().V1().Pods()
+	serviceInformer := factory.IFactory.Core().V1().Services()
 	endpointsInformer := factory.IFactory.Core().V1().Endpoints()
 
 	return &ovn.Controller{
 		StartPodWatch: func(handler cache.ResourceEventHandler) {
 			podInformer.Informer().AddEventHandler(handler)
 			go podInformer.Informer().Run(utilwait.NeverStop)
+		},
+		StartServiceWatch: func(handler cache.ResourceEventHandler) {
+			serviceInformer.Informer().AddEventHandler(handler)
+			go serviceInformer.Informer().Run(utilwait.NeverStop)
 		},
 		StartEndpointWatch: func(handler cache.ResourceEventHandler) {
 			endpointsInformer.Informer().AddEventHandler(handler)

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -111,7 +111,12 @@ func (ovn *Controller) addEndpoints(ep *kapi.Endpoints) error {
 func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 	svc, err := ovn.Kube.GetService(ep.Namespace, ep.Name)
 	if err != nil {
-		return err
+		// This is not necessarily an error. For e.g when a service is deleted,
+		// you will get endpoint delete event and the call to fetch service
+		// will fail.
+		logrus.Debugf("no service found for endpoint %s in namespace %s",
+			ep.Name, ep.Namespace)
+		return nil
 	}
 	for _, svcPort := range svc.Spec.Ports {
 		lb := ovn.getLoadBalancer(svcPort.Protocol)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -14,6 +14,7 @@ type Controller struct {
 	Kube kube.Interface
 
 	StartPodWatch      func(handler cache.ResourceEventHandler)
+	StartServiceWatch  func(handler cache.ResourceEventHandler)
 	StartEndpointWatch func(handler cache.ResourceEventHandler)
 
 	gatewayCache map[string]string
@@ -28,6 +29,7 @@ const (
 func (oc *Controller) Run() {
 	oc.gatewayCache = make(map[string]string)
 	oc.WatchPods()
+	oc.WatchServices()
 	oc.WatchEndpoints()
 }
 
@@ -57,6 +59,36 @@ func (oc *Controller) WatchPods() {
 				}
 			}
 			oc.deleteLogicalPort(pod)
+			return
+		},
+	})
+}
+
+// WatchServices starts the watching of Service resource and calls back the
+// appropriate handler logic
+func (oc *Controller) WatchServices() {
+	oc.StartServiceWatch(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			return
+		},
+		UpdateFunc: func(old, new interface{}) {
+			return
+		},
+		DeleteFunc: func(obj interface{}) {
+			service, ok := obj.(*kapi.Service)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					logrus.Errorf("couldn't get object from tombstone %+v", obj)
+					return
+				}
+				service, ok = tombstone.Obj.(*kapi.Service)
+				if !ok {
+					logrus.Errorf("tombstone contained object that is not a Service %#v", obj)
+					return
+				}
+			}
+			oc.deleteService(service)
 			return
 		},
 	})

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -1,0 +1,46 @@
+package ovn
+
+import (
+	"github.com/Sirupsen/logrus"
+	kapi "k8s.io/client-go/pkg/api/v1"
+)
+
+func (ovn *Controller) deleteService(service *kapi.Service) {
+	if service.Spec.ClusterIP == "" || len(service.Spec.Ports) == 0 {
+		return
+	}
+
+	// TODO: Change this after supporting gateways.
+	if service.Spec.Type == "NodePort" {
+		return
+	}
+	ips := make([]string, 0)
+
+	for _, svcPort := range service.Spec.Ports {
+		if svcPort.Port == 0 {
+			continue
+		}
+
+		protocol := svcPort.Protocol
+		if protocol == "" || (protocol != "TCP" && protocol != "UDP") {
+			protocol = "TCP"
+		}
+
+		// TODO: Support named ports.
+		if svcPort.TargetPort.Type == 1 {
+			continue
+		}
+
+		targetPort := svcPort.TargetPort.IntVal
+		if targetPort == 0 {
+			targetPort = svcPort.Port
+		}
+
+		err := ovn.createLoadBalancerVIP(ovn.getLoadBalancer(protocol),
+			service.Spec.ClusterIP, svcPort.Port, ips, targetPort)
+		if err != nil {
+			logrus.Errorf("Error in deleting load balancer for service "+
+				"%s:%d %+v", service.Name, svcPort.Port, err)
+		}
+	}
+}


### PR DESCRIPTION
When a service is deleted, you will endup with a
situation where no endpoints are deleted.

This commit adds a service watcher which will delete all the
endpoints from the load-balancer when a service is directly
deleted.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>