### PR TITLE
Added man pages for utils

### DIFF
--- a/docs/ovn-k8s-overlay.1
+++ b/docs/ovn-k8s-overlay.1
@@ -1,0 +1,63 @@
+.TH OVN-K8S-OVERLAY "1" "Jan 2018" "ovn-kubernetes" "OVN-KUBERNETES User Commands"
+.SH NAME
+ovn-k8s-overlay \- initialize gateway
+.SH SYNOPSIS
+.B ovn-k8s-overlay
+[\fI\,GLOBAL OPTION\/\fR]... \fI\,COMMAND\/\fR [\fI\,COMMAND OPTIONS\/\fR] [\fI\,ARGUMENTS\/\fR...]
+.SH DESCRIPTION
+.PP
+ovn-k8s-overlay to init gateway
+
+.SH COMMANDS
+.PP
+\fBgateway-init\fR
+Initialize k8s gateway node
+
+.PP
+.SH COMMAND OPTIONS
+.TP
+\fB\--cluster-ip-subnet\fR  value
+The cluster wide larger subnet of private ip addresses.
+.TP
+\fB\--physical-interface\fR  value
+The physical interface via which external connectivity is provided.
+.TP
+\fB\--bridge-interface\fR  value
+The OVS bridge interface via which external connectivity is provided.
+.TP
+\fB\--physical-ip\fR  value
+The ip address of the physical interface or bridge interface via which external connectivity is provided. This should be of the form IP/MASK.
+.TP
+\fB\--node-name\fR  value
+A unique node name.
+.TP
+\fB\--default-gw\fR  value
+The next hop IP address for your physical interface.
+.TP
+\fB\--rampout-ip-subnets\fR  value
+Uses this gateway to rampout traffic originating from the specified comma separated ip subnets.  Used to distribute outgoing traffic via multiple gateways.
+.TP
+\fB\--nb-privkey\fR  value
+The private key used for northbound API SSL connections.
+.TP
+\fB\--nb-cert\fR  value
+The certificate used for northbound API SSL connections.
+.TP
+\fB\--nb-cacert\fR  value
+The CA certificate used for northbound API SSL connections.
+
+.SH GLOBAL OPTIONS
+.TP
+\fB\--help\fR, \fB\-h\fR
+show help
+.TP
+\fB\--version\fR, \fB\-v
+print the version
+
+
+.SH "SEE ALSO"
+.BR ovnkube (1),
+.BR ovn-kube-util (1).
+
+.PP
+https://github.com/openvswitch/ovn-kubernetes

--- a/docs/ovn-kube-util.1
+++ b/docs/ovn-kube-util.1
@@ -1,0 +1,31 @@
+.TH OVN-KUBE-UTIL "1" "Jan 2018" "ovn-kubernetes" "OVN-KUBERNETES User Commands"
+.SH NAME
+ovn-kube-util \- Utils for ovn-kubernetes
+.SH SYNOPSIS
+.B ovn-kube-util
+[\fI\,GLOBAL OPTION\/\fR]... \fI\,COMMAND\/\fR [\fI\,COMMAND OPTIONS\/\fR] [\fI\,ARGUMENTS\/\fR...]
+.SH DESCRIPTION
+Utils for ovn-kubernetes
+
+.SS COMMANDS
+.PP
+\fBnics-to-bridge\fR
+Create ovs bridge for nic interfaces
+.PP
+\fBhelp\fR, \fBh\fR
+Shows a list of commands or help for one command.
+
+.SH GLOBAL OPTIONS
+.TP
+\fB\--help\fR, \fB\-h\fR
+Show help.
+.TP
+\fB\--version\fR, \fB\-v\fR
+Print the version.
+
+.SH "SEE ALSO"
+.BR ovn-k8s-overlay (1),
+.BR ovnkube (1).
+
+.PP
+https://github.com/openvswitch/ovn-kubernetes

--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -1,0 +1,107 @@
+.TH OVNKUBE "1" "Jan 2018" "ovn-kubernetes" "OVN-KUBERNETES User Commands"
+.SH NAME
+ovnkube \- ovn utility
+.SH SYNOPSIS
+.B ovnkube
+[\fI\,OPTION\/\fR]... [\fI\,FILE\/\fR]...
+.SH DESCRIPTION
+.PP
+The ovn utility used to confiugre ovn-kubernetes
+.SH OPTIONS
+.TP
+\fB\-alsologtostderr\fR
+log to standard error as well as files
+.TP
+\fB\-apiserver\fR string
+URL to the Kubernetes apiserver (default "https://localhost:8443")
+.TP
+\fB\-ca-cert\fR string
+CA cert for the Kubernetes api server
+.TP
+\fB\-cluster-subnet\fR string
+Cluster wide IP subnet to use (default "11.11.0.0/16")
+.TP
+\fB\-init-master\fR string
+initialize master, requires the hostname as argument
+.TP
+\fB\-init-node\fR string
+initialize node, requires the name that node is registered with in kubernetes cluster
+.TP
+\fB\-kubeconfig\fR string
+absolute path to the kubeconfig file
+.TP
+\fB\-log_backtrace_at value
+when logging hits line file:N, emit a stack trace
+.TP
+\fB\-log_dir\fR string
+If non-empty, write log files in this directory
+.TP
+\fB\-loglevel\fR int
+logrus loglevels (default 5)
+.TP
+\fB\-logtostderr
+log to standard error instead of files
+.TP
+\fB\-net-controller
+Flag to start the central controller that watches pods/services/policies
+.TP
+\fB\-ovn-north-client-cacert\fR string
+CA certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket.
+.TP
+\fB\-ovn-north-client-cert\fR string
+Client certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket.
+.TP
+\fB\-ovn-north-client-privkey\fR string
+Private key that the client should use for talking to the OVN database.  Leave empty to use local unix socket.
+.TP
+\fB\-ovn-north-db\fR string
+IP address and port of the OVN northbound API (eg, ssl://1.2.3.4:6641).  Leave empty to use a local unix socket.
+.TP
+\fB\-ovn-north-server-cacert\fR string
+CA certificate that the OVN northbound API should use for securing the API.  Leave empty to use local unix socket.
+.TP
+\fB\-ovn-north-server-cert\fR string
+Server certificate that the OVN northbound API should use for securing the API.  Leave empty to use local unix socket.
+.TP
+\fB\-ovn-north-server-privkey\fR string
+Private key that the OVN northbound API should use for securing the API.  Leave empty to use local unix socket.
+.TP
+\fB\-ovn-south-client-cacert\fR string
+CA certificate that the client should use for talking to the OVN database.
+.TP
+\fB\-ovn-south-client-cert\fR string
+Client certificate that the client should use for talking to the OVN database.
+.TP
+\fB\-ovn-south-client-privkey\fR string
+Private key that the client should use for talking to the OVN database.
+.TP
+\fB\-ovn-south-db\fR string
+IP address and port of the OVN southbound database (eg, ssl://1.2.3.4:6642).
+.TP
+\fB\-ovn-south-server-cacert\fR string
+CA certificate that the OVN southbound database should use for securing the API.
+.TP
+\fB\-ovn-south-server-cert\fR string
+Server certificate that the OVN southbound database should use for securing the API.
+.TP
+\fB\-ovn-south-server-privkey\fR string
+Private key that the OVN southbound database should use for securing the API.
+.TP
+\fB\-stderrthreshold\fR value
+logs at or above this threshold go to stderr
+.TP
+\fB\-token\fR string
+Bearer token to use for establishing ovn infrastructure
+.TP
+\fB\-v\fR value
+log level for V logs
+.TP
+\fB\-vmodule\fR value
+comma-separated list of pattern=N settings for file-filtered logging
+
+.SH "SEE ALSO"
+.BR ovn-k8s-overlay (1),
+.BR ovn-kube-util (1).
+
+.PP
+https://github.com/openvswitch/ovn-kubernetes


### PR DESCRIPTION
First draft of man pages for:
ovn-k8s-overlay
ovn-kube-util
ovnkube
They are based on "help" output from the commands.
This is part of building an RPM for fedora.

Signed-off-by: pcameron <pcameron@redhat.com>