### PR TITLE
vagrant: Add a few minor fixes.

### DIFF
--- a/vagrant/provisioning/setup-k8s-master.sh
+++ b/vagrant/provisioning/setup-k8s-master.sh
@@ -40,7 +40,7 @@ sudo docker run --net=host -v /var/etcd/data:/var/etcd/data -d \
 # Start k8s daemons
 pushd k8s/server/kubernetes/server/bin
 echo "Starting kube-apiserver ..."
-nohup sudo ./kube-apiserver --service-cluster-ip-range=192.168.200.0/24 \
+nohup sudo ./kube-apiserver --service-cluster-ip-range=172.16.1.0/24 \
                             --address=0.0.0.0 --etcd-servers=http://127.0.0.1:4001 \
                             --v=2 2>&1 0<&- &>/dev/null &
 
@@ -97,6 +97,8 @@ if [ $PROTOCOL = "ssl" ]; then
  -apiserver="http://$OVERLAY_IP:8080" \
  -logfile="/var/log/openvswitch/ovnkube.log" \
  -init-master="k8smaster" -cluster-subnet="192.168.0.0/16" \
+ -service-cluster-ip-range=172.16.1.0/24 \
+ -nodeport \
  -ovn-north-db="$PROTOCOL://$OVERLAY_IP:6631" \
  -ovn-north-server-privkey /etc/openvswitch/ovnnb-privkey.pem \
  -ovn-north-server-cert /etc/openvswitch/ovnnb-cert.pem \
@@ -107,7 +109,7 @@ if [ $PROTOCOL = "ssl" ]; then
  -ovn-south-server-cacert /vagrant/pki/switchca/cacert.pem  \
  -ovn-north-client-privkey /etc/openvswitch/ovncontroller-privkey.pem \
  -ovn-north-client-cert /etc/openvswitch/ovncontroller-cert.pem \
- -ovn-north-client-cacert /etc/openvswitch/ovnsb-ca.cert \
+ -ovn-north-client-cacert /etc/openvswitch/ovnnb-ca.cert \
  -ovn-south-client-privkey /etc/openvswitch/ovncontroller-privkey.pem \
  -ovn-south-client-cert /etc/openvswitch/ovncontroller-cert.pem \
  -ovn-south-client-cacert /etc/openvswitch/ovnsb-ca.cert 2>&1 &
@@ -116,6 +118,8 @@ else
  -apiserver="http://$OVERLAY_IP:8080" \
  -logfile="/var/log/openvswitch/ovnkube.log" \
  -init-master="k8smaster" -cluster-subnet="192.168.0.0/16" \
+ -service-cluster-ip-range=172.16.1.0/24 \
+ -nodeport \
  -ovn-north-db="$PROTOCOL://$OVERLAY_IP:6631" \
  -ovn-south-db="$PROTOCOL://$OVERLAY_IP:6632" 2>&1 &
 fi

--- a/vagrant/provisioning/setup-k8s-minion.sh
+++ b/vagrant/provisioning/setup-k8s-minion.sh
@@ -64,6 +64,7 @@ if [ $PROTOCOL = "ssl" ]; then
 sudo ovnkube -kubeconfig $HOME/kubeconfig.yaml -v=4 -alsologtostderr \
     -apiserver="http://$MASTER_OVERLAY_IP:8080" \
     -init-node="$MINION_NAME"  \
+    -nodeport \
     -ovn-north-db="$PROTOCOL://$MASTER_OVERLAY_IP:6631" \
     -ovn-south-db="$PROTOCOL://$MASTER_OVERLAY_IP:6632" --token="test" \
     -ovn-north-client-privkey /etc/openvswitch/ovncontroller-privkey.pem \
@@ -73,14 +74,17 @@ sudo ovnkube -kubeconfig $HOME/kubeconfig.yaml -v=4 -alsologtostderr \
     -ovn-south-client-cert /etc/openvswitch/ovncontroller-cert.pem \
     -ovn-south-client-cacert /etc/openvswitch/ovnsb-ca.cert \
     -init-gateways -gateway-interface=enp0s9 -gateway-nexthop="$GW_IP" \
+    -service-cluster-ip-range=172.16.1.0/24 \
     -cluster-subnet="192.168.0.0/16" 2>&1
 else
 sudo ovnkube -kubeconfig $HOME/kubeconfig.yaml -v=4 -alsologtostderr \
     -apiserver="http://$MASTER_OVERLAY_IP:8080" \
     -init-node="$MINION_NAME"  \
+    -nodeport \
     -ovn-north-db="$PROTOCOL://$MASTER_OVERLAY_IP:6631" \
     -ovn-south-db="$PROTOCOL://$MASTER_OVERLAY_IP:6632" --token="test" \
     -init-gateways -gateway-interface=enp0s9 -gateway-nexthop="$GW_IP" \
+    -service-cluster-ip-range=172.16.1.0/24 \
     -cluster-subnet="192.168.0.0/16" 2>&1
 fi
 

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -72,6 +72,7 @@ if [ -n "$SSL" ]; then
     sudo bash -c 'cat >> /etc/default/ovn-host <<EOF
 OVN_CTL_OPTS="--ovn-controller-ssl-key=/etc/openvswitch/ovncontroller-privkey.pem  --ovn-controller-ssl-cert=/etc/openvswitch/ovncontroller-cert.pem --ovn-controller-ssl-bootstrap-ca-cert=/etc/openvswitch/ovnsb-ca.cert"
 EOF'
+   sudo service ovn-host restart
 else
     echo "PROTOCOL=tcp" >> setup_master_args.sh
 fi


### PR DESCRIPTION
The fixes do the following.
1. Adds the recently added -nodeport option to ovnkube
as we want nodeport to work in vagrant
2. Adds the recently added -service-cluster-ip-range to ovnkube
so that it gets tested.
3. Changes a typo in certificate name passed to -ovn-north-client-cacert
4. Does a 'sudo service ovn-host restart' for master after setting the
SSL options to ovn-controller. We need this because, for master, ovnkube
does not do a ovn-controller restart.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>