### PR TITLE
build: show lint progress so travis doesn't time out

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -45,7 +45,7 @@ install.tools: check-gopath
 	$(GOPATH)/bin/gometalinter.v1 --install;
 
 lint:
-	@./hack/lint.sh
+	./hack/lint.sh
 
 gofmt:
 	@./hack/verify-gofmt.sh

--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -7,6 +7,7 @@ set -o nounset
 set -o pipefail
 
 for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -not -iwholename '*vendor*' -a -not -iname '_output'); do
+	echo "Linting ${d}"
 	${GOPATH}/bin/gometalinter.v1 \
 		 --exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
 		 --exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \


### PR DESCRIPTION
We seem to be getting travis CI timeouts on the linting, which
does take a while.  Instead of just bumping up the travis timeout,
show some linting progress.

Signed-off-by: Dan Williams <dcbw@redhat.com>

@shettyg @rajatchopra 