### PR TITLE
Vagrant: Use golang watcher and utilities.

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -61,15 +61,14 @@ You can verify the services are up and running now:
 * ./kubectl get svc
 
 You can now get to the service from the host running Virtualbox by using
-the Nodeport and the IP 10.10.0.11 (the public-ip for the master found in
+the Nodeport and the IP 10.10.0.12 (the public-ip for the k8s-minion1 found in
 the vagrant/provisioning/vm_config.conf.yml file).
 
-* curl 10.10.0.11:[nodeport]
-
-Since the vagrant initializes gateway node on the minions too, you should be
-able to access the same service via the IP addresses of the minion nodes too.
-
 * curl 10.10.0.12:[nodeport]
+
+Since the vagrant initializes gateway node on the other minion too, you should
+be able to access the same service via 10.10.0.13 too.
+
 * curl 10.10.0.13:[nodeport]
 
 Note: The above IP addresss are NOT used when you use the vagrant's public

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -30,12 +30,12 @@ Vagrant.configure(2) do |config|
     else
         k8smaster.vm.network "private_network", ip: vagrant_config['k8smaster']['public-ip'], netmask: netmask
     end
+    k8smaster.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['short_name']}"
     k8smaster.vm.provision "shell", path: "provisioning/setup-master.sh", privileged: false,
       :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['public-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8smaster']['master-switch-subnet']}"
     k8smaster.vm.provision "shell", path: "provisioning/setup-k8s-master.sh", privileged: false,
       :args => "#{vagrant_config['k8smaster']['public-ip']} #{netmask} #{vagrant_config['public_gateway']} #{ovn_external}"
-    k8smaster.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,
-      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['short_name']}"
     k8smaster.vm.provider "virtualbox" do |vb|
        vb.name = vagrant_config['k8smaster']['short_name']
        vb.memory = vagrant_config['k8smaster']['memory']
@@ -65,12 +65,12 @@ Vagrant.configure(2) do |config|
     else
         k8sminion1.vm.network "private_network", ip: vagrant_config['k8sminion1']['public-ip'], netmask: netmask
     end
+    k8sminion1.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['short_name']}"
     k8sminion1.vm.provision "shell", path: "provisioning/setup-minion.sh", privileged: false,
       :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['public-ip']} #{netmask} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion1']['minion-switch-subnet']} #{vagrant_config['public_gateway']} #{ovn_external}"
     k8sminion1.vm.provision "shell", path: "provisioning/setup-k8s-minion.sh", privileged: false,
       :args => "#{vagrant_config['k8smaster']['overlay-ip']}"
-    k8sminion1.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,
-      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['short_name']}"
     k8sminion1.vm.provider "virtualbox" do |vb|
        vb.name = vagrant_config['k8sminion1']['short_name']
        vb.memory = vagrant_config['k8sminion1']['memory']
@@ -98,14 +98,14 @@ Vagrant.configure(2) do |config|
     if !ovn_external.nil?
         k8sminion2.vm.network "public_network", bridge: ovn_external
     else
-        k8sminion2.vm.network "private_network", ip: vagrant_config['k8sminion1']['public-ip'], netmask: netmask
+        k8sminion2.vm.network "private_network", ip: vagrant_config['k8sminion2']['public-ip'], netmask: netmask
     end
+    k8sminion2.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,
+      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['short_name']}"
     k8sminion2.vm.provision "shell", path: "provisioning/setup-minion.sh", privileged: false,
       :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['public-ip']} #{netmask} #{vagrant_config['k8sminion2']['short_name']} #{vagrant_config['k8sminion2']['minion-switch-subnet']} #{vagrant_config['public_gateway']} #{ovn_external}"
     k8sminion2.vm.provision "shell", path: "provisioning/setup-k8s-minion.sh", privileged: false,
       :args => "#{vagrant_config['k8smaster']['overlay-ip']}"
-    k8sminion2.vm.provision "shell", path: "provisioning/setup-hostnames.sh", privileged: true,
-      :args => "#{vagrant_config['k8smaster']['overlay-ip']} #{vagrant_config['k8smaster']['short_name']} #{vagrant_config['k8sminion1']['overlay-ip']} #{vagrant_config['k8sminion1']['short_name']} #{vagrant_config['k8sminion2']['overlay-ip']} #{vagrant_config['k8sminion2']['short_name']}"
     k8sminion2.vm.provider "virtualbox" do |vb|
        vb.name = vagrant_config['k8sminion2']['short_name']
        vb.memory = vagrant_config['k8sminion2']['memory']

--- a/vagrant/provisioning/setup-k8s-minion.sh
+++ b/vagrant/provisioning/setup-k8s-minion.sh
@@ -20,6 +20,35 @@ pushd /opt/cni/bin
 sudo tar xvzf ~/cni-amd64-v0.5.2.tgz
 popd
 
+source ~/setup_minion_args.sh
+# Create a kubeconfig file.
+cat << KUBECONFIG >> ~/kubeconfig.yaml
+apiVersion: v1
+clusters:
+- cluster:
+    server: http://$MASTER_OVERLAY_IP:8080
+  name: default-cluster
+- cluster:
+    server: http://$MASTER_OVERLAY_IP:8080
+  name: local-server
+- cluster:
+    server: http://$MASTER_OVERLAY_IP:8080
+  name: ubuntu
+contexts:
+- context:
+    cluster: ubuntu
+    user: ubuntu
+  name: ubuntu
+current-context: ubuntu
+kind: Config
+preferences: {}
+users:
+- name: ubuntu
+  user:
+    password: p1NVMZqhOOOqkWQq
+    username: admin
+KUBECONFIG
+
 # Start k8s daemons
 pushd k8s/server/kubernetes/server/bin
 echo "Starting kubelet ..."
@@ -29,6 +58,19 @@ nohup sudo ./kubelet --api-servers=http://$MASTER_IP:8080 --v=2 --address=0.0.0.
                      --cni-bin-dir="/opt/cni/bin/" 2>&1 0<&- &>/dev/null &
 sleep 5
 popd
+
+# Initialize the minion and gateway.
+sudo ovnkube -kubeconfig $HOME/kubeconfig.yaml -v=4 -alsologtostderr \
+    -apiserver="http://$MASTER_OVERLAY_IP:8080" \
+    -init-node="$MINION_NAME"  -ovn-north-db="tcp://$MASTER_OVERLAY_IP:6631" \
+    -ovn-south-db="tcp://$MASTER_OVERLAY_IP:6632" --token="test" \
+    -init-gateways -gateway-interface=enp0s9 -gateway-nexthop="$GW_IP" \
+    -cluster-subnet="192.168.0.0/16" 2>&1
+
+
+# Start the gateway helper.
+sudo ovn-k8s-gateway-helper --physical-bridge=brenp0s9 \
+            --physical-interface=enp0s9 --pidfile --detach
 
 # Restore xtrace
 $XTRACE


### PR DESCRIPTION
The golang watcher and utilities have come of age.
So we can replace most python utilities with golang
ones.

We still have one python utility -  ovn-k8s-gateway-watcher
that will still be used with this vagrant.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>