### PR TITLE
go-controller: Change node_name to be always lowercase

### DIFF
--- a/go-controller/cmd/ovn-k8s-overlay/app/common.go
+++ b/go-controller/cmd/ovn-k8s-overlay/app/common.go
@@ -321,6 +321,16 @@ func createManagementPort(nodeName, localSubnet, clusterSubnet string) error {
 	n, _ := localSubnetNet.Mask.Size()
 	routerIPMask := fmt.Sprintf("%s/%d", ip.String(), n)
 	routerIP := ip.String()
+	// Kubernetes emits events when pods are created. The event will contain
+	// only lowercase letters of the hostname even though the kubelet is
+	// started with a hostname that contains lowercase and uppercase letters.
+	// When the kubelet is started with a hostname containing lowercase and
+	// uppercase letters, this causes a mismatch between what the watcher
+	// will try to fetch and what kubernetes provides, thus failing to
+	// create the port on the logical switch.
+	// Until the above is changed, switch to a lowercase hostname for
+	// initMinion.
+	nodeName = strings.ToLower(nodeName)
 
 	routerMac, stderr, err := util.RunOVNNbctl("--if-exist", "get", "logical_router_port", "rtos-"+nodeName, "mac")
 	if err != nil {


### PR DESCRIPTION
When containers are created through kubernetes, an event will be sent.
The event will contain the lowercase hostname even though kubernetes
even though the hostname contains also some uppercase letters.

This causes the watcher to fail when it tries to fetch the logical switch
based on the hostname from kubernetes. It will fail to create the logical
port for the pod. Switching to lowercase hostname when creating the
logical switch will fix the issue.

Signed-off-by: Alin Balutoiu <abalutoiu@cloudbasesolutions.com>