### PR TITLE
Remove package install bits from setup scripts

### DIFF
--- a/go-controller/pkg/cluster/bin/install_ovn.sh
+++ b/go-controller/pkg/cluster/bin/install_ovn.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+install_redhat_linux() {
+	# Add a repo for where we can get OVS 2.6 packages
+	if [ ! -f /etc/yum.repos.d/delorean-deps.repo ] ; then
+	    curl http://trunk.rdoproject.org/centos7/delorean-deps.repo | sudo tee /etc/yum.repos.d/delorean-deps.repo
+	fi
+	sudo yum install -y openvswitch openvswitch-ovn-central openvswitch-ovn-host
+}
+
+install_debian_linux() {
+	echo "TODO: openvswitch/ovn installation will be skipped for debian distribution"
+}
+
+install_linux() {
+	echo "TODO: openvswitch/ovn installation will be skipped for generic linux distribution"
+}
+
+OS=`uname -s`
+if [ "${OS}" = "Linux" ] ; then
+	if [ -f /etc/redhat-release ] ; then
+		install_redhat_linux
+	elif [ -f /etc/debian_version ] ; then
+		install_debian_linux
+	else
+		install_linux
+	fi
+fi

--- a/go-controller/pkg/cluster/bin/ovnkube-setup-master
+++ b/go-controller/pkg/cluster/bin/ovnkube-setup-master
@@ -14,22 +14,6 @@ if [[ "${API_TOKEN}" == "" ]]; then
 	exit 1
 fi
 
-install_redhat_linux() {
-	# Add a repo for where we can get OVS 2.6 packages
-	if [ ! -f /etc/yum.repos.d/delorean-deps.repo ] ; then
-	    curl http://trunk.rdoproject.org/centos7/delorean-deps.repo | sudo tee /etc/yum.repos.d/delorean-deps.repo
-	fi
-	sudo yum install -y openvswitch openvswitch-ovn-central openvswitch-ovn-host
-}
-
-install_debian_linux() {
-	echo "TODO: openvswitch/ovn installation will be skipped for debian distribution"
-}
-
-install_linux() {
-	echo "TODO: openvswitch/ovn installation will be skipped for generic linux distribution"
-}
-
 init() {
 	sudo systemctl start openvswitch
 	sudo systemctl start ovn-northd
@@ -50,17 +34,6 @@ ovnsetup() {
 	  --master-switch-subnet="${MASTER_SWITCH_SUBNET}" \
 	  --node-name="${NODE_NAME}"
 }
-
-OS=`uname -s`
-if [ "${OS}" = "Linux" ] ; then
-	if [ -f /etc/redhat-release ] ; then
-		install_redhat_linux
-	elif [ -f /etc/debian_version ] ; then
-		install_debian_linux
-	else
-		install_linux
-	fi
-fi
 
 init
 ovnsetup

--- a/go-controller/pkg/cluster/bin/ovnkube-setup-node
+++ b/go-controller/pkg/cluster/bin/ovnkube-setup-node
@@ -16,22 +16,6 @@ if [[ "${API_TOKEN}" == "" ]]; then
 	exit 1
 fi
 
-install_redhat_linux() {
-	# Add a repo for where we can get OVS 2.6 packages
-	if [ ! -f /etc/yum.repos.d/delorean-deps.repo ] ; then
-	    curl http://trunk.rdoproject.org/centos7/delorean-deps.repo | sudo tee /etc/yum.repos.d/delorean-deps.repo
-	fi
-	sudo yum install -y openvswitch openvswitch-ovn-central openvswitch-ovn-host
-}
-
-install_debian_linux() {
-	echo "TODO: openvswitch/ovn installation will be skipped for debian distribution"
-}
-
-install_linux() {
-	echo "TODO: openvswitch/ovn installation will be skipped for generic linux distribution"
-}
-
 init() {
 	systemctl start openvswitch
 	ovs-vsctl set Open_vSwitch . external_ids:ovn-remote="tcp:$CENTRAL_IP:6642" \
@@ -51,17 +35,6 @@ ovnsetup() {
 	  --minion-switch-subnet=${MINION_SWITCH_SUBNET} \
 	  --node-name="${NODE_NAME}"
 }
-
-OS=`uname -s`
-if [ "${OS}" = "Linux" ] ; then
-	if [ -f /etc/redhat-release ] ; then
-		install_redhat_linux
-	elif [ -f /etc/debian_version ] ; then
-		install_debian_linux
-	else
-		install_linux
-	fi
-fi
 
 init
 ovnsetup


### PR DESCRIPTION

Move ovn/ovs installation bits to another util script; ovnkube setup should not install packages, just init them. Currently the setup scripts end up forcing a particular package of OVS on the installation.
 
Package install should be left to cluster installers e.g. ansible

Signed-off-by: Rajat Chopra <rchopra@redhat.com>