### PR TITLE
go-controller/cluster: Setup routes for service-cluster-ip-range.

### DIFF
--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -113,6 +113,11 @@ Server certificate that the OVN southbound database should use for securing the 
 \fB\-ovn-south-server-privkey\fR string
 Private key that the OVN southbound database should use for securing the API.
 .TP
+\fB\-service-cluster-ip-range\fR value
+A CIDR notation IP range from which k8s assigns service cluster IPs.
+This should be the same as the one provided for kube-apiserver's
+\fB\-service-cluster-ip-range\fR option.
+.TP
 \fB\-stderrthreshold\fR value
 logs at or above this threshold go to stderr
 .TP

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -25,6 +25,10 @@ func main() {
 	rootCAFile := flag.String("ca-cert", "", "CA cert for the Kubernetes api server")
 	token := flag.String("token", "", "Bearer token to use for establishing ovn infrastructure")
 	clusterSubnet := flag.String("cluster-subnet", "11.11.0.0/16", "Cluster wide IP subnet to use")
+	clusterServicesSubnet := flag.String("service-cluster-ip-range", "",
+		"A CIDR notation IP range from which k8s assigns service cluster "+
+			"IPs. This should be the same as the one provided for "+
+			"kube-apiserver \"-service-cluster-ip-range\" option.")
 
 	// IP address and port of the northbound API server
 	ovnNorth := flag.String("ovn-north-db", "", "IP address and port of the OVN northbound API (eg, ssl://1.2.3.4:6641).  Leave empty to use a local unix socket.")
@@ -140,6 +144,16 @@ func main() {
 		_, clusterController.ClusterIPNet, err = net.ParseCIDR(*clusterSubnet)
 		if err != nil {
 			panic(err.Error)
+		}
+
+		if *clusterServicesSubnet != "" {
+			var servicesSubnet *net.IPNet
+			_, servicesSubnet, err = net.ParseCIDR(
+				*clusterServicesSubnet)
+			if err != nil {
+				panic(err.Error)
+			}
+			clusterController.ClusterServicesSubnet = servicesSubnet.String()
 		}
 
 		clusterController.NorthDBClientAuth, err = ovncluster.NewOvnDBAuth(*ovnNorth, *ovnNorthClientPrivKey, *ovnNorthClientCert, *ovnNorthClientCACert, false)

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -19,11 +19,12 @@ type OvnClusterController struct {
 	Kube                  kube.Interface
 	masterSubnetAllocator *netutils.SubnetAllocator
 
-	KubeServer       string
-	CACert           string
-	Token            string
-	ClusterIPNet     *net.IPNet
-	HostSubnetLength uint32
+	KubeServer            string
+	CACert                string
+	Token                 string
+	ClusterIPNet          *net.IPNet
+	ClusterServicesSubnet string
+	HostSubnetLength      uint32
 
 	GatewayInit      bool
 	GatewayIntf      string

--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -230,7 +230,8 @@ func (cluster *OvnClusterController) SetupMaster(masterNodeName string, masterSw
 		return err
 	}
 
-	err = ovn.CreateManagementPort(masterNodeName, masterSwitchNetwork, cluster.ClusterIPNet.String())
+	err = ovn.CreateManagementPort(masterNodeName, masterSwitchNetwork,
+		cluster.ClusterIPNet.String(), cluster.ClusterServicesSubnet)
 	if err != nil {
 		return fmt.Errorf("Failed create management port: %v", err)
 	}

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -99,7 +99,10 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	// Update config globals that OVN exec utils use
 	cluster.NorthDBClientAuth.SetConfig()
 
-	if err := ovn.CreateManagementPort(node.Name, subnet.String(), cluster.ClusterIPNet.String()); err != nil {
+	err = ovn.CreateManagementPort(node.Name, subnet.String(),
+		cluster.ClusterIPNet.String(),
+		cluster.ClusterServicesSubnet)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently, we need to manually add a route to access k8s services
from the node.

This commit lets us access the services from nodes without manual
intervention. This is also useful when you run ingress controllers
and they need to route to service IPs.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>