### PR TITLE
go-controller: Handle services in different platforms.

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,6 +15,9 @@ const (
 	ovsCommandTimeout = 5
 	ovsVsctlCommand   = "ovs-vsctl"
 	ovnNbctlCommand   = "ovn-nbctl"
+	osRelease         = "/etc/os-release"
+	rhel              = "RHEL"
+	ubuntu            = "Ubuntu"
 )
 
 // PathExist checks the path exist or not.
@@ -23,6 +27,112 @@ func PathExist(path string) bool {
 		return false
 	}
 	return true
+}
+
+func runningPlatform() (string, error) {
+	fileContents, err := ioutil.ReadFile(osRelease)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse file %s (%v)", osRelease, err)
+	}
+
+	var platform string
+	ss := strings.Split(string(fileContents), "\n")
+	for _, pair := range ss {
+		keyValue := strings.Split(pair, "=")
+		if len(keyValue) == 2 {
+			if keyValue[0] == "Name" || keyValue[0] == "NAME" {
+				platform = keyValue[1]
+				break
+			}
+		}
+	}
+
+	if platform == "" {
+		return "", fmt.Errorf("failed to find the platform name")
+	}
+
+	if strings.Contains(platform, "Fedora") ||
+		strings.Contains(platform, rhel) {
+		return rhel, nil
+	} else if strings.Contains(platform, "Debian") ||
+		strings.Contains(platform, ubuntu) {
+		return ubuntu, nil
+	} else if strings.Contains(platform, "VMware") {
+		return "Photon", nil
+	}
+	return "", fmt.Errorf("Unknown platform")
+}
+
+// StartOVS starts OVS service
+func StartOVS() error {
+	platform, err := runningPlatform()
+	if err != nil {
+		return err
+	}
+	if platform == rhel {
+		out, err := exec.Command("systemctl", "start",
+			"openvswitch").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("error starting openvswitch "+
+				"service: %v\n  %q", err, string(out))
+		}
+	} else if platform == ubuntu {
+		out, err := exec.Command("service", "openvswitch-switch",
+			"start").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("error starting openvswitch "+
+				"service: %v\n  %q", err, string(out))
+		}
+	}
+	return nil
+}
+
+// StartOvnNorthd starts ovn-northd
+func StartOvnNorthd() error {
+	platform, err := runningPlatform()
+	if err != nil {
+		return err
+	}
+	if platform == rhel {
+		out, err := exec.Command("systemctl", "start",
+			"ovn-northd").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("error starting ovn-northd "+
+				"service: %v\n  %q", err, string(out))
+		}
+	} else if platform == ubuntu {
+		out, err := exec.Command("service", "ovn-central",
+			"start").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("error starting ovn-central "+
+				"service: %v\n  %q", err, string(out))
+		}
+	}
+	return nil
+}
+
+// RestartOvnController restarts ovn-controller
+func RestartOvnController() error {
+	platform, err := runningPlatform()
+	if err != nil {
+		return err
+	}
+	if platform == rhel {
+		out, err := exec.Command("systemctl", "restart",
+			"ovn-controller").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("error starting ovn-controller "+
+				"service: %v\n  %q", err, string(out))
+		}
+	} else if platform == ubuntu {
+		out, err := exec.Command("service", "ovn-host",
+			"restart").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("error starting ovn-host "+
+				"service: %v\n  %q", err, string(out))
+		}
+	}
+	return nil
 }
 
 // RunOVSVsctl runs a command via ovs-vsctl.


### PR DESCRIPTION
Currently, the code makes an assumption that the platform
is RHEL or Fedora. This expands the scope to Ubuntu and
also makes sure that the code does not error out on
VMware Photon platform.

The second patch of the series adds ovn-remote, ovn-encap-type 
and ovn-encap-ip for master too.
