### PR TITLE
config: Fix OVN address when fetching from external_ids

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -401,6 +401,9 @@ func buildOvnAuth(direction, externalID string, cliAuth, confAuth *rawOvnAuthCon
 	}
 	if address == "" && readAddress {
 		address = getOVSExternalID("ovn-" + direction)
+		// address will be in format ssl:1.2.3.4:6641 from external_ids,
+		// but we want it in url format, i.e. ssl://1.2.3.4:6641
+		address = strings.Replace(address, ":", "://", 1)
 	}
 
 	auth := &rawOvnAuthConfig{Address: address}


### PR DESCRIPTION
The OVN addresses from external_ids will have format
ssl:1.2.3.4:6641 but we need to store them in URL format,
i.e. ssl://1.2.3.4:6641.

This will cause issues when trying to read the OVN
addresses from external_ids which will cause a crash
with error "missing port in address". This happens
if the components try to read the OVN addresses from
external_ids.

This commit fixes the issue by replacing the first
occurence of ':' with '://' when fetching the address
from OVS external_ids.

Signed-off-by: Alin Balutoiu <abalutoiu@cloudbasesolutions.com>