### PR TITLE
ovn-k8s-overlay: reorganize args parsing

### DIFF
--- a/go-controller/cmd/ovn-k8s-overlay/app/common.go
+++ b/go-controller/cmd/ovn-k8s-overlay/app/common.go
@@ -19,6 +19,40 @@ import (
 	"github.com/urfave/cli"
 )
 
+const (
+	argClusterIPSubnet string = "cluster-ip-subnet"
+	argNodeName        string = "node-name"
+	argNBPrivKey       string = "nb-privkey"
+	argNBCert          string = "nb-cert"
+	argNBCACert        string = "nb-cacert"
+)
+
+func newFlags(customFlags ...cli.Flag) []cli.Flag {
+	flags := []cli.Flag{
+		cli.StringFlag{
+			Name:  argClusterIPSubnet,
+			Usage: "The cluster wide larger subnet of private ip addresses.",
+		},
+		cli.StringFlag{
+			Name:  argNodeName,
+			Usage: "A unique node name.",
+		},
+		cli.StringFlag{
+			Name:  argNBPrivKey,
+			Usage: "The private key used for northbound API SSL connections.",
+		},
+		cli.StringFlag{
+			Name:  argNBCert,
+			Usage: "The certificate used for northbound API SSL connections.",
+		},
+		cli.StringFlag{
+			Name:  argNBCACert,
+			Usage: "The CA certificate used for northbound API SSL connections.",
+		},
+	}
+	return append(flags, customFlags...)
+}
+
 func fetchOVNNB(context *cli.Context) error {
 	ovnNB, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".", "external_ids:ovn-nb")
 	if err != nil {
@@ -38,19 +72,19 @@ func fetchOVNNB(context *cli.Context) error {
 
 	config.Scheme = url.Scheme
 	if url.Scheme == "ssl" {
-		privkey := context.String("nb-privkey")
-		cert := context.String("nb-cert")
-		cacert := context.String("nb-cacert")
-
+		privkey, _ := util.StringArg(context, argNBPrivKey)
 		if privkey != "" {
 			config.NbctlPrivateKey = privkey
 		}
+		cert, _ := util.StringArg(context, argNBCert)
 		if cert != "" {
 			config.NbctlCertificate = cert
 		}
+		cacert, _ := util.StringArg(context, argNBCACert)
 		if cacert != "" {
 			config.NbctlCACert = cacert
 		}
+
 		if config.NbctlPrivateKey == "" || config.NbctlCertificate == "" || config.NbctlCACert == "" {
 			return fmt.Errorf("Must specify private key, certificate, and CA certificate for 'ssl' scheme")
 		}

--- a/go-controller/cmd/ovn-k8s-overlay/app/master_init.go
+++ b/go-controller/cmd/ovn-k8s-overlay/app/master_init.go
@@ -9,36 +9,20 @@ import (
 	"github.com/urfave/cli"
 )
 
+const (
+	argMasterSwitchSubnet string = "master-switch-subnet"
+)
+
 // InitMasterCmd initializes k8s master node.
 var InitMasterCmd = cli.Command{
 	Name:  "master-init",
 	Usage: "Initialize k8s master node",
-	Flags: []cli.Flag{
+	Flags: newFlags(
 		cli.StringFlag{
-			Name:  "cluster-ip-subnet",
-			Usage: "The cluster wide larger subnet of private ip addresses.",
-		},
-		cli.StringFlag{
-			Name:  "master-switch-subnet",
+			Name:  argMasterSwitchSubnet,
 			Usage: "The smaller subnet just for master.",
 		},
-		cli.StringFlag{
-			Name:  "node-name",
-			Usage: "A unique node name.",
-		},
-		cli.StringFlag{
-			Name:  "nb-privkey",
-			Usage: "The private key used for northbound API SSL connections.",
-		},
-		cli.StringFlag{
-			Name:  "nb-cert",
-			Usage: "The certificate used for northbound API SSL connections.",
-		},
-		cli.StringFlag{
-			Name:  "nb-cacert",
-			Usage: "The CA certificate used for northbound API SSL connections.",
-		},
-	},
+	),
 	Action: func(context *cli.Context) error {
 		if err := initMaster(context); err != nil {
 			return fmt.Errorf("Failed init master: %v", err)
@@ -48,27 +32,26 @@ var InitMasterCmd = cli.Command{
 }
 
 func initMaster(context *cli.Context) error {
-	masterSwitchSubnet := context.String("master-switch-subnet")
-	if masterSwitchSubnet == "" {
-		return fmt.Errorf("argument --master-switch-subnet should be non-null")
+	masterSwitchSubnet, err := util.StringArg(context, argMasterSwitchSubnet)
+	if err != nil {
+		return err
 	}
 
-	clusterIPSubnet := context.String("cluster-ip-subnet")
-	if clusterIPSubnet == "" {
-		return fmt.Errorf("argument --cluster-ip-subnet should be non-null")
+	clusterIPSubnet, err := util.StringArg(context, argClusterIPSubnet)
+	if err != nil {
+		return err
 	}
 
-	nodeName := context.String("node-name")
-	if nodeName == "" {
-		return fmt.Errorf("argument --cluster-ip-subnet should be non-null")
+	nodeName, err := util.StringArg(context, argNodeName)
+	if err != nil {
+		return err
 	}
 
 	// Fetch config file to override default values.
 	config.FetchConfig()
 
 	// Fetch OVN central database's ip address.
-	err := fetchOVNNB(context)
-	if err != nil {
+	if err := fetchOVNNB(context); err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+// StringArg gets the named command-line argument or returns an error if it is empty
+func StringArg(context *cli.Context, name string) (string, error) {
+	val := context.String(name)
+	if val == "" {
+		return "", fmt.Errorf("argument --%s should be non-null", name)
+	}
+	return val, nil
+}


### PR DESCRIPTION
Use constants for argument names to turn potential code errors
into compile time errors instead of runtime ones. urfave/cli
returns "" if the argument isn't defined, so mistyping the arg
name in the code could cause unexpected behavior during parsing.

Also unify the common args between master and minion to reduce
code duplication.

Signed-off-by: Dan Williams <dcbw@redhat.com>

@rajatchopra @shettyg 