### PR TITLE
Fix an init race condition

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -61,12 +61,13 @@ const (
 // Run starts the actual watching. Also initializes any local structures needed.
 func (oc *Controller) Run() {
 	oc.gatewayCache = make(map[string]string)
+	oc.initializePolicyData()
+
 	oc.WatchPods()
 	oc.WatchServices()
 	oc.WatchEndpoints()
 	oc.WatchNamespaces()
 
-	oc.initializePolicyData()
 	oc.WatchNetworkPolicy()
 }
 


### PR DESCRIPTION
Move the policy init function prior to WatchPods because create pod event callback refers to logicalSwitchCache and an init race can result in null pointer dereference.

Signed-off-by: Rajat Chopra <rchopra@redhat.com>

@shettyg PTAL. Thanks.