### PR TITLE
travis: Don't run 'make lint' twice.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ install:
     - eval "$(gimme 1.8.1)"
 script:
     - tox -e $TOX_ENV
-    - cd go-controller
-    - make
-    - make gofmt
-    - make install.tools
-    - make lint
+    - 'if [ "$TOX_ENV" = "py27" ]; then
+        cd go-controller;
+        make;
+        make gofmt;
+        make install.tools;
+        make lint;
+       fi'


### PR DESCRIPTION
'make lint' takes up a lot of resources and is very slow.
Currently we are running it twice for each environment.
Avoid it.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>