### PR TITLE
cluster/master: Fix node subnet annotation.

### DIFF
--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -59,6 +59,9 @@ func (cluster *OvnClusterController) StartClusterMaster(masterNodeName string) e
 
 	// now go over the 'existing' list again and create annotations for those who do not have it
 	for _, node := range existingNodes.Items {
+		if node.Name == masterNodeName {
+			continue
+		}
 		_, ok := node.Annotations[OvnHostSubnet]
 		if !ok {
 			err := cluster.addNode(&node)


### PR DESCRIPTION
The current code makes an assumption that no
kubelet is running in master node. But when kubelet
does run in master, it will allocate a separate subnet
for that node and annotate it.

With this commit, we skip annotating the node
if the node is the same as the master.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>