### PR TITLE
ovn-k8s-overlay: A few small fixes

### DIFF
--- a/go-controller/cmd/ovn-k8s-overlay/app/common.go
+++ b/go-controller/cmd/ovn-k8s-overlay/app/common.go
@@ -152,14 +152,14 @@ func configureManagementPortDebian(nodeName, clusterSubnet, routerIP, interfaceN
 
 		// Look for a line of the form "allow-ovs br-int".
 		if strings.Contains(line, "allow-ovs") && strings.Contains(line, "br-int") {
-			logrus.Infof("Has configed allow-ovs br-int")
+			logrus.Debugf("Has configed allow-ovs br-int")
 			bridgeExists = true
 			continue
 		}
 
 		// Look for a line of the form "allow-br-int $interfaceName".
 		if strings.Contains(line, "allow-br-int") && strings.Contains(line, interfaceName) {
-			logrus.Infof("Has configed allow-ovs %s", interfaceName)
+			logrus.Debugf("Has configed allow-ovs %s", interfaceName)
 			interfaceExists = true
 			continue
 		}
@@ -271,9 +271,7 @@ func configureManagementPort(nodeName, clusterSubnet, routerIP, interfaceName, i
 		if err != nil {
 			return err
 		}
-	}
-
-	if util.PathExist("/etc/sysconfig/network-scripts/ifup-ovs") {
+	} else if util.PathExist("/etc/sysconfig/network-scripts/ifup-ovs") {
 		err := configureManagementPortRedhat(nodeName, clusterSubnet, routerIP, interfaceName, interfaceIP)
 		if err != nil {
 			return err
@@ -367,8 +365,17 @@ func createManagementPort(nodeName, localSubnet, clusterSubnet string) error {
 	}
 
 	// Create a OVS internal interface.
-	interfaceName := "k8s-" + (nodeName[:11])
-	stdout, stderr, err = util.RunOVSVsctl("--", "--may-exist", "add-port", "br-int", interfaceName, "--", "set", "interface", interfaceName, "type=internal", "mtu_request="+string(config.MTU), "external-ids:iface-id=k8s-"+nodeName)
+	var interfaceName string
+	if len(nodeName) > 11 {
+		interfaceName = "k8s-" + (nodeName[:11])
+	} else {
+		interfaceName = "k8s-" + nodeName
+	}
+
+	stdout, stderr, err = util.RunOVSVsctl("--", "--may-exist", "add-port",
+		"br-int", interfaceName, "--", "set", "interface", interfaceName,
+		"type=internal", "mtu_request="+fmt.Sprintf("%d", config.MTU),
+		"external-ids:iface-id=k8s-"+nodeName)
 	if err != nil {
 		logrus.Errorf("Failed to add port to br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err


### PR DESCRIPTION
In the new golang port:

1. Downgrade a couple of "info" statements.
2. string(int) gives junk value. Use Sprintf instead.
3. don't try to access index greater than string length

Signed-off-by: Gurucharan Shetty <guru@ovn.org>