### PR TITLE
overlay.py: Add clusterip when nodeport is created.

### DIFF
--- a/ovn_k8s/modes/overlay.py
+++ b/ovn_k8s/modes/overlay.py
@@ -407,23 +407,24 @@ class OvnNB(object):
         external_ips = service_data['spec'].get('externalIPs')
 
         for service_port in service_ports:
+            protocol = service_port.get('protocol', 'TCP')
+
             if service_type == "NodePort":
                 port = service_port.get('nodePort')
-            else:
-                port = service_port.get('port')
+                if port:
+                    target_port = str(service_port.get('targetPort', port))
+                    # Add the 'NodePort' to a load-balancer instantiated in
+                    # gateways.
+                    self._create_gateways_vip(namespace, ips, port,
+                                              target_port, protocol)
 
+            port = service_port.get('port')
             if not port:
                 continue
-
-            protocol = service_port.get('protocol', 'TCP')
             target_port = str(service_port.get('targetPort', port))
 
-            if service_type == "NodePort":
-                # Add the 'NodePort' to a load-balancer instantiated in
-                # gateways.
-                self._create_gateways_vip(namespace, ips, port, target_port,
-                                          protocol)
-            elif service_type == "ClusterIP":
+            # service_type of NodePort also has a service_ip.
+            if service_type == "ClusterIP" or service_type == "NodePort":
                 # Add the 'service_ip:port' as a VIP in the cluster
                 # load-balancer.
                 self._create_cluster_vip(namespace, service_ip, ips, port,
@@ -577,22 +578,22 @@ class OvnNB(object):
             external_ips = service['spec'].get('externalIPs')
 
             for service_port in service_ports:
-                if service_type == "NodePort":
-                    port = service_port.get('nodePort')
-                else:
-                    port = service_port.get('port')
-
-                if not port:
-                    continue
-
                 protocol = service_port.get('protocol', 'TCP')
 
                 if service_type == "NodePort":
-                    if protocol == "TCP":
-                        nodeport_services['TCP'].append(str(port))
-                    else:
-                        nodeport_services['UDP'].append(str(port))
-                elif service_type == "ClusterIP":
+                    port = service_port.get('nodePort')
+                    if port:
+                        if protocol == "TCP":
+                            nodeport_services['TCP'].append(str(port))
+                        else:
+                            nodeport_services['UDP'].append(str(port))
+
+                port = service_port.get('port')
+                if not port:
+                    continue
+
+                # service_type of NodePort also has a service_ip.
+                if service_type == "ClusterIP" or service_type == "NodePort":
                     key = "%s:%s" % (service_ip, port)
                     if protocol == "TCP":
                         cluster_services['TCP'].append(key)


### PR DESCRIPTION
Currently when a service of nodeport is created, we do not
add the clusterIP of that service in the cluster load-balancer.

This commit adds that support.

Fixes: #128

Signed-off-by: Gurucharan Shetty <guru@ovn.org>