### PR TITLE
config: Don't fail after certificate bootstrapping fails.

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -619,7 +619,7 @@ func (a *OvnDBAuth) ensureCACert() error {
 	args = append(args, "list", "nb_global")
 	_ = exec.Command(cmdPath, args...).Run()
 	if _, err = os.Stat(a.CACert); os.IsNotExist(err) {
-		return fmt.Errorf("bootstapping %s CA certificate failed", a.CACert)
+		logrus.Warnf("bootstrapping %s CA certificate failed", a.CACert)
 	}
 	return nil
 }


### PR DESCRIPTION
We currently fail when certificate bootstrapping fails.
Instead, just log the error. If the certificate in
question is indeed being used, then the utility which
uses it will eventually fail.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>