### PR TITLE
go-controller: Add Windows support for minion-init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
     - 'if [ "$TOX_ENV" = "py27" ]; then
         cd go-controller;
         make;
+        make windows;
         make gofmt;
         make install.tools;
         make lint;

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -16,6 +16,10 @@ all build:
 	hack/build-go.sh cmd/ovn-kube-util/ovn-kube-util.go
 	hack/build-go.sh cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
 
+windows:
+	export WINDOWS_BUILD="yes"; \
+	hack/build-go.sh cmd/ovnkube/ovnkube.go;
+
 install:
 	install -D -m 755 ${OUT_DIR}/go/bin/ovnkube ${BINDIR}/
 	install -D -m 755 ${OUT_DIR}/go/bin/ovn-k8s-overlay ${BINDIR}/

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -184,6 +185,9 @@ func main() {
 		clusterController.NodePortEnable = *nodePortEnable
 
 		if *master != "" {
+			if runtime.GOOS == "windows" {
+				panic("Windows is not supported as master node")
+			}
 			clusterController.NorthDBServerAuth, err = ovncluster.NewOvnDBAuth(*ovnNorth, *ovnNorthServerPrivKey, *ovnNorthServerCert, *ovnNorthServerCACert, true)
 			if err != nil {
 				panic(err.Error())

--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -21,6 +21,21 @@ build_binaries() {
     go install -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -v -x "${OVN_KUBE_BINARIES[@]}";
 }
 
+build_windows_binaries() {
+    # Check for `go` binary and set ${GOPATH}.
+    setup_env
+
+    local go_pkg_dir="${GOPATH}/src/${OVN_KUBE_GO_PACKAGE}"
+    cd ${go_pkg_dir}
+    mkdir -p "${OVN_KUBE_OUTPUT_BINPATH_WINDOWS}"
+
+    GOOS=windows GOARCH=amd64 go build "${OVN_KUBE_BINARIES[0]}"
+
+    _output_filename=$(basename ${OVN_KUBE_BINARIES[0]})
+    output_exe=${_output_filename/go/exe}
+    mv $output_exe "${OVN_KUBE_OUTPUT_BINPATH_WINDOWS}"
+}
+
 test() {
     for test in "${tests[@]:+${tests[@]}}"; do
       local outfile="${OVN_KUBE_OUTPUT_BINPATH}/${platform}/$(basename ${test})"
@@ -33,5 +48,8 @@ test() {
 }
 
 OVN_KUBE_BINARIES=("$@")
-build_binaries
-
+if [ -z "${WINDOWS_BUILD}" ]; then
+    build_binaries
+else
+    build_windows_binaries
+fi

--- a/go-controller/hack/init.sh
+++ b/go-controller/hack/init.sh
@@ -30,6 +30,7 @@ EOF
   # create a local GOPATH in _output
   GOPATH="${OVN_KUBE_OUTPUT}/go"
   OVN_KUBE_OUTPUT_BINPATH=${GOPATH}/bin
+  OVN_KUBE_OUTPUT_BINPATH_WINDOWS=${GOPATH}/windows
   local go_pkg_dir="${GOPATH}/src/${OVN_KUBE_GO_PACKAGE}"
   local go_pkg_basedir=$(dirname "${go_pkg_dir}")
 

--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -1,0 +1,146 @@
+// +build linux
+
+package cluster
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// getIPv4Address returns the ipv4 address for the network interface 'iface'.
+func getIPv4Address(iface string) (string, error) {
+	var ipAddress string
+	intf, err := net.InterfaceByName(iface)
+	if err != nil {
+		return ipAddress, err
+	}
+
+	addrs, err := intf.Addrs()
+	if err != nil {
+		return ipAddress, err
+	}
+
+	for _, addr := range addrs {
+		switch ip := addr.(type) {
+		case *net.IPNet:
+			if ip.IP.To4() != nil {
+				ipAddress = ip.String()
+			}
+		}
+	}
+	return ipAddress, nil
+}
+
+// getDefaultGatewayInterfaceDetails returns the interface name on
+// which the default gateway (for route to 0.0.0.0) is configured.
+// It also returns the default gateway itself.
+func getDefaultGatewayInterfaceDetails() (string, string, error) {
+	routes, err := netlink.RouteList(nil, syscall.AF_INET)
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to get routing table in node")
+	}
+
+	for i := range routes {
+		route := routes[i]
+		if route.Dst == nil && route.Gw != nil && route.LinkIndex > 0 {
+			intfLink, err := netlink.LinkByIndex(route.LinkIndex)
+			if err != nil {
+				continue
+			}
+			intfName := intfLink.Attrs().Name
+			if intfName != "" {
+				return intfName, route.Gw.String(), nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("Failed to get default gateway interface")
+}
+
+func (cluster *OvnClusterController) initGateway(
+	nodeName, clusterIPSubnet, subnet string) error {
+	if cluster.GatewayNextHop == "" || cluster.GatewayIntf == "" {
+		// We need to get the interface details from the default gateway.
+		gatewayIntf, gatewayNextHop, err := getDefaultGatewayInterfaceDetails()
+		if err != nil {
+			return err
+		}
+
+		if cluster.GatewayNextHop == "" {
+			cluster.GatewayNextHop = gatewayNextHop
+		}
+
+		if cluster.GatewayIntf == "" {
+			cluster.GatewayIntf = gatewayIntf
+		}
+	}
+
+	var ipAddress string
+	var err error
+	if !cluster.GatewaySpareIntf {
+		// Check to see whether the interface is OVS bridge.
+		_, _, err = util.RunOVSVsctl("--", "br-exists", cluster.GatewayIntf)
+		if err != nil {
+			// This is not a OVS bridge. We need to create a OVS bridge
+			// and add cluster.GatewayIntf as a port of that bridge.
+			err = util.NicToBridge(cluster.GatewayIntf)
+			if err != nil {
+				return fmt.Errorf("Failed to convert nic %s to OVS bridge "+
+					"(%v)", cluster.GatewayIntf, err)
+			}
+			cluster.GatewayBridge = fmt.Sprintf("br%s", cluster.GatewayIntf)
+		} else {
+			return fmt.Errorf("gateway interface is not a physical device, " +
+				"but rather a bridge device")
+		}
+
+		// Now, we get IP address from OVS bridge. If IP does not exist,
+		// error out.
+		ipAddress, err = getIPv4Address(cluster.GatewayBridge)
+		if err != nil {
+			return fmt.Errorf("Failed to get interface details for %s (%v)",
+				cluster.GatewayBridge, err)
+		}
+		if ipAddress == "" {
+			return fmt.Errorf("%s does not have a ipv4 address",
+				cluster.GatewayBridge)
+		}
+		err = util.GatewayInit(clusterIPSubnet, nodeName, ipAddress, "",
+			cluster.GatewayBridge, cluster.GatewayNextHop, subnet)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		// Now, we get IP address from physical interface. If IP does not
+		// exists error out.
+		ipAddress, err = getIPv4Address(cluster.GatewayIntf)
+		if err != nil {
+			return fmt.Errorf("Failed to get interface details for %s (%v)",
+				cluster.GatewayIntf, err)
+		}
+		if ipAddress == "" {
+			return fmt.Errorf("%s does not have a ipv4 address",
+				cluster.GatewayIntf)
+		}
+		err = util.GatewayInit(clusterIPSubnet, nodeName, ipAddress,
+			cluster.GatewayIntf, "", cluster.GatewayNextHop, subnet)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !cluster.NodePortEnable && !cluster.GatewaySpareIntf {
+		// Program cluster.GatewayIntf to let non-pod traffic to go to host
+		// stack
+		err = cluster.addDefaultConntrackRules()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go-controller/pkg/cluster/gateway_init_windows.go
+++ b/go-controller/pkg/cluster/gateway_init_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package cluster
+
+func (cluster *OvnClusterController) initGateway(
+	nodeName, clusterIPSubnet, subnet string) error {
+	return nil
+}

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -5,17 +5,19 @@ import (
 	"net"
 	"os"
 	"runtime"
-	"syscall"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/vishvananda/netlink"
 
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
+)
+
+const (
+	windowsOS = "windows"
 )
 
 // StartClusterNode learns the subnet assigned to it by the master controller
@@ -76,6 +78,9 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	}
 
 	if cluster.GatewayInit {
+		if runtime.GOOS == windowsOS {
+			panic("Windows is not supported as a gateway node")
+		}
 		err = cluster.initGateway(node.Name, cluster.ClusterIPNet.String(),
 			subnet.String())
 		if err != nil {
@@ -84,7 +89,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	}
 
 	// Install the CNI config file after all initialization is done
-	if runtime.GOOS != "win32" {
+	if runtime.GOOS != windowsOS {
 		// MkdirAll() returns no error if the path already exists
 		err = os.MkdirAll(config.CniConfPath, os.ModeDir)
 		if err != nil {
@@ -107,139 +112,6 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		}
 	}
 
-	return nil
-}
-
-// getIPv4Address returns the ipv4 address for the network interface 'iface'.
-func getIPv4Address(iface string) (string, error) {
-	var ipAddress string
-	intf, err := net.InterfaceByName(iface)
-	if err != nil {
-		return ipAddress, err
-	}
-
-	addrs, err := intf.Addrs()
-	if err != nil {
-		return ipAddress, err
-	}
-
-	for _, addr := range addrs {
-		switch ip := addr.(type) {
-		case *net.IPNet:
-			if ip.IP.To4() != nil {
-				ipAddress = ip.String()
-			}
-		}
-	}
-	return ipAddress, nil
-}
-
-// getDefaultGatewayInterfaceDetails returns the interface name on
-// which the default gateway (for route to 0.0.0.0) is configured.
-// It also returns the default gateway itself.
-func getDefaultGatewayInterfaceDetails() (string, string, error) {
-	routes, err := netlink.RouteList(nil, syscall.AF_INET)
-	if err != nil {
-		return "", "", fmt.Errorf("Failed to get routing table in node")
-	}
-
-	for i := range routes {
-		route := routes[i]
-		if route.Dst == nil && route.Gw != nil && route.LinkIndex > 0 {
-			intfLink, err := netlink.LinkByIndex(route.LinkIndex)
-			if err != nil {
-				continue
-			}
-			intfName := intfLink.Attrs().Name
-			if intfName != "" {
-				return intfName, route.Gw.String(), nil
-			}
-		}
-	}
-	return "", "", fmt.Errorf("Failed to get default gateway interface")
-}
-
-func (cluster *OvnClusterController) initGateway(
-	nodeName, clusterIPSubnet, subnet string) error {
-	if cluster.GatewayNextHop == "" || cluster.GatewayIntf == "" {
-		// We need to get the interface details from the default gateway.
-		gatewayIntf, gatewayNextHop, err := getDefaultGatewayInterfaceDetails()
-		if err != nil {
-			return err
-		}
-
-		if cluster.GatewayNextHop == "" {
-			cluster.GatewayNextHop = gatewayNextHop
-		}
-
-		if cluster.GatewayIntf == "" {
-			cluster.GatewayIntf = gatewayIntf
-		}
-	}
-
-	var ipAddress string
-	var err error
-	if !cluster.GatewaySpareIntf {
-		// Check to see whether the interface is OVS bridge.
-		_, _, err = util.RunOVSVsctl("--", "br-exists", cluster.GatewayIntf)
-		if err != nil {
-			// This is not a OVS bridge. We need to create a OVS bridge
-			// and add cluster.GatewayIntf as a port of that bridge.
-			err = util.NicToBridge(cluster.GatewayIntf)
-			if err != nil {
-				return fmt.Errorf("Failed to convert nic %s to OVS bridge "+
-					"(%v)", cluster.GatewayIntf, err)
-			}
-			cluster.GatewayBridge = fmt.Sprintf("br%s", cluster.GatewayIntf)
-		} else {
-			return fmt.Errorf("gateway interface is not a physical device, " +
-				"but rather a bridge device")
-		}
-
-		// Now, we get IP address from OVS bridge. If IP does not exist,
-		// error out.
-		ipAddress, err = getIPv4Address(cluster.GatewayBridge)
-		if err != nil {
-			return fmt.Errorf("Failed to get interface details for %s (%v)",
-				cluster.GatewayBridge, err)
-		}
-		if ipAddress == "" {
-			return fmt.Errorf("%s does not have a ipv4 address",
-				cluster.GatewayBridge)
-		}
-		err = util.GatewayInit(clusterIPSubnet, nodeName, ipAddress, "",
-			cluster.GatewayBridge, cluster.GatewayNextHop, subnet)
-		if err != nil {
-			return err
-		}
-
-	} else {
-		// Now, we get IP address from physical interface. If IP does not
-		// exists error out.
-		ipAddress, err = getIPv4Address(cluster.GatewayIntf)
-		if err != nil {
-			return fmt.Errorf("Failed to get interface details for %s (%v)",
-				cluster.GatewayIntf, err)
-		}
-		if ipAddress == "" {
-			return fmt.Errorf("%s does not have a ipv4 address",
-				cluster.GatewayIntf)
-		}
-		err = util.GatewayInit(clusterIPSubnet, nodeName, ipAddress,
-			cluster.GatewayIntf, "", cluster.GatewayNextHop, subnet)
-		if err != nil {
-			return err
-		}
-	}
-
-	if !cluster.NodePortEnable && !cluster.GatewaySpareIntf {
-		// Program cluster.GatewayIntf to let non-pod traffic to go to host
-		// stack
-		err = cluster.addDefaultConntrackRules()
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package util
 
 import (


### PR DESCRIPTION
This patch adds support for doing minion-init on a Windows host.

The following changes were made:
- Add check for master / gateway init on Windows hosts which is
currently not supported
- Update build scripts to compile the Windows version of ovnkube.
The binary will be found in _output/go/windows/ovnkube.exe
- Moved the gatewayInit code in another file and added conditional
compilation. The gatewayInit is making use of "github.com/vishvananda/netlink"
package which does not compile on Windows.
- Implemented configureManagementPort for Windows. Added the equivalent
commands for enabling the interface, setting IP and the rest.
- Added conditional compilation for nicstobridge.go which is used
only in gatewayInit and imports the package "github.com/vishvananda/netlink"
- Added equivalent commands to start / restart the
openvswitch / ovn-controller services on Windows

The make command will also build the ovnkube.exe binary for Windows which will be placed under _output/go/windows

Signed-off-by: Alin Balutoiu <abalutoiu@cloudbasesolutions.com>