### PR TITLE
ovnkube: Don't default logging to a file.

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -409,7 +409,7 @@ func InitConfig(ctx *cli.Context, defaults *Defaults) error {
 	Default.MTU = getConfigInt(cliConfig.Default.MTU, cfg.Default.MTU, 1400)
 	Default.ConntrackZone = getConfigInt(cliConfig.Default.ConntrackZone, cfg.Default.ConntrackZone, 64000)
 
-	Logging.File = getConfigStr(cliConfig.Logging.File, cfg.Logging.File, "/var/log/ovn-kubernetes.log")
+	Logging.File = getConfigStr(cliConfig.Logging.File, cfg.Logging.File, "")
 	Logging.Level = getConfigInt(cliConfig.Logging.Level, cfg.Logging.Level, 4)
 
 	CNI.ConfDir = getConfigStr(cliConfig.CNI.ConfDir, cfg.CNI.ConfDir, "/etc/cni/net.d")

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Config Operations", func() {
 
 			Expect(Default.MTU).To(Equal(1400))
 			Expect(Default.ConntrackZone).To(Equal(64000))
-			Expect(Logging.File).To(Equal("/var/log/ovn-kubernetes.log"))
+			Expect(Logging.File).To(Equal(""))
 			Expect(Logging.Level).To(Equal(4))
 			Expect(CNI.ConfDir).To(Equal("/etc/cni/net.d"))
 			Expect(CNI.Plugin).To(Equal("ovn-k8s-cni-overlay"))


### PR DESCRIPTION
If there is no logging file specified in config or
via command line, then don't default to the file
"/var/log/ovn-kubernetes.log". We need a way to log to stderr.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>