### PR TITLE
vagrant: Handle new libopenvswitch package in master.

### DIFF
--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -54,7 +54,7 @@ popd
 sudo dpkg -i openvswitch-datapath-dkms*.deb
 sudo dpkg -i openvswitch-switch*.deb openvswitch-common*.deb \
              ovn-central*.deb ovn-common*.deb \
-             python-openvswitch*.deb ovn-docker*.deb \
+             python-openvswitch*.deb libopenvswitch*.deb \
              ovn-host*.deb
 
 # Start the daemons

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -61,7 +61,7 @@ popd
 sudo dpkg -i openvswitch-datapath-dkms*.deb
 sudo dpkg -i openvswitch-switch*.deb openvswitch-common*.deb \
              ovn-central*.deb ovn-common*.deb \
-             python-openvswitch*.deb ovn-docker*.deb \
+             python-openvswitch*.deb libopenvswitch*.deb \
              ovn-host*.deb
 
 # Start the daemons


### PR DESCRIPTION
Also, ovn-docker package is not needed for kubernetes.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>