### PR TITLE
let ovn annotations which stored in pod comply with standard json format

### DIFF
--- a/ovn_k8s/modes/overlay.py
+++ b/ovn_k8s/modes/overlay.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import ast
+import json
 
 import ovs.vlog
 from ovn_k8s.common import exceptions
@@ -334,14 +335,14 @@ class OvnNB(object):
 
         ip_address_mask = "%s/%s" % (ip_address, mask)
 
-        annotation = {'ip_address': ip_address_mask,
-                      'mac_address': mac_address,
-                      'gateway_ip': gateway_ip}
+        annotation = {'ip_address': str(ip_address_mask),
+                      'mac_address': str(mac_address),
+                      'gateway_ip': str(gateway_ip)}
 
         try:
             kubernetes.set_pod_annotation(variables.K8S_API_SERVER,
                                           namespace, pod_name,
-                                          "ovn", str(annotation))
+                                          "ovn", json.dumps(annotation))
         except Exception as e:
             vlog.err("_create_logical_port: failed to annotate addresses (%s)"
                      % (str(e)))


### PR DESCRIPTION
When I try to translate ovn-k8s-cni-overlay from python to go,
I found that I can't unmarshal the ovn annotations which get from the pod information.
Finally ,I found the reason, the ovn annotations in the pod look like follows:
ovn:{'gateway_ip': u'192.168.2.1', 'ip_address': u'192.168.2.3/24', 'mac_address': '0a:00:00:00:00:01'}
Actually it's not a standard json format, so I write some code to make it general, like follows:
ovn:{"gateway_ip": "192.168.2.1", "ip_address": "192.168.2.5/24", "mac_address": "0a:00:00:00:00:03"}
which make it more compatible.