### PR TITLE
ansible based ci/cd testing infrastructure based on openshift on DinD setup

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,19 @@
+# Integration Tests
+
+This directory contains playbooks to set up for and run set of integration
+tests for ovn-kubernetes using openshift-dind cluster on RHEL and Fedora hosts. One entrypoint exists:
+
+ - `main.yml`: sets up the machine and runs tests
+
+When running `main.yml`, two tags are present:
+
+ - `setup`: run all tasks to set up the system for testing
+ - `integration`: build ovn-kubernetes from source and run the dind based cni_vendor_tests
+
+The playbooks assume the following things about your system:
+
+ - on RHEL, the server and extras repos are configured and certs are present
+ - `ansible` is installed and the host is boot-strapped to allow `ansible` to run against it
+ - the `$GOPATH` is set and present for all shells (*e.g.* written in `/etc/environment`)
+ - ovn-kubernetes repository is checked out to the correct state at `${GOPATH}/src/github.com/openvswitch/ovn-kubernetes`
+ - the user running the playbook has access to passwordless `sudo`

--- a/test/integration/ansible.cfg
+++ b/test/integration/ansible.cfg
@@ -1,0 +1,359 @@
+# config file for ansible -- http://ansible.com/
+# ==============================================
+
+# nearly all parameters can be overridden in ansible-playbook
+# or with command line flags. ansible will read ANSIBLE_CONFIG,
+# ansible.cfg in the current working directory, .ansible.cfg in
+# the home directory or /etc/ansible/ansible.cfg, whichever it
+# finds first
+
+[defaults]
+
+# some basic default values...
+
+#inventory       = inventory
+#library        = /usr/share/my_modules/
+#remote_tmp     = $HOME/.ansible/tmp
+#local_tmp      = .ansible/tmp
+#forks          = 5
+forks           = 10
+#poll_interval  = 15
+#sudo_user      = root
+#ask_sudo_pass = True
+ask_sudo_pass = False
+#ask_pass      = True
+ask_pass      = False
+#transport      = smart
+#remote_port    = 22
+#module_lang    = C
+#module_set_locale = True
+
+# plays will gather facts by default, which contain information about
+# the remote system.
+#
+# smart - gather by default, but don't regather if already gathered
+# implicit - gather by default, turn off with gather_facts: False
+# explicit - do not gather by default, must say gather_facts: True
+#gathering = implicit
+gathering = smart
+
+# by default retrieve all facts subsets
+# all - gather all subsets
+# network - gather min and network facts
+# hardware - gather hardware facts (longest facts to retrieve)
+# virtual - gather min and virtual facts
+# facter - import facts from facter
+# ohai - import facts from ohai
+# You can combine them using comma (ex: network,virtual)
+# You can negate them using ! (ex: !hardware,!facter,!ohai)
+# A minimal set of facts is always gathered.
+gather_subset = network
+
+# additional paths to search for roles in, colon separated
+# N/B: This depends on how ansible is called
+#roles_path    = $WORKSPACE/kommandir_workspace/roles
+
+# uncomment this to disable SSH key host checking
+#host_key_checking = False
+host_key_checking = False
+
+# change the default callback
+#stdout_callback = skippy
+# enable additional callbacks
+#callback_whitelist = timer, mail
+
+# Determine whether includes in tasks and handlers are "static" by
+# default. As of 2.0, includes are dynamic by default. Setting these
+# values to True will make includes behave more like they did in the
+# 1.x versions.
+task_includes_static = True
+handler_includes_static = True
+
+# change this for alternative sudo implementations
+#sudo_exe = sudo
+
+# What flags to pass to sudo
+# WARNING: leaving out the defaults might create unexpected behaviours
+#sudo_flags = -H -S -n
+
+# SSH timeout
+#timeout = 10
+
+# default user to use for playbooks if user is not specified
+# (/usr/bin/ansible will use current user as default)
+#remote_user = root
+remote_user = openshift
+
+# logging is off by default unless this path is defined
+# if so defined, consider logrotate
+log_path = $ARTIFACTS/main.log
+
+# default module name for /usr/bin/ansible
+#module_name = command
+
+# use this shell for commands executed under sudo
+# you may need to change this to bin/bash in rare instances
+# if sudo is constrained
+# executable = /bin/sh
+
+# if inventory variables overlap, does the higher precedence one win
+# or are hash values merged together?  The default is 'replace' but
+# this can also be set to 'merge'.
+hash_behaviour = replace
+
+# by default, variables from roles will be visible in the global variable
+# scope. To prevent this, the following option can be enabled, and only
+# tasks and handlers within the role will see the variables there
+private_role_vars = False
+
+# list any Jinja2 extensions to enable here:
+#jinja2_extensions = jinja2.ext.do,jinja2.ext.i18n
+
+# if set, always use this private key file for authentication, same as
+# if passing --private-key to ansible or ansible-playbook
+#private_key_file = /path/to/file
+
+# If set, configures the path to the Vault password file as an alternative to
+# specifying --vault-password-file on the command line.
+#vault_password_file = /path/to/vault_password_file
+
+# format of string {{ ansible_managed }} available within Jinja2
+# templates indicates to users editing templates files will be replaced.
+# replacing {file}, {host} and {uid} and strftime codes with proper values.
+#ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
+# This short version is better used in templates as it won't flag the file as changed every run.
+#ansible_managed = Ansible managed: {file} on {host}
+
+# by default, ansible-playbook will display "Skipping [host]" if it determines a task
+# should not be run on a host.  Set this to "False" if you don't want to see these "Skipping"
+# messages. NOTE: the task header will still be shown regardless of whether or not the
+# task is skipped.
+#display_skipped_hosts = True
+display_skipped_hosts = False
+
+# by default, if a task in a playbook does not include a name: field then
+# ansible-playbook will construct a header that includes the task's action but
+# not the task's args.  This is a security feature because ansible cannot know
+# if the *module* considers an argument to be no_log at the time that the
+# header is printed.  If your environment doesn't have a problem securing
+# stdout from ansible-playbook (or you have manually specified no_log in your
+# playbook on all of the tasks where you have secret information) then you can
+# safely set this to True to get more informative messages.
+display_args_to_stdout = False
+
+# by default (as of 1.3), Ansible will raise errors when attempting to dereference
+# Jinja2 variables that are not set in templates or action lines. Uncomment this line
+# to revert the behavior to pre-1.3.
+#error_on_undefined_vars = False
+
+# by default (as of 1.6), Ansible may display warnings based on the configuration of the
+# system running ansible itself. This may include warnings about 3rd party packages or
+# other conditions that should be resolved if possible.
+# to disable these warnings, set the following value to False:
+system_warnings = False
+
+# by default (as of 1.4), Ansible may display deprecation warnings for language
+# features that should no longer be used and will be removed in future versions.
+# to disable these warnings, set the following value to False:
+deprecation_warnings = False
+
+# (as of 1.8), Ansible can optionally warn when usage of the shell and
+# command module appear to be simplified by using a default Ansible module
+# instead.  These warnings can be silenced by adjusting the following
+# setting or adding warn=yes or warn=no to the end of the command line
+# parameter string.  This will for example suggest using the git module
+# instead of shelling out to the git command.
+command_warnings = False
+
+
+# set plugin path directories here, separate with colons
+#action_plugins     = /usr/share/ansible/plugins/action
+#callback_plugins   = /usr/share/ansible/plugins/callback
+#connection_plugins = /usr/share/ansible/plugins/connection
+#lookup_plugins     = /usr/share/ansible/plugins/lookup
+#vars_plugins       = /usr/share/ansible/plugins/vars
+#filter_plugins     = /usr/share/ansible/plugins/filter
+#test_plugins       = /usr/share/ansible/plugins/test
+#strategy_plugins   = /usr/share/ansible/plugins/strategy
+
+# Most callbacks shipped with Ansible are disabled by default
+# and need to be whitelisted in your ansible.cfg file in order to function.
+callback_whitelist = default
+
+# by default callbacks are not loaded for /bin/ansible, enable this if you
+# want, for example, a notification or logging callback to also apply to
+# /bin/ansible runs
+#bin_ansible_callbacks = False
+
+
+# don't like cows?  that's unfortunate.
+# set to 1 if you don't want cowsay support or export ANSIBLE_NOCOWS=1
+#nocows = 1
+
+# set which cowsay stencil you'd like to use by default. When set to 'random',
+# a random stencil will be selected for each task. The selection will be filtered
+# against the `cow_whitelist` option below.
+#cow_selection = default
+#cow_selection = random
+
+# when using the 'random' option for cowsay, stencils will be restricted to this list.
+# it should be formatted as a comma-separated list with no spaces between names.
+# NOTE: line continuations here are for formatting purposes only, as the INI parser
+#       in python does not support them.
+#cow_whitelist=bud-frogs,bunny,cheese,daemon,default,dragon,elephant-in-snake,elephant,eyes,\
+#              hellokitty,kitty,luke-koala,meow,milk,moofasa,moose,ren,sheep,small,stegosaurus,\
+#              stimpy,supermilker,three-eyes,turkey,turtle,tux,udder,vader-koala,vader,www
+
+# don't like colors either?
+# set to 1 if you don't want colors, or export ANSIBLE_NOCOLOR=1
+nocolor = 0
+
+# if set to a persistent type (not 'memory', for example 'redis') fact values
+# from previous runs in Ansible will be stored.  This may be useful when
+# wanting to use, for example, IP information from one group of servers
+# without having to talk to them in the same playbook run to get their
+# current IP information.
+#fact_caching = memory
+
+# retry files
+# When a playbook fails by default a .retry file will be created in ~/
+# You can disable this feature by setting retry_files_enabled to False
+# and you can change the location of the files by setting retry_files_save_path
+
+#retry_files_enabled = False
+retry_files_enabled = False
+
+# squash actions
+# Ansible can optimise actions that call modules with list parameters
+# when looping. Instead of calling the module once per with_ item, the
+# module is called once with all items at once. Currently this only works
+# under limited circumstances, and only with parameters named 'name'.
+squash_actions = apk,apt,dnf,package,pacman,pkgng,yum,zypper
+
+# prevents logging of task data, off by default
+#no_log = False
+
+# prevents logging of tasks, but only on the targets, data is still logged on the master/controller
+no_target_syslog = True
+
+# controls whether Ansible will raise an error or warning if a task has no
+# choice but to create world readable temporary files to execute a module on
+# the remote machine.  This option is False by default for security.  Users may
+# turn this on to have behaviour more like Ansible prior to 2.1.x.  See
+# https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user
+# for more secure ways to fix this than enabling this option.
+#allow_world_readable_tmpfiles = False
+
+# controls the compression level of variables sent to
+# worker processes. At the default of 0, no compression
+# is used. This value must be an integer from 0 to 9.
+#var_compression_level = 9
+
+# controls what compression method is used for new-style ansible modules when
+# they are sent to the remote system.  The compression types depend on having
+# support compiled into both the controller's python and the client's python.
+# The names should match with the python Zipfile compression types:
+# * ZIP_STORED (no compression. available everywhere)
+# * ZIP_DEFLATED (uses zlib, the default)
+# These values may be set per host via the ansible_module_compression inventory
+# variable
+#module_compression = 'ZIP_DEFLATED'
+
+# This controls the cutoff point (in bytes) on --diff for files
+# set to 0 for unlimited (RAM may suffer!).
+#max_diff_size = 1048576
+
+[privilege_escalation]
+become=True
+#become_method=sudo
+#become_user=root
+become_user=root
+#become_ask_pass=False
+
+[paramiko_connection]
+
+# uncomment this line to cause the paramiko connection plugin to not record new host
+# keys encountered.  Increases performance on new host additions.  Setting works independently of the
+# host key checking setting above.
+#record_host_keys=False
+
+# by default, Ansible requests a pseudo-terminal for commands executed under sudo. Uncomment this
+# line to disable this behaviour.
+#pty=False
+
+[ssh_connection]
+
+# ssh arguments to use
+# Leaving off ControlPersist will result in poor performance, so use
+# paramiko on older platforms rather than removing it
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null -o PreferredAuthentications=publickey -o ConnectTimeout=13
+
+# The path to use for the ControlPath sockets. This defaults to
+# "%(directory)s/ansible-ssh-%%h-%%p-%%r", however on some systems with
+# very long hostnames or very long path names (caused by long user names or
+# deeply nested home directories) this can exceed the character limit on
+# file socket names (108 characters for most platforms). In that case, you
+# may wish to shorten the string below.
+#
+# Example:
+# control_path = %(directory)s/%%h-%%r
+#control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
+
+# Enabling pipelining reduces the number of SSH operations required to
+# execute a module on the remote server. This can result in a significant
+# performance improvement when enabled, however when using "sudo:" you must
+# first disable 'requiretty' in /etc/sudoers
+#
+# By default, this option is disabled to preserve compatibility with
+# sudoers configurations that have requiretty (the default on many distros).
+#
+#pipelining = False
+pipelining=True
+
+# if True, make ansible use scp if the connection type is ssh
+# (default is sftp)
+#scp_if_ssh = True
+
+# if False, sftp will not use batch mode to transfer files. This may cause some
+# types of file transfer failures impossible to catch however, and should
+# only be disabled if your sftp version has problems with batch mode
+#sftp_batch_mode = False
+
+[accelerate]
+#accelerate_port = 5099
+#accelerate_timeout = 30
+#accelerate_connect_timeout = 5.0
+
+# The daemon timeout is measured in minutes. This time is measured
+# from the last activity to the accelerate daemon.
+#accelerate_daemon_timeout = 30
+
+# If set to yes, accelerate_multi_key will allow multiple
+# private keys to be uploaded to it, though each user must
+# have access to the system via SSH to add a new key. The default
+# is "no".
+#accelerate_multi_key = yes
+
+[selinux]
+# file systems that require special treatment when dealing with security context
+# the default behaviour that copies the existing context or uses the user default
+# needs to be changed to use the file system dependent context.
+#special_context_filesystems=nfs,vboxsf,fuse,ramfs
+
+# Set this to yes to allow libvirt_lxc connections to work without SELinux.
+#libvirt_lxc_noseclabel = yes
+
+[colors]
+#highlight = white
+#verbose = blue
+#warn = bright purple
+#error = red
+#debug = dark gray
+#deprecate = purple
+#skip = cyan
+#unreachable = red
+#ok = green
+#changed = yellow
+#diff_add = green
+#diff_remove = red
+#diff_lines = cyan

--- a/test/integration/build/openshift.yml
+++ b/test/integration/build/openshift.yml
@@ -1,0 +1,16 @@
+---
+
+- name: clone openshift origin source repo
+  git:
+    repo: "https://github.com/openshift/origin.git"
+    dest: "{{ ansible_env.GOPATH }}/src/github.com/openshift/origin"
+    force: "{{ force_clone | default(False) | bool}}"
+
+- name: build openshift 
+  make:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/openshift/origin"
+
+- name: build dind images
+  shell: "hack/build-dind-images.sh"
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/openshift/origin"

--- a/test/integration/build/ovnkube.yml
+++ b/test/integration/build/ovnkube.yml
@@ -1,0 +1,39 @@
+---
+
+- name: stat the expected ovn-kubernetes directory
+  stat:
+    path: "{{ ansible_env.GOPATH }}/src/github.com/openvswitch/ovn-kubernetes"
+  register: dir_stat
+
+- name: ensure cni bin directory is present
+  file: path=/opt/cni/bin state=directory
+
+- name: expect ovn-kubernetes to be cloned already
+  fail:
+    msg: "Expected ovn-kubernetes to be cloned at {{ ansible_env.GOPATH }}/src/github.com/openvswitch/ovn-kubernetes but it wasn't!"
+  when: not dir_stat.stat.exists
+
+- name: install ovn-kubernetes tools
+  make:
+    target: install.tools
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/openvswitch/ovn-kubernetes/go-controller"
+
+- name: build ovn-kubernetes
+  make:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/openvswitch/ovn-kubernetes/go-controller"
+
+- name: install ovn-kubernetes
+  make:
+    target: install
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/openvswitch/ovn-kubernetes/go-controller"
+
+#- name: install ovn-kubernetes systemd files
+#  make:
+#    target: install.systemd
+#    chdir: "{{ ansible_env.GOPATH }}/src/github.com/openvswitch/ovn-kubernetes/go-controller"
+#  when: ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
+#
+#- name: install ovn-kubernetes config
+#  make:
+#    target: install.config
+#    chdir: "{{ ansible_env.GOPATH }}/src/github.com/openvswitch/ovn-kubernetes"

--- a/test/integration/golang.yml
+++ b/test/integration/golang.yml
@@ -1,0 +1,49 @@
+---
+
+- name: ensure Golang dir is empty first
+  file:
+    path: /usr/local/go
+    state: absent
+
+- name: fetch Golang
+  unarchive:
+    remote_src: yes
+    src: "https://storage.googleapis.com/golang/go{{ version }}.linux-amd64.tar.gz"
+    dest: /usr/local
+
+- name: link go toolchain
+  file:
+    src: "/usr/local/go/bin/{{ item }}"
+    dest: "/usr/bin/{{ item }}"
+    state: link
+  with_items:
+    - go
+    - gofmt
+    - godoc
+
+- name: ensure user profile exists
+  file:
+    path: "{{ ansible_user_dir }}/.profile"
+    state: touch
+
+- name: set up PATH for Go toolchain and built binaries
+  lineinfile:
+    dest: "{{ ansible_user_dir }}/.profile"
+    line: 'PATH={{ ansible_env.PATH }}:{{ ansible_env.GOPATH }}/bin:/usr/local/go/bin'
+    regexp: '^PATH='
+    state: present
+
+- name: set up directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ ansible_env.GOPATH }}/src/github.com/openvswitch"
+    - "{{ ansible_env.GOPATH }}/src/github.com/k8s.io"
+    - "{{ ansible_env.GOPATH }}/src/github.com/openshift"
+
+- name: install Go tools and dependencies
+  shell: /usr/bin/go get -u "github.com/{{ item }}"
+  with_items:
+    - tools/godep
+    - onsi/ginkgo/ginkgo

--- a/test/integration/hosts
+++ b/test/integration/hosts
@@ -1,0 +1,2 @@
+[hosts]
+localhost

--- a/test/integration/main.yml
+++ b/test/integration/main.yml
@@ -1,0 +1,28 @@
+- hosts: all
+  become_user: root
+  vars_files:
+    - "{{ playbook_dir }}/vars.yml"
+  tags:
+    - setup
+  tasks:
+    - name: set up the system
+      include: system.yml
+
+    - name: install Golang tools
+      include: golang.yml
+      vars:
+        version: "1.9.1"
+
+    - name: clone build and install openshift 
+      include: "build/openshift.yml"
+
+- hosts: all
+  vars_files:
+    - "{{ playbook_dir }}/vars.yml"
+  tags:
+    - integration
+  tasks:
+    - name: clone build and install ovn-kubernetes
+      include: "build/ovnkube.yml"
+    - name: run openshift-dind tests
+      include: "openshift-dind-test.yml"

--- a/test/integration/openshift-dind-test.yml
+++ b/test/integration/openshift-dind-test.yml
@@ -1,0 +1,29 @@
+---
+
+- name: disable selinux
+  selinux:
+    state: disabled
+
+- name: setup dind cluster with ovn
+  shell: "OVN_ROOT={{ ansible_env.GOPATH }}/src/github.com/openvswitch/ovn-kubernetes hack/dind-cluster.sh start -n ovn"
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/openshift/origin"
+  async: 5400
+  poll: 30
+
+- name: ensure artifacts directory is present
+  file: path={{ artifacts }} state=directory
+
+- name: run integration tests
+  shell: "OPENSHIFT_TEST_KUBECONFIG={{ openshift_dind_kubeconfig }} ./cni_vendor_test.sh &> {{ artifacts }}/cni_vendor_test.log"
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/openshift/origin/test/extended"
+  async: 5400
+  poll: 30
+
+- name: cleanup after integration tests
+  shell: "./hack/dind-cluster.sh stop"
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/openshift/origin"
+  async: 5400
+  poll: 30

--- a/test/integration/system.yml
+++ b/test/integration/system.yml
@@ -1,0 +1,83 @@
+---
+
+- name: Make sure we have all required packages
+  become_user: root
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - curl
+    - docker
+    - expect
+    - findutils
+    - gcc
+    - git
+    - glib2-devel
+    - glibc-devel
+    - glibc-static
+    - hostname
+    - iproute
+    - iptables
+    - libxml2-devel
+    - make
+    - nfs-utils
+    - nmap-ncat
+    - openssl
+    - openssl-devel
+    - pkgconfig
+    - python
+    - python2-crypto
+    - python-devel
+    - python-virtualenv
+    - PyYAML
+    - rpcbind
+    - rsync
+    - sed
+    - socat
+    - tar
+    - wget
+  async: 600
+  poll: 10
+
+- name: Update all packages
+  package:
+    name: '*'
+    state: latest
+  async: 600
+  poll: 10
+
+- name: Setup swap to prevent kernel firing off the OOM killer
+  shell: |
+    truncate -s 8G /root/swap && \
+    export SWAPDEV=$(losetup --show -f /root/swap | head -1) && \
+    mkswap $SWAPDEV && \
+    swapon $SWAPDEV && \
+    swapon --show
+
+- name: ensure directories exist as needed
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - /opt/cni/bin
+    - /etc/cni/net.d
+
+- name: set sysctl vm.overcommit_memory=1 for CentOS
+  sysctl:
+    name: vm.overcommit_memory
+    state: present
+    value: 1
+  when: ansible_distribution == 'CentOS'
+
+- name: inject hostname into /etc/hosts
+  lineinfile:
+    dest: /etc/hosts
+    line: '{{ ansible_default_ipv4.address }} {{ ansible_nodename }}'
+    insertafter: 'EOF'
+    regexp: '{{ ansible_default_ipv4.address }}\s+{{ ansible_nodename }}'
+    state: present
+
+- name: start docker daemon
+  systemd:
+    state: started
+    name: docker

--- a/test/integration/vars.yml
+++ b/test/integration/vars.yml
@@ -1,0 +1,7 @@
+---
+
+# For results.yml Paths use rsync 'source' conventions
+artifacts: "/tmp/artifacts"  # Base-directory for collection
+openshift_dind_kubeconfig: "/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig"
+result_dest_basedir: '{{ lookup("env","WORKSPACE") |
+                         default(playbook_dir, True) }}/artifacts'


### PR DESCRIPTION
Testing infrastructure based on openshift. The ansible playbooks intend to be invoked by a ci/cd mechanism (e.g. jenkins). The prereqs require a merged branch of ovn-kubernetes be available at the following location: $GOPATH/github.com/openvswitch/ovn-kubernetes
Manual entry point is main.yml with two tags present: setup, integration. 'setup' sets up the env, and 'integration' runs the DinD (docker in docker) tests. The infrastructure can be expanded upon later.

Signed-off-by: Rajat Chopra <rchopra@redhat.com>

Next tasks:
1. build a kubernetes end-to-end test infrastructure
2. infrastructure for locally written tests
