### PR TITLE
do not override hostsubnet if one already exists for a node

### DIFF
--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -89,6 +89,15 @@ func (cluster *OvnClusterController) SetupMaster(masterNodeName string, masterSw
 }
 
 func (cluster *OvnClusterController) addNode(node *kapi.Node) error {
+	// Do not create a subnet if the node already has a subnet
+	hostsubnet, ok := node.Annotations[OvnHostSubnet]
+	if ok {
+		// double check if the hostsubnet looks valid
+		_, _, err := net.ParseCIDR(hostsubnet)
+		if err == nil {
+			return nil
+		}
+	}
 	// Create new subnet
 	sn, err := cluster.masterSubnetAllocator.GetNetwork()
 	if err != nil {


### PR DESCRIPTION
@shettyg 
Bug found where hostsubnets would get re-assigned unnecessarily. Fix is to just check the annotation before assigning a new hostsubnet.
