### PR TITLE
Sync k8s resources with OVN backend when watcher starts

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -232,7 +232,7 @@ func (oc *Controller) WatchNetworkPolicy() {
 			oc.deleteNetworkPolicy(policy)
 			return
 		},
-	}, nil)
+	}, oc.syncNetworkPolicies)
 }
 
 // WatchNamespaces starts the watching of namespace resource and calls
@@ -265,5 +265,5 @@ func (oc *Controller) WatchNamespaces() {
 			oc.deleteNamespace(ns)
 			return
 		},
-	}, nil)
+	}, oc.syncNamespaces)
 }


### PR DESCRIPTION
When ovnkube watcher starts, sync k8s resources with OVN backend
including pods, policies, and namespaces. If there is any obsolete
resource left on OVN after k8s resource has been deleted, clean up
the stale resource from OVN.

Signed-off-by: Tong Liu <tongl@vmware.com>