### PR TITLE
travis: Move exclusively to golang.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 sudo: required
-language: python
-python:
-      - "2.7"
-env:
-    - TOX_ENV=py27
-    - TOX_ENV=flake8
+language: go
+go:
+      - 1.8.1
 before_install:
     - export GOPATH=$HOME/go
     - export PATH=$HOME/usr/local/go/bin:$GOPATH/bin:$PATH
@@ -12,15 +9,11 @@ before_install:
     - mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/openvswitch/ovn-kubernetes
     - cd $GOPATH/src/github.com/openvswitch/ovn-kubernetes
 install:
-    - pip install tox-travis
     - eval "$(gimme 1.8.1)"
 script:
-    - tox -e $TOX_ENV
-    - 'if [ "$TOX_ENV" = "py27" ]; then
-        cd go-controller;
-        make;
-        make windows;
-        make gofmt;
-        make install.tools;
-        make lint;
-       fi'
+    -   cd go-controller;
+    -    make;
+    -    make windows;
+    -    make gofmt;
+    -    make install.tools;
+    -    make lint;


### PR DESCRIPTION
The travis tests were ignoring intermediate failures
in golang tests. For e.g., 'make gofmt' failing would
not fail the entire test. This commit takes this
opportunity to retire python checking and to move
exclusively to golang. This also will cause failures
if any intermediate step fails.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>