### PR TITLE
build: make sure environment is set up for all targets

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -26,9 +26,8 @@ ifndef GOPATH
 	$(error GOPATH is not set)
 endif
 
-install.tools: check-gopath
-	go get -u gopkg.in/alecthomas/gometalinter.v1; \
-	$(GOPATH)/bin/gometalinter.v1 --install;
+install.tools:
+	@./hack/install-tools.sh
 
 lint:
 	@./hack/lint.sh

--- a/go-controller/hack/install-tools.sh
+++ b/go-controller/hack/install-tools.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE}")/init.sh"
+
+# Check for `go` binary and set ${GOPATH}.
+setup_env
+
+go get -u gopkg.in/alecthomas/gometalinter.v1; \
+  ${GOPATH}/bin/gometalinter.v1 --install;
+

--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-echo $GOPATH
+source "$(dirname "${BASH_SOURCE}")/init.sh"
+
+# Check for `go` binary and set ${GOPATH}.
+setup_env
+
+echo ${GOPATH}
 
 set -o errexit
 set -o nounset

--- a/go-controller/hack/verify-gofmt.sh
+++ b/go-controller/hack/verify-gofmt.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+source "$(dirname "${BASH_SOURCE}")/init.sh"
+
+# Check for `go` binary and set ${GOPATH}.
+setup_env
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -8,6 +13,7 @@ find_files() {
   find . -not \( \
       \( \
         -wholename '*/vendor/*' \
+        -o -wholename '*/alecthomas/*' \
       \) -prune \
     \) -name '*.go'
 }


### PR DESCRIPTION
Now, just like for the build target, you can just run 'make gofmt'
and 'make lint' and things will work without having an explicit
GOPATH set.

Signed-off-by: Dan Williams <dcbw@redhat.com>

@rajatchopra @shettyg 