### PR TITLE
lint: Use gometalinter.v1

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -27,8 +27,8 @@ ifndef GOPATH
 endif
 
 install.tools: check-gopath
-	go get -u github.com/alecthomas/gometalinter; \
-	$(GOPATH)/bin/gometalinter --install;
+	go get -u gopkg.in/alecthomas/gometalinter.v1; \
+	$(GOPATH)/bin/gometalinter.v1 --install;
 
 lint:
 	@./hack/lint.sh

--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -7,7 +7,7 @@ set -o nounset
 set -o pipefail
 
 for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -not -iwholename '*vendor*' -a -not -iname '_output'); do
-	${GOPATH}/bin/gometalinter \
+	${GOPATH}/bin/gometalinter.v1 \
 		 --exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
 		 --exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \
 		 --exclude='duplicate of.*_test.go.*\(dupl\)$' \


### PR DESCRIPTION
Currently we are getting gometalinter from master branch.
This gives us new issues everytime something changes in
gometalinter. With this commit, we use gometalinter.v1

Signed-off-by: Gurucharan Shetty <guru@ovn.org>