### PR TITLE
go-controller: don't use sudo in master setup script

### DIFF
--- a/go-controller/pkg/cluster/bin/ovnkube-setup-master
+++ b/go-controller/pkg/cluster/bin/ovnkube-setup-master
@@ -15,8 +15,8 @@ if [[ "${API_TOKEN}" == "" ]]; then
 fi
 
 init() {
-	sudo systemctl start openvswitch
-	sudo systemctl start ovn-northd
+	systemctl start openvswitch
+	systemctl start ovn-northd
 }
 
 ovnsetup() {


### PR DESCRIPTION
Instead, the go-controller should be started with sudo.

@rajatchopra 