### PR TITLE
vagrant: Install OVS with packages.

### DIFF
--- a/docs/INSTALL.UBUNTU.md
+++ b/docs/INSTALL.UBUNTU.md
@@ -1,15 +1,56 @@
-Installing OVS and OVN from sources on Ubuntu
-=============================================
+# Installing OVS and OVN on Ubuntu
+
+## Installing OVS and OVN from packages
+
+Some students in a university in New Zealand maintain OVS and OVN packages at
+http://packages.wand.net.nz/
+
+To install packages from there, you can run:
+
+```
+sudo apt-get install apt-transport-https
+echo "deb https://packages.wand.net.nz $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/wand.list
+sudo curl https://packages.wand.net.nz/keyring.gpg -o /etc/apt/trusted.gpg.d/wand.gpg
+sudo apt-get update
+```
+
+To install OVS bits on all nodes, run:
+
+```
+sudo apt-get build-dep dkms
+sudo apt-get install python-six openssl python-pip -y
+sudo -H pip install --upgrade pip
+
+sudo apt-get install openvswitch-datapath-dkms -y
+sudo apt-get install openvswitch-switch openvswitch-common -y
+sudo -H pip install ovs
+```
+
+On the master node, where you intend to start OVN's central components,
+run:
+
+```
+sudo apt-get install ovn-central ovn-common -y
+```
+
+On the agent nodes, run:
+
+```
+sudo apt-get install ovn-host ovn-common -y
+```
+
+## Installing OVS and OVN from sources
 
 Install a few pre-requisite packages.
 
 ```
 apt-get update
 apt-get install -y build-essential fakeroot debhelper \
-                    autoconf automake bzip2 libssl-dev \
-                    openssl graphviz python-all procps \
-                    python-dev python-setuptools \
-                    python-twisted-conch libtool git dh-autoreconf \
+                    autoconf automake libssl-dev \
+                    openssl python-all \
+                    python-setuptools \
+                    python-six \
+                    libtool git dh-autoreconf \
                     linux-headers-$(uname -r)
 easy_install -U pip
 ```
@@ -48,6 +89,8 @@ upstream linux.
 ```
 cat > /etc/depmod.d/openvswitch.conf << EOF
 override openvswitch * extra
+override vport-geneve * extra
+override vport-stt * extra
 override vport-* * extra
 EOF
 ```

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -28,12 +28,16 @@ SSL="true"
 # FIXME(mestery): Remove once Vagrant boxes allow apt-get to work again
 sudo rm -rf /var/lib/apt/lists/*
 
-# First, install docker
+# Add external repos to install docker and OVS from packages.
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates
+echo "deb https://packages.wand.net.nz $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/wand.list
+sudo curl https://packages.wand.net.nz/keyring.gpg -o /etc/apt/trusted.gpg.d/wand.gpg
 sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 sudo su -c "echo \"deb https://apt.dockerproject.org/repo ubuntu-xenial main\" >> /etc/apt/sources.list.d/docker.list"
 sudo apt-get update
+
+# First, install docker
 sudo apt-get purge lxc-docker
 sudo apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual
 sudo apt-get install -y docker-engine
@@ -41,26 +45,15 @@ sudo service docker start
 
 # Install OVS and dependencies
 sudo apt-get build-dep dkms
-sudo apt-get install -y autoconf automake bzip2 debhelper dh-autoreconf \
-                        libssl-dev libtool openssl procps \
-                        python-six dkms
+sudo apt-get install python-six openssl python-pip -y
+sudo -H pip install --upgrade pip
 
-git clone https://github.com/openvswitch/ovs.git
-pushd ovs/
-sudo DEB_BUILD_OPTIONS='nocheck parallel=2' fakeroot debian/rules binary
+sudo apt-get install openvswitch-datapath-dkms=2.7.0-1 -y
+sudo apt-get install openvswitch-switch=2.7.0-1 openvswitch-common=2.7.0-1 -y
+sudo -H pip install ovs
 
-# Install OVS/OVN debs
-popd
-sudo dpkg -i openvswitch-datapath-dkms*.deb
-sudo dpkg -i openvswitch-switch*.deb openvswitch-common*.deb \
-             ovn-central*.deb ovn-common*.deb \
-             python-openvswitch*.deb libopenvswitch*.deb \
-             ovn-host*.deb
+sudo apt-get install ovn-central=2.7.0-1 ovn-common=2.7.0-1 ovn-host=2.7.0-1 -y
 
-# Start the daemons
-sudo /etc/init.d/openvswitch-switch force-reload-kmod
-sudo /usr/share/openvswitch/scripts/ovn-ctl stop_northd
-sudo /usr/share/openvswitch/scripts/ovn-ctl start_northd
 
 if [ -n "$SSL" ]; then
     # Install SSL certificates
@@ -109,8 +102,6 @@ sudo /etc/init.d/ovn-host restart
 sudo ovs-vsctl set Open_vSwitch . external_ids:k8s-api-server="0.0.0.0:8080"
 
 # Install OVN+K8S Integration
-sudo apt-get install -y python-pip
-sudo -H pip install --upgrade pip
 git clone https://github.com/openvswitch/ovn-kubernetes
 pushd ovn-kubernetes
 sudo -H pip install .


### PR DESCRIPTION
Compiling OVS increases time. Also, compiling
everytime can get us bugs from OVS master branch.
So use a released version of OVS instead.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>