### PR TITLE
config: Add default config path and create CNI config on Windows

### DIFF
--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -89,30 +89,25 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	}
 
 	// Install the CNI config file after all initialization is done
-	if runtime.GOOS != windowsOS {
-		// MkdirAll() returns no error if the path already exists
-		err = os.MkdirAll(config.CNI.ConfDir, os.ModeDir)
-		if err != nil {
-			return err
-		}
-
-		// Always create the CNI config for consistency.
-		cniConf := config.CNI.ConfDir + "/10-ovn-kubernetes.conf"
-
-		var f *os.File
-		f, err = os.OpenFile(cniConf, os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		confJSON := fmt.Sprintf("{\"name\":\"ovn-kubernetes\", \"type\":\"%s\"}", config.CNI.Plugin)
-		_, err = f.Write([]byte(confJSON))
-		if err != nil {
-			return err
-		}
+	// MkdirAll() returns no error if the path already exists
+	err = os.MkdirAll(config.CNI.ConfDir, os.ModeDir)
+	if err != nil {
+		return err
 	}
 
-	return nil
+	// Always create the CNI config for consistency.
+	cniConf := config.CNI.ConfDir + "/10-ovn-kubernetes.conf"
+
+	var f *os.File
+	f, err = os.OpenFile(cniConf, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	confJSON := fmt.Sprintf("{\"name\":\"ovn-kubernetes\", \"type\":\"%s\"}", config.CNI.Plugin)
+	_, err = f.Write([]byte(confJSON))
+
+	return err
 }
 
 func (cluster *OvnClusterController) addDefaultConntrackRules() error {

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -388,7 +389,13 @@ func InitConfig(ctx *cli.Context, defaults *Defaults) error {
 		}
 	} else {
 		// Failure to find a default config file is not a hard error
-		f, _ = os.Open("/etc/openvswitch/ovn_k8s.conf")
+		if runtime.GOOS != "windows" {
+			f, _ = os.Open("/etc/openvswitch/ovn_k8s.conf")
+		} else {
+			// On Windows we have to retrieve the conf path via an environment variable
+			// which gets set by the OVS installer.
+			f, _ = os.Open(fmt.Sprintf("%s\\ovn_k8s.conf", os.Getenv("OVS_SYSCONFDIR")))
+		}
 	}
 	if f != nil {
 		defer f.Close()


### PR DESCRIPTION
Adds default config path for Windows based on the OVS_SYSCONFDIR
environment variable which is set by the OVS installer.

The if was removed from the CNI config file creation.
Now it is been enabled on Windows as well.

Signed-off-by: Alin Balutoiu <abalutoiu@cloudbasesolutions.com>