### PR TITLE
pods.go: Use '--if-exists' while deleting logical port.

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -35,9 +35,11 @@ func (oc *Controller) getGatewayFromSwitch(logicalSwitch string) (string, string
 
 func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 	logrus.Debugf("Deleting pod: %s", pod.Name)
-	out, err := exec.Command(OvnNbctl, "lsp-del", fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)).CombinedOutput()
+	out, err := exec.Command(OvnNbctl, "--if-exists", "lsp-del",
+		fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)).CombinedOutput()
 	if err != nil {
-		logrus.Errorf("Error in deleting pod network switch - %v(%v)", out, err)
+		logrus.Errorf("Error in deleting pod network switch - %s (%v)",
+			string(out), err)
 	}
 	return
 }


### PR DESCRIPTION
Also log errors in string.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>