### PR TITLE
cluster/node: Direct attach of gateway physical interface.

### DIFF
--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -22,6 +22,10 @@ CA cert for the Kubernetes api server
 The interface in minions that will be the gateway interface.  If none
 specified, then the node's interface on which the default gateway is
 configured will be used as the gateway interface. Only useful with
+\fB\-gateway\-spare\-interface\fR
+If set, assumes that \fB\-gateway\-interface\fR provided can be
+exclusively used for  the OVN gateway.  When specified, only OVN
+related traffic can flow through this interface.
 \fBinit-gateways\fR.
 .TP
 \fB\-gateway\-nexthop\fR string

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -77,6 +77,10 @@ func main() {
 			"of the node in question. If not specified, the default gateway"+
 			"configured in the node is used. Only useful with "+
 			"\"init-gateways\"")
+	gatewaySpareIntf := flag.Bool("gateway-spare-interface", false,
+		"If true, assumes that \"gateway-interface\" provided can be "+
+			"exclusively used for the OVN gateway.  When true, only OVN"+
+			"related traffic can flow through this interface")
 
 	// Enable nodeport
 	nodePortEnable := flag.Bool("nodeport", false,
@@ -132,6 +136,7 @@ func main() {
 		clusterController.GatewayInit = *gatewayInit
 		clusterController.GatewayIntf = *gatewayIntf
 		clusterController.GatewayNextHop = *gatewayNextHop
+		clusterController.GatewaySpareIntf = *gatewaySpareIntf
 		_, clusterController.ClusterIPNet, err = net.ParseCIDR(*clusterSubnet)
 		if err != nil {
 			panic(err.Error)

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -22,11 +22,12 @@ type OvnClusterController struct {
 	ClusterIPNet     *net.IPNet
 	HostSubnetLength uint32
 
-	GatewayInit    bool
-	GatewayIntf    string
-	GatewayBridge  string
-	GatewayNextHop string
-	NodePortEnable bool
+	GatewayInit      bool
+	GatewayIntf      string
+	GatewayBridge    string
+	GatewayNextHop   string
+	GatewaySpareIntf bool
+	NodePortEnable   bool
 
 	NorthDBServerAuth *OvnDBAuth
 	NorthDBClientAuth *OvnDBAuth


### PR DESCRIPTION
 One can currently pass -gateway-interface to specify the
 physical interface to use for a OVN gateway. With this patch
 you can specify -gateway-spare-interface to directly
 attach the -gateway-interface to br-int.

 Signed-off-by: Gurucharan Shetty <guru@ovn.org>