### PR TITLE
vagrant: Update to support k8s 1.7.x

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -18,7 +18,7 @@ Pull down Kubernetes (it's big)
 
 * mkdir k8s
 * cd k8s
-* wget https://github.com/kubernetes/kubernetes/releases/download/v1.5.3/kubernetes.tar.gz
+* wget https://github.com/kubernetes/kubernetes/releases/download/v1.7.5/kubernetes.tar.gz
 * tar xvzf kubernetes.tar.gz
 * ./kubernetes/cluster/get-kube-binaries.sh
 * mkdir server

--- a/vagrant/provisioning/setup-k8s-master.sh
+++ b/vagrant/provisioning/setup-k8s-master.sh
@@ -22,8 +22,12 @@ EOL
 # Install k8s
 
 # Install an etcd cluster
-sudo docker run --net=host -d gcr.io/google_containers/etcd:2.0.12 /usr/local/bin/etcd \
-                --addr=127.0.0.1:4001 --bind-addr=0.0.0.0:4001 --data-dir=/var/etcd/data
+sudo docker run --net=host -v /var/etcd/data:/var/etcd/data -d \
+        gcr.io/google_containers/etcd:3.0.17 /usr/local/bin/etcd \
+        --listen-peer-urls http://127.0.0.1:2380 \
+        --advertise-client-urls=http://127.0.0.1:4001 \
+        --listen-client-urls=http://0.0.0.0:4001 \
+        --data-dir=/var/etcd/data
 
 # Start k8s daemons
 pushd k8s/server/kubernetes/server/bin


### PR DESCRIPTION
K8s 1.7.x by default uses etcd 3.x

Signed-off-by: Gurucharan Shetty <guru@ovn.org>