### PR TITLE
gateway-init: Add outport name for default next hop.

### DIFF
--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -200,7 +200,8 @@ func GatewayInit(clusterIPSubnet, nodeName, nicIP, physicalInterface,
 	// Add a static route in GR with physical gateway as the default next hop.
 	if defaultGW != "" {
 		stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
-			gatewayRouter, "0.0.0.0/0", defaultGW)
+			gatewayRouter, "0.0.0.0/0", defaultGW,
+			fmt.Sprintf("rtoe-%s", gatewayRouter))
 		if err != nil {
 			logrus.Errorf("Failed to add a static route in GR with physical "+
 				"gateway as the default next hop, stdout: %q, "+


### PR DESCRIPTION
When we moved from python gateway-init code to
golang gateway-init code, we missed specifying outport
name for the default route for gateway router. This
becomes a problem when we run in GCE where there are
/32 IP addresses and we need to specify the outport
name.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>