### PR TITLE
Fix ovn-k8s-cni-overlay issues

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -12,7 +12,7 @@ all build:
 	hack/build-go.sh cmd/ovnkube/ovnkube.go
 	hack/build-go.sh cmd/ovn-k8s-overlay/ovn-k8s-overlay.go
 	hack/build-go.sh cmd/ovn-kube-util/ovn-kube-util.go
-	hack/build-go.sh cmd/ovn-kube-cni-overlay/ovn-kube-cni-overlay.go
+	hack/build-go.sh cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
 
 install:
 	cp ${OUT_DIR}/go/bin/* /usr/bin/

--- a/go-controller/cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
+++ b/go-controller/cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
@@ -288,7 +288,10 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	f, _ := os.OpenFile(config.LogPath, os.O_WRONLY|os.O_CREATE, 0755)
-	logrus.SetOutput(f)
+	f, err := os.OpenFile(config.LogPath, os.O_WRONLY|os.O_CREATE, 0755)
+	if err == nil {
+		defer f.Close()
+		logrus.SetOutput(f)
+	}
 	skel.PluginMain(cmdAdd, cmdDel, version.All)
 }

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -11,10 +11,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	certutil "k8s.io/client-go/util/cert"
 
 	ovncluster "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/cluster"
 	ovnfactory "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/factory"
+	util "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 )
 
 func main() {
@@ -71,7 +71,7 @@ func main() {
 		// uses the current context in kubeconfig
 		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	} else if *server != "" && *token != "" && ((*rootCAFile != "") || !strings.HasPrefix(*server, "https")) {
-		config, err = CreateConfig(*server, *token, *rootCAFile)
+		config, err = util.CreateConfig(*server, *token, *rootCAFile)
 	} else {
 		err = fmt.Errorf("Provide kubeconfig file or give server/token/tls credentials")
 	}
@@ -148,22 +148,4 @@ func main() {
 		// run forever
 		select {}
 	}
-}
-
-// CreateConfig creates the restclient.Config object from token, ca file and the apiserver
-// (similar to what is obtainable from kubeconfig file)
-func CreateConfig(server, token, rootCAFile string) (*restclient.Config, error) {
-	tlsClientConfig := restclient.TLSClientConfig{}
-	if rootCAFile != "" {
-		if _, err := certutil.NewPool(rootCAFile); err != nil {
-			return nil, err
-		}
-		tlsClientConfig.CAFile = rootCAFile
-	}
-
-	return &restclient.Config{
-		Host:            server,
-		BearerToken:     token,
-		TLSClientConfig: tlsClientConfig,
-	}, nil
 }

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -131,6 +131,9 @@ func FetchConfig() {
 	if cfg.Default.CACert != "" {
 		NbctlCACert = cfg.Default.CACert
 	}
+	if cfg.Default.K8sCACertificate != "" {
+		K8sCACertificate = cfg.Default.K8sCACertificate
+	}
 	if cfg.Default.Rundir != "" {
 		Rundir = cfg.Default.Rundir
 	}

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	restclient "k8s.io/client-go/rest"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+// CreateConfig creates the restclient.Config object from token, ca file and the apiserver
+// (similar to what is obtainable from kubeconfig file)
+func CreateConfig(server, token, rootCAFile string) (*restclient.Config, error) {
+	tlsClientConfig := restclient.TLSClientConfig{}
+	if rootCAFile != "" {
+		if _, err := certutil.NewPool(rootCAFile); err != nil {
+			return nil, err
+		}
+		tlsClientConfig.CAFile = rootCAFile
+	}
+
+	return &restclient.Config{
+		Host:            server,
+		BearerToken:     token,
+		TLSClientConfig: tlsClientConfig,
+	}, nil
+}


### PR DESCRIPTION
Bringing the cni plugin executable at par with python version.

 - rename ovn-kube-cni-overlay to ovn-k8s-cni-overlay (because config file pkg/config/config.go:CniPlugin parameter should match)
 - fix ovn-k8s-cni-overlay logging
 - fix ovn-k8s-cni-overlay so that it can talk to an apiserver over ssl (with its own bearer token)

Signed-off-by: Rajat Chopra <rchopra@redhat.com>