### PR TITLE
allow for a preprocessing callback for the watchers

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -41,25 +41,47 @@ func (factory *Factory) CreateOvnController() *ovn.Controller {
 	namespaceInformer := factory.IFactory.Core().V1().Namespaces()
 
 	return &ovn.Controller{
-		StartPodWatch: func(handler cache.ResourceEventHandler) {
-			podInformer.Informer().AddEventHandler(handler)
+		StartPodWatch: func(handler cache.ResourceEventHandler, processExisting func([]interface{})) {
 			go podInformer.Informer().Run(utilwait.NeverStop)
+			cache.WaitForCacheSync(utilwait.NeverStop, podInformer.Informer().HasSynced)
+			if processExisting != nil {
+				// cache has synced, lets process the list
+				processExisting(podInformer.Informer().GetStore().List())
+			}
+			// now register the event handler
+			podInformer.Informer().AddEventHandler(handler)
 		},
-		StartServiceWatch: func(handler cache.ResourceEventHandler) {
-			serviceInformer.Informer().AddEventHandler(handler)
+		StartServiceWatch: func(handler cache.ResourceEventHandler, processExisting func([]interface{})) {
 			go serviceInformer.Informer().Run(utilwait.NeverStop)
+			cache.WaitForCacheSync(utilwait.NeverStop, serviceInformer.Informer().HasSynced)
+			if processExisting != nil {
+				processExisting(serviceInformer.Informer().GetStore().List())
+			}
+			serviceInformer.Informer().AddEventHandler(handler)
 		},
-		StartEndpointWatch: func(handler cache.ResourceEventHandler) {
-			endpointsInformer.Informer().AddEventHandler(handler)
+		StartEndpointWatch: func(handler cache.ResourceEventHandler, processExisting func([]interface{})) {
 			go endpointsInformer.Informer().Run(utilwait.NeverStop)
+			cache.WaitForCacheSync(utilwait.NeverStop, endpointsInformer.Informer().HasSynced)
+			if processExisting != nil {
+				processExisting(endpointsInformer.Informer().GetStore().List())
+			}
+			endpointsInformer.Informer().AddEventHandler(handler)
 		},
-		StartPolicyWatch: func(handler cache.ResourceEventHandler) {
-			policyInformer.Informer().AddEventHandler(handler)
+		StartPolicyWatch: func(handler cache.ResourceEventHandler, processExisting func([]interface{})) {
 			go policyInformer.Informer().Run(utilwait.NeverStop)
+			cache.WaitForCacheSync(utilwait.NeverStop, policyInformer.Informer().HasSynced)
+			if processExisting != nil {
+				processExisting(policyInformer.Informer().GetStore().List())
+			}
+			policyInformer.Informer().AddEventHandler(handler)
 		},
-		StartNamespaceWatch: func(handler cache.ResourceEventHandler) {
-			namespaceInformer.Informer().AddEventHandler(handler)
+		StartNamespaceWatch: func(handler cache.ResourceEventHandler, processExisting func([]interface{})) {
 			go namespaceInformer.Informer().Run(utilwait.NeverStop)
+			cache.WaitForCacheSync(utilwait.NeverStop, namespaceInformer.Informer().HasSynced)
+			if processExisting != nil {
+				processExisting(namespaceInformer.Informer().GetStore().List())
+			}
+			namespaceInformer.Informer().AddEventHandler(handler)
 		},
 		Kube: &kube.Kube{KClient: factory.KClient},
 	}

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/cluster"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/ovn"
@@ -43,7 +44,10 @@ func (factory *Factory) CreateOvnController() *ovn.Controller {
 	return &ovn.Controller{
 		StartPodWatch: func(handler cache.ResourceEventHandler, processExisting func([]interface{})) {
 			go podInformer.Informer().Run(utilwait.NeverStop)
-			cache.WaitForCacheSync(utilwait.NeverStop, podInformer.Informer().HasSynced)
+			if !cache.WaitForCacheSync(utilwait.NeverStop, podInformer.Informer().HasSynced) {
+				logrus.Errorf("Error in syncing cache for Pod Informer. Informer will not be run.")
+				return
+			}
 			if processExisting != nil {
 				// cache has synced, lets process the list
 				processExisting(podInformer.Informer().GetStore().List())
@@ -53,7 +57,10 @@ func (factory *Factory) CreateOvnController() *ovn.Controller {
 		},
 		StartServiceWatch: func(handler cache.ResourceEventHandler, processExisting func([]interface{})) {
 			go serviceInformer.Informer().Run(utilwait.NeverStop)
-			cache.WaitForCacheSync(utilwait.NeverStop, serviceInformer.Informer().HasSynced)
+			if !cache.WaitForCacheSync(utilwait.NeverStop, serviceInformer.Informer().HasSynced) {
+				logrus.Errorf("Error in syncing cache for Service Informer. Informer will not be run.")
+				return
+			}
 			if processExisting != nil {
 				processExisting(serviceInformer.Informer().GetStore().List())
 			}
@@ -61,7 +68,10 @@ func (factory *Factory) CreateOvnController() *ovn.Controller {
 		},
 		StartEndpointWatch: func(handler cache.ResourceEventHandler, processExisting func([]interface{})) {
 			go endpointsInformer.Informer().Run(utilwait.NeverStop)
-			cache.WaitForCacheSync(utilwait.NeverStop, endpointsInformer.Informer().HasSynced)
+			if !cache.WaitForCacheSync(utilwait.NeverStop, endpointsInformer.Informer().HasSynced) {
+				logrus.Errorf("Error in syncing cache for Endpoints Informer. Informer will not be run.")
+				return
+			}
 			if processExisting != nil {
 				processExisting(endpointsInformer.Informer().GetStore().List())
 			}
@@ -69,7 +79,10 @@ func (factory *Factory) CreateOvnController() *ovn.Controller {
 		},
 		StartPolicyWatch: func(handler cache.ResourceEventHandler, processExisting func([]interface{})) {
 			go policyInformer.Informer().Run(utilwait.NeverStop)
-			cache.WaitForCacheSync(utilwait.NeverStop, policyInformer.Informer().HasSynced)
+			if !cache.WaitForCacheSync(utilwait.NeverStop, policyInformer.Informer().HasSynced) {
+				logrus.Errorf("Error in syncing cache for Policy Informer. Informer will not be run.")
+				return
+			}
 			if processExisting != nil {
 				processExisting(policyInformer.Informer().GetStore().List())
 			}
@@ -77,7 +90,10 @@ func (factory *Factory) CreateOvnController() *ovn.Controller {
 		},
 		StartNamespaceWatch: func(handler cache.ResourceEventHandler, processExisting func([]interface{})) {
 			go namespaceInformer.Informer().Run(utilwait.NeverStop)
-			cache.WaitForCacheSync(utilwait.NeverStop, namespaceInformer.Informer().HasSynced)
+			if !cache.WaitForCacheSync(utilwait.NeverStop, namespaceInformer.Informer().HasSynced) {
+				logrus.Errorf("Error in syncing cache for Namespace Informer. Informer will not be run.")
+				return
+			}
 			if processExisting != nil {
 				processExisting(namespaceInformer.Informer().GetStore().List())
 			}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -106,7 +106,7 @@ func (oc *Controller) WatchPods() {
 			oc.deleteLogicalPort(pod)
 		},
 	}
-	oc.StartPodWatch(handler, nil)
+	oc.StartPodWatch(handler, oc.syncPods)
 }
 
 // WatchServices starts the watching of Service resource and calls back the


### PR DESCRIPTION
Starting any of the watches will now allow for a processExisting function to be passed. This function can be used to match ovn's state to current list of active items and hence do some cleanup.

This PR does not do any cleanup, just provides for a way for the function to be passed.

@pravisankar PTAL, thanks.
