### PR TITLE
hack: don't pass -a to 'go install'

### DIFF
--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -18,7 +18,7 @@ build_binaries() {
     export GOBIN="${OVN_KUBE_OUTPUT_BINPATH}"
 
     # Add a buildid to the executable - needed by rpmbuild
-    go install -a -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -v -x "${OVN_KUBE_BINARIES[@]}";
+    go install -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -v -x "${OVN_KUBE_BINARIES[@]}";
 }
 
 test() {


### PR DESCRIPTION
-a means "force rebuild packages that are already up-to-date", which
makes builds take longer, but worse tries to install things to the
system gopath that it shouldn't touch:

```
hack/build-go.sh cmd/ovnkube/ovnkube.go
WORK=/tmp/go-build173037572
runtime/internal/sys
mkdir -p $WORK/runtime/internal/sys/_obj/
mkdir -p $WORK/runtime/internal/
cd /usr/lib/golang/src/runtime/internal/sys
/usr/lib/golang/pkg/tool/linux_amd64/compile -o $WORK/runtime/internal/sys.a -trimpath $WORK -goversion go1.9.2 -p runtime/internal/sys -std -+ -complete -buildid 1c8a63759c54727d75e76055a9cf70042cbecdee -D _/usr/lib/golang/src/runtime/internal/sys -I $WORK -pack ./arch.go ./arch_amd64.go ./intrinsics.go ./stubs.go ./sys.go ./zgoarch_amd64.go ./zgoos_linux.go ./zversion.go
mkdir -p /usr/lib/golang/pkg/linux_amd64/runtime/internal/
cp $WORK/runtime/internal/sys.a /usr/lib/golang/pkg/linux_amd64/runtime/internal/sys.a
go install runtime/internal/sys: open /usr/lib/golang/pkg/linux_amd64/runtime/internal/sys.a: permission denied
make: *** [Makefile:14: all] Error 1
```

Signed-off-by: Dan Williams <dcbw@redhat.com>

@pecameron @rajatchopra @shettyg 