### PR TITLE
Add HA support by rebuilding OVN database for cluster nodes

### DIFF
--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -129,6 +129,9 @@ Client certificate that the client should use for talking to the OVN database.  
 \fB\--sb-client-cacert\fR string
 CA certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket.
 .TP
+\fB\--ha
+Flag to rebuild ovn db if it is started on a new node (experimental feature).
+.TP
 \fB\--help\fR, \fB\-h\fR
 Show help.
 .TP

--- a/go-controller/README.md
+++ b/go-controller/README.md
@@ -92,6 +92,8 @@ Usage:
      Client certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/openvswitch/ovnsb-cert.pem)
   -sb-client-cacert string
      CA certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/openvswitch/ovnsb-ca.cert)
+  -ha
+     rebuilds ovn db if it is started on a new node (experimental feature)
 ```
 
 ### Configuration File
@@ -145,6 +147,8 @@ ovnkube --init-master <master-host-name> \
 	--cluster-subnet <cidr representing the global pod network e.g. 192.168.0.0/16> \
 	--net-controller
 ```
+
+Note that to rebuild ovn database on a new master node in case of failover, you can provide -ha option when you start ovnkube on both master and all nodes.
 
 With the above the master ovnkube controller will initialize the central master logical router and establish the watcher loops for the following:
  - nodes: as new nodes are born and init-node is called, the logical switches will be created automatically by giving out IPAM for the respective nodes

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -29,11 +29,16 @@ type OvnClusterController struct {
 	GatewayNextHop   string
 	GatewaySpareIntf bool
 	NodePortEnable   bool
+	OvnHA            bool
 }
 
 const (
 	// OvnHostSubnet is the constant string representing the annotation key
 	OvnHostSubnet = "ovn_host_subnet"
+	// DefaultNamespace is the name of the default namespace
+	DefaultNamespace = "default"
+	// MasterOverlayIP is the overlay IP address on master node
+	MasterOverlayIP = "master_overlay_ip"
 )
 
 // NewClusterController creates a new controller for IP subnet allocation to

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (
@@ -108,6 +109,75 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	defer f.Close()
 	confJSON := fmt.Sprintf("{\"name\":\"ovn-kubernetes\", \"type\":\"%s\"}", config.CNI.Plugin)
 	_, err = f.Write([]byte(confJSON))
+	if err != nil {
+		return err
+	}
 
+	if cluster.OvnHA {
+		err = cluster.watchNamespaceUpdate(node, subnet.String())
+		return err
+	}
+
+	return nil
+}
+
+// If default namespace MasterOverlayIP annotation has been chaged, update
+// config.OvnNorth and config.OvnSouth auth with new ovn-nb and ovn-remote
+// IP address
+func (cluster *OvnClusterController) updateOvnNode(masterIP string,
+	node *kapi.Node, subnet string) error {
+	err := config.UpdateOvnNodeAuth(masterIP)
+	if err != nil {
+		return err
+	}
+	err = setupOVNNode(node.Name, config.Kubernetes.APIServer,
+		config.Kubernetes.Token, config.Kubernetes.CACert)
+	if err != nil {
+		return err
+	}
+
+	// Recreate logical switch and management port for this node
+	err = ovn.CreateManagementPort(node.Name, subnet,
+		cluster.ClusterIPNet.String(),
+		cluster.ClusterServicesSubnet)
+	if err != nil {
+		return err
+	}
+
+	// Reinit Gateway for this node if the --init-gateways flag is set
+	if cluster.GatewayInit {
+		if runtime.GOOS == windowsOS {
+			panic("Windows is not supported as a gateway node")
+		}
+		err = cluster.initGateway(node.Name, cluster.ClusterIPNet.String(),
+			subnet)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// watchNamespaceUpdate starts watching namespace resources and calls back
+// the update handler logic if there is any namspace update event
+func (cluster *OvnClusterController) watchNamespaceUpdate(node *kapi.Node,
+	subnet string) error {
+	_, err := cluster.watchFactory.AddNamespaceHandler(
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(old, newer interface{}) {
+				oldNs := old.(*kapi.Namespace)
+				oldMasterIP := oldNs.Annotations[MasterOverlayIP]
+				newNs := newer.(*kapi.Namespace)
+				newMasterIP := newNs.Annotations[MasterOverlayIP]
+				if newMasterIP != oldMasterIP {
+					err := cluster.updateOvnNode(newMasterIP, node, subnet)
+					if err != nil {
+						logrus.Errorf("Failed to update OVN node with new ",
+							"masterIP %s: %v", newMasterIP, err)
+					}
+				}
+			},
+		}, nil)
 	return err
 }

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	kapi "k8s.io/api/core/v1"
+	kapisnetworking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -17,6 +18,7 @@ import (
 type Interface interface {
 	SetAnnotationOnPod(pod *kapi.Pod, key, value string) error
 	SetAnnotationOnNode(node *kapi.Node, key, value string) error
+	SetAnnotationOnNamespace(ns *kapi.Namespace, key, value string) error
 	GetAnnotationsOnPod(namespace, name string) (map[string]string, error)
 	GetPod(namespace, name string) (*kapi.Pod, error)
 	GetPods(namespace string) (*kapi.PodList, error)
@@ -24,6 +26,10 @@ type Interface interface {
 	GetNodes() (*kapi.NodeList, error)
 	GetNode(name string) (*kapi.Node, error)
 	GetService(namespace, name string) (*kapi.Service, error)
+	GetEndpoints(namespace string) (*kapi.EndpointsList, error)
+	GetNamespace(name string) (*kapi.Namespace, error)
+	GetNamespaces() (*kapi.NamespaceList, error)
+	GetNetworkPolicies(namespace string) (*kapisnetworking.NetworkPolicyList, error)
 }
 
 // Kube is the structure object upon which the Interface is implemented
@@ -49,6 +55,23 @@ func (k *Kube) SetAnnotationOnNode(node *kapi.Node, key, value string) error {
 	_, err := k.KClient.Core().Nodes().Patch(node.Name, types.MergePatchType, []byte(patchData))
 	if err != nil {
 		logrus.Errorf("Error in setting annotation on node %s: %v", node.Name, err)
+	}
+	return err
+}
+
+// SetAnnotationOnNamespace takes the Namespace object and key/value pair
+// to set it as an annotation
+func (k *Kube) SetAnnotationOnNamespace(ns *kapi.Namespace, key,
+	value string) error {
+	logrus.Infof("Setting annotations %s=%s on namespace %s", key, value,
+		ns.Name)
+	patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, key,
+		value)
+	_, err := k.KClient.Core().Namespaces().Patch(ns.Name,
+		types.MergePatchType, []byte(patchData))
+	if err != nil {
+		logrus.Errorf("Error in setting annotation on namespace %s: %v",
+			ns.Name, err)
 	}
 	return err
 }
@@ -93,4 +116,26 @@ func (k *Kube) GetNode(name string) (*kapi.Node, error) {
 // GetService returns the Service resource from kubernetes apiserver, given its name and namespace
 func (k *Kube) GetService(namespace, name string) (*kapi.Service, error) {
 	return k.KClient.Core().Services(namespace).Get(name, metav1.GetOptions{})
+}
+
+// GetEndpoints returns all the Endpoint resources from kubernetes
+// apiserver, given namespace
+func (k *Kube) GetEndpoints(namespace string) (*kapi.EndpointsList, error) {
+	return k.KClient.Core().Endpoints(namespace).List(metav1.ListOptions{})
+}
+
+// GetNamespace returns the Namespace resource from kubernetes apiserver,
+// given its name
+func (k *Kube) GetNamespace(name string) (*kapi.Namespace, error) {
+	return k.KClient.Core().Namespaces().Get(name, metav1.GetOptions{})
+}
+
+// GetNamespaces returns all Namespace resource from kubernetes apiserver
+func (k *Kube) GetNamespaces() (*kapi.NamespaceList, error) {
+	return k.KClient.Core().Namespaces().List(metav1.ListOptions{})
+}
+
+// GetNetworkPolicies returns all network policy objects from kubernetes
+func (k *Kube) GetNetworkPolicies(namespace string) (*kapisnetworking.NetworkPolicyList, error) {
+	return k.KClient.Networking().NetworkPolicies(namespace).List(metav1.ListOptions{})
 }

--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -152,6 +152,22 @@ func (oc *Controller) getIPFromOvnAnnotation(ovnAnnotation string) string {
 	return ipAddressMask[0]
 }
 
+func (oc *Controller) getMacFromOvnAnnotation(ovnAnnotation string) string {
+	if ovnAnnotation == "" {
+		return ""
+	}
+
+	var ovnAnnotationMap map[string]string
+	err := json.Unmarshal([]byte(ovnAnnotation), &ovnAnnotationMap)
+	if err != nil {
+		logrus.Errorf("Error in json unmarshaling ovn annotation "+
+			"(%v)", err)
+		return ""
+	}
+
+	return ovnAnnotationMap["mac_address"]
+}
+
 func stringSliceMembership(slice []string, key string) bool {
 	for _, val := range slice {
 		if val == key {

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -8,7 +8,8 @@ import (
 	kapi "k8s.io/api/core/v1"
 )
 
-func (ovn *Controller) addEndpoints(ep *kapi.Endpoints) error {
+// AddEndpoints adds endpoints and creates corresponding resources in OVN
+func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 	// get service
 	// TODO: cache the service
 	svc, err := ovn.kube.GetService(ep.Namespace, ep.Name)

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -90,7 +90,8 @@ func (oc *Controller) deletePodFromNamespaceAddressSet(ns, address string) {
 	oc.setAddressSet(hashedAddressSet(ns), addresses)
 }
 
-func (oc *Controller) addNamespace(ns *kapi.Namespace) {
+// AddNamespace creates corresponding addressset in ovn db
+func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 	logrus.Debugf("Adding namespace: %s", ns.Name)
 
 	if oc.namespaceMutex[ns.Name] == nil {
@@ -128,7 +129,6 @@ func (oc *Controller) addNamespace(ns *kapi.Namespace) {
 		addresses)
 
 	oc.namespacePolicies[ns.Name] = make(map[string]*namespacePolicy)
-	return
 }
 
 func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -129,7 +129,7 @@ func (oc *Controller) WatchEndpoints() error {
 	_, err := oc.watchFactory.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			ep := obj.(*kapi.Endpoints)
-			err := oc.addEndpoints(ep)
+			err := oc.AddEndpoints(ep)
 			if err != nil {
 				logrus.Errorf("Error in adding load balancer: %v", err)
 			}
@@ -146,7 +146,7 @@ func (oc *Controller) WatchEndpoints() error {
 					logrus.Errorf("Error in deleting endpoints - %v", err)
 				}
 			} else {
-				err := oc.addEndpoints(epNew)
+				err := oc.AddEndpoints(epNew)
 				if err != nil {
 					logrus.Errorf("Error in modifying endpoints: %v", err)
 				}
@@ -169,7 +169,7 @@ func (oc *Controller) WatchNetworkPolicy() error {
 	_, err := oc.watchFactory.AddPolicyHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			policy := obj.(*kapisnetworking.NetworkPolicy)
-			oc.addNetworkPolicy(policy)
+			oc.AddNetworkPolicy(policy)
 			return
 		},
 		UpdateFunc: func(old, newer interface{}) {
@@ -177,7 +177,7 @@ func (oc *Controller) WatchNetworkPolicy() error {
 			newPolicy := newer.(*kapisnetworking.NetworkPolicy)
 			if !reflect.DeepEqual(oldPolicy, newPolicy) {
 				oc.deleteNetworkPolicy(oldPolicy)
-				oc.addNetworkPolicy(newPolicy)
+				oc.AddNetworkPolicy(newPolicy)
 			}
 			return
 		},
@@ -196,7 +196,7 @@ func (oc *Controller) WatchNamespaces() error {
 	_, err := oc.watchFactory.AddNamespaceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			ns := obj.(*kapi.Namespace)
-			oc.addNamespace(ns)
+			oc.AddNamespace(ns)
 			return
 		},
 		UpdateFunc: func(old, newer interface{}) {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -223,7 +223,7 @@ func (oc *Controller) addAllowACLFromNode(logicalSwitch string) {
 	subnetRaw, err := exec.Command(OvnNbctl, "get", "logical_switch",
 		logicalSwitch, "other-config:subnet").Output()
 	if err != nil {
-		logrus.Errorf("failed to get the logical_switch %s subent (%v)",
+		logrus.Errorf("failed to get the logical_switch %s subnet (%v)",
 			logicalSwitch, err)
 		return
 	}
@@ -1025,7 +1025,8 @@ func (oc *Controller) handlePeerNamespaceSelector(
 	np.stopWg.Done()
 }
 
-func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) {
+// AddNetworkPolicy adds network policy and create corresponding acl rules
+func (oc *Controller) AddNetworkPolicy(policy *knet.NetworkPolicy) {
 	logrus.Infof("Adding network policy %s in namespace %s", policy.Name,
 		policy.Namespace)
 


### PR DESCRIPTION
Current, ovn controller only runs on one kube master node with one
central OVN database. In case of failover, all kube nodes data are
gone. This patch recontructs OVN database on a new kube master
node after failover including node's logical switch, management
port etc. The HA mode can be invoked by --ha command arg.
e.g. ovnkube -net-controller -init-master -ha

Signed-off-by: Tong Liu <tongl@vmware.com>