### PR TITLE
ovnkube: depend on out-of-band install (make install, RPM¸ deb, etc) for CNI plugin

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -1,6 +1,8 @@
-
 OUT_DIR = _output
 export OUT_DIR
+PREFIX ?= ${DESTDIR}/usr
+BINDIR ?= ${PREFIX}/bin
+CNIBINDIR ?= ${DESTDIR}/opt/cni/bin
 
 .PHONY: all build
 
@@ -15,7 +17,10 @@ all build:
 	hack/build-go.sh cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
 
 install:
-	cp ${OUT_DIR}/go/bin/* /usr/bin/
+	install -D -m 755 ${OUT_DIR}/go/bin/ovnkube ${BINDIR}/
+	install -D -m 755 ${OUT_DIR}/go/bin/ovn-k8s-overlay ${BINDIR}/
+	install -D -m 755 ${OUT_DIR}/go/bin/ovn-kube-util ${BINDIR}/
+	install -D -m 755 ${OUT_DIR}/go/bin/ovn-k8s-cni-overlay ${CNIBINDIR}/
 
 clean:
 	rm -rf ${OUT_DIR}


### PR DESCRIPTION
Also keep the original name of the executable; no reason to call it
ovn_cni, as CNI doesn't care what it's called, it just runs whatever
its given.

Signed-off-by: Dan Williams <dcbw@redhat.com>

@rajatchopra @shettyg 