### PR TITLE
cluster/node: Program the gateway bridge for egress.

### DIFF
--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -63,6 +63,10 @@ log to standard error instead of files
 \fB\-net-controller
 Flag to start the central controller that watches pods/services/policies
 .TP
+\fB\-nodeport\fR
+Setup nodeport based entries in OVN gateways for ingress into the k8s cluster.
+By default, it is disabled.
+.TP
 \fB\-ovn-north-client-cacert\fR string
 CA certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket.
 .TP

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -164,6 +164,7 @@ func main() {
 		if *token == "" {
 			panic("Cannot initialize node without service account 'token'. Please provide one with --token argument")
 		}
+		clusterController.NodePortEnable = *nodePortEnable
 
 		err := clusterController.StartClusterNode(*node)
 		if err != nil {

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -78,6 +78,10 @@ func main() {
 			"configured in the node is used. Only useful with "+
 			"\"init-gateways\"")
 
+	// Enable nodeport
+	nodePortEnable := flag.Bool("nodeport", false,
+		"Setup nodeport based ingress on gateways.")
+
 	flag.Parse()
 
 	// Process log flags
@@ -176,6 +180,7 @@ func main() {
 		}
 	}
 	if *netController {
+		ovnController.NodePortEnable = *nodePortEnable
 		ovnController.Run()
 	}
 	if *master != "" || *netController {

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -24,7 +24,9 @@ type OvnClusterController struct {
 
 	GatewayInit    bool
 	GatewayIntf    string
+	GatewayBridge  string
 	GatewayNextHop string
+	NodePortEnable bool
 
 	NorthDBServerAuth *OvnDBAuth
 	NorthDBClientAuth *OvnDBAuth

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -46,7 +46,7 @@ func (ovn *Controller) addEndpoints(ep *kapi.Endpoints) error {
 	for targetPort, ips := range tcpPortMap {
 		for _, svcPort := range svc.Spec.Ports {
 			if svcPort.Protocol == kapi.ProtocolTCP && svcPort.TargetPort.IntVal == targetPort {
-				if svc.Spec.Type == kapi.ServiceTypeNodePort {
+				if svc.Spec.Type == kapi.ServiceTypeNodePort && ovn.NodePortEnable {
 					logrus.Debugf("Creating Gateways IP for NodePort: %d, %d, %v", svcPort.NodePort, targetPort, ips)
 					err = ovn.createGatewaysVIP(string(svcPort.Protocol), svcPort.NodePort, targetPort, ips)
 					if err != nil {
@@ -67,7 +67,7 @@ func (ovn *Controller) addEndpoints(ep *kapi.Endpoints) error {
 	for targetPort, ips := range udpPortMap {
 		for _, svcPort := range svc.Spec.Ports {
 			if svcPort.Protocol == kapi.ProtocolUDP && svcPort.TargetPort.IntVal == targetPort {
-				if svc.Spec.Type == kapi.ServiceTypeNodePort {
+				if svc.Spec.Type == kapi.ServiceTypeNodePort && ovn.NodePortEnable {
 					err = ovn.createGatewaysVIP(string(svcPort.Protocol), svcPort.NodePort, targetPort, ips)
 					if err != nil {
 						logrus.Errorf("Error in creating Node Port for svc %s, node port: %d - %v\n", svc.Name, svcPort.NodePort, err)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -13,7 +13,8 @@ import (
 // Controller structure is the object which holds the controls for starting
 // and reacting upon the watched resources (e.g. pods, endpoints)
 type Controller struct {
-	Kube kube.Interface
+	Kube           kube.Interface
+	NodePortEnable bool
 
 	StartPodWatch       func(cache.ResourceEventHandler, func([]interface{}))
 	StartEndpointWatch  func(cache.ResourceEventHandler, func([]interface{}))

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -169,7 +169,7 @@ func (ovn *Controller) deleteService(service *kapi.Service) {
 			targetPort = svcPort.Port
 		}
 
-		if service.Spec.Type == kapi.ServiceTypeNodePort {
+		if service.Spec.Type == kapi.ServiceTypeNodePort && ovn.NodePortEnable {
 			// Delete the 'NodePort' service from a load-balancer instantiated in gateways.
 			err := ovn.createGatewaysVIP(string(protocol), port, targetPort, ips)
 			if err != nil {

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -14,6 +14,7 @@ import (
 const (
 	ovsCommandTimeout = 5
 	ovsVsctlCommand   = "ovs-vsctl"
+	ovsOfctlCommand   = "ovs-ofctl"
 	ovnNbctlCommand   = "ovn-nbctl"
 	osRelease         = "/etc/os-release"
 	rhel              = "RHEL"
@@ -133,6 +134,23 @@ func RestartOvnController() error {
 		}
 	}
 	return nil
+}
+
+// RunOVSOfctl runs a command via ovs-ofctl.
+func RunOVSOfctl(args ...string) (string, string, error) {
+	cmdPath, err := exec.LookPath(ovsOfctlCommand)
+	if err != nil {
+		return "", "", err
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := exec.Command(cmdPath, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err = cmd.Run()
+	return strings.Trim(stdout.String(), "\" \n"), stderr.String(), err
 }
 
 // RunOVSVsctl runs a command via ovs-vsctl.


### PR DESCRIPTION
If nodeport is not enabled, we can program the gateway
bridge with static flows to enable all exited traffic
from pods to re-enter. With this, we don't need to run
ovn-k8s-gateway-helper on all the gateways.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>