### PR TITLE
vagrant: Explicitly set libopenvswitch version.

### DIFF
--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -49,7 +49,7 @@ sudo apt-get install python-six openssl python-pip -y
 sudo -H pip install --upgrade pip
 
 sudo apt-get install openvswitch-datapath-dkms=2.8.1-1 -y
-sudo apt-get install openvswitch-switch=2.8.1-1 openvswitch-common=2.8.1-1 -y
+sudo apt-get install openvswitch-switch=2.8.1-1 openvswitch-common=2.8.1-1 libopenvswitch=2.8.1-1 -y
 sudo -H pip install ovs
 
 sudo apt-get install ovn-central=2.8.1-1 ovn-common=2.8.1-1 ovn-host=2.8.1-1 -y

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -64,7 +64,7 @@ sudo apt-get install python-six openssl python-pip -y
 sudo -H pip install --upgrade pip
 
 sudo apt-get install openvswitch-datapath-dkms=2.8.1-1 -y
-sudo apt-get install openvswitch-switch=2.8.1-1 openvswitch-common=2.8.1-1 -y
+sudo apt-get install openvswitch-switch=2.8.1-1 openvswitch-common=2.8.1-1 libopenvswitch=2.8.1-1 -y
 sudo -H pip install ovs
 
 sudo apt-get install ovn-central=2.8.1-1 ovn-common=2.8.1-1 ovn-host=2.8.1-1 -y


### PR DESCRIPTION
With OVS 2.9 released, we have a conflict with package
installations in vagrant. It installs 2.9 version of
libopenvswitch by default. This makes libopenvswitch version
explicit.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>