### PR TITLE
Network policy fixes

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -1,19 +1,27 @@
 package ovn
 
 import (
+	"fmt"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	"sync"
 	"time"
 )
 
-func (oc *Controller) waitForNamespaceEvent(namespace string) {
+func (oc *Controller) waitForNamespaceEvent(namespace string) error {
+	// Wait for 10 seconds to get the namespace event.
+	count := 100
 	for {
 		if oc.namespacePolicies[namespace] != nil {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
+		count--
+		if count == 0 {
+			return fmt.Errorf("timeout waiting for namespace event")
+		}
 	}
+	return nil
 }
 
 func (oc *Controller) addPodToNamespaceAddressSet(ns, address string) {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1043,7 +1043,12 @@ func (oc *Controller) addNetworkPolicy(policy *kapisnetworking.NetworkPolicy) {
 		return
 	}
 
-	oc.waitForNamespaceEvent(policy.Namespace)
+	err := oc.waitForNamespaceEvent(policy.Namespace)
+	if err != nil {
+		logrus.Errorf("failed to wait for namespace %s event (%v)",
+			policy.Namespace, err)
+		return
+	}
 
 	np := &namespacePolicy{}
 	np.name = policy.Name

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -70,6 +70,7 @@ const (
 	defaultAllowPriority = "1001"
 	// IP Block except deny acl rule priority
 	ipBlockDenyPriority = "1010"
+	emptyLabelSelector  = "<none>"
 )
 
 func (oc *Controller) addAllowACLFromNode(logicalSwitch string) {
@@ -796,6 +797,9 @@ func (oc *Controller) handleLocalPodSelector(
 	clientset, _ := client.KClient.(*kubernetes.Clientset)
 	podSelectorAsSelector := metav1.FormatLabelSelector(
 		&policy.Spec.PodSelector)
+	if podSelectorAsSelector == emptyLabelSelector {
+		podSelectorAsSelector = ""
+	}
 
 	watchlist := newListWatchFromClient(clientset.Core().RESTClient(), "pods",
 		policy.Namespace, podSelectorAsSelector)
@@ -836,6 +840,9 @@ func (oc *Controller) handlePeerPodSelector(
 	client, _ := oc.Kube.(*kube.Kube)
 	clientset, _ := client.KClient.(*kubernetes.Clientset)
 	podSelectorAsSelector := metav1.FormatLabelSelector(podSelector)
+	if podSelectorAsSelector == emptyLabelSelector {
+		podSelectorAsSelector = ""
+	}
 
 	watchlist := newListWatchFromClient(clientset.Core().RESTClient(), "pods",
 		policy.Namespace, podSelectorAsSelector)
@@ -949,6 +956,9 @@ func (oc *Controller) handlePeerNamespaceSelector(
 	clientset, _ := client.KClient.(*kubernetes.Clientset)
 	nsSelectorAsSelector := metav1.FormatLabelSelector(
 		namespaceSelector)
+	if nsSelectorAsSelector == emptyLabelSelector {
+		nsSelectorAsSelector = ""
+	}
 
 	watchlist := newNamespaceListWatchFromClient(clientset.Core().RESTClient(),
 		nsSelectorAsSelector)


### PR DESCRIPTION
1. policy: Handle "<none>" label selectors.
2. policy: Don't wait forever for a namespace event.