### PR TITLE
ovnkube: Prevent ovnkube from hanging if SSL configuration is already present

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -670,7 +670,12 @@ func (a *OvnDBAuth) SetDBAuth() error {
 			if !pathExists(a.CACert) {
 				return fmt.Errorf("server CA certificate file %s not found", a.CACert)
 			}
-			// Tell the database what SSL keys and certs to use
+			// Tell the database what SSL keys and certs to use, but before that delete
+			// any SSL configuration. Otherwise, ovn-{nbctl|sbctl} set-ssl command will hang
+			out, err = exec.Command(a.ctlCmd, "del-ssl").CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("error deleting %s SSL configuration: %v\n %q", a.ctlCmd, err, string(out))
+			}
 			out, err = exec.Command(a.ctlCmd, "set-ssl", a.PrivKey, a.Cert, a.CACert).CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("error setting %s SSL API certificates: %v\n  %q", a.ctlCmd, err, string(out))


### PR DESCRIPTION
It so happens that on the master node if SSL configuration is already present,
then running ovnkube on the master will hang at the following command invocation

$ ovn-nbctl set-ssl /etc/openvswitch/ovnnb-privkey.pem \
  /etc/openvswitch/ovnnb-cert.pem /etc/openvswitch/cacert.pem

The only way to make ovnkube to proceed at this point is to either perform:
  - ovn-nbctl del-ssl
  - ovn-nbctl clear nb_global . ssl

The following patch prevents this situation, by deleting the SSL configuration
before we call set-ssl

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>
Reviewed-by: Ram Vepa <rvepa@nvidia.com>