### PR TITLE
vagrant: Use golang gateway helper.

### DIFF
--- a/vagrant/provisioning/setup-k8s-minion.sh
+++ b/vagrant/provisioning/setup-k8s-minion.sh
@@ -66,6 +66,7 @@ popd
 # Initialize the minion and gateway.
 if [ $PROTOCOL = "ssl" ]; then
 sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
+    -logfile="/var/log/openvswitch/ovnkube.log" \
     -k8s-apiserver="http://$MASTER_OVERLAY_IP:8080" \
     -init-node="$MINION_NAME"  \
     -nodeport \
@@ -79,9 +80,10 @@ sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -sb-client-cacert /etc/openvswitch/ovnsb-ca.cert \
     -init-gateways -gateway-interface=enp0s9 -gateway-nexthop="$GW_IP" \
     -service-cluster-ip-range=172.16.1.0/24 \
-    -cluster-subnet="192.168.0.0/16" 2>&1
+    -cluster-subnet="192.168.0.0/16" 2>&1 &
 else
 sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
+    -logfile="/var/log/openvswitch/ovnkube.log" \
     -k8s-apiserver="http://$MASTER_OVERLAY_IP:8080" \
     -init-node="$MINION_NAME"  \
     -nodeport \
@@ -89,12 +91,8 @@ sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -sb-address="$PROTOCOL://$MASTER_OVERLAY_IP:6632" -k8s-token="test" \
     -init-gateways -gateway-interface=enp0s9 -gateway-nexthop="$GW_IP" \
     -service-cluster-ip-range=172.16.1.0/24 \
-    -cluster-subnet="192.168.0.0/16" 2>&1
+    -cluster-subnet="192.168.0.0/16" 2>&1 &
 fi
-
-# Start the gateway helper.
-sudo ovn-k8s-gateway-helper --physical-bridge=brenp0s9 \
-            --physical-interface=enp0s9 --pidfile --detach
 
 # Restore xtrace
 $XTRACE

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -60,8 +60,7 @@ sudo service docker start
 
 # Install OVS and dependencies
 sudo apt-get build-dep dkms
-sudo apt-get install python-six openssl python-pip -y
-sudo -H pip install --upgrade pip
+sudo apt-get install python-six openssl -y
 
 sudo apt-get install openvswitch-datapath-dkms=2.8.1-1 -y
 sudo apt-get install openvswitch-switch=2.8.1-1 openvswitch-common=2.8.1-1 libopenvswitch=2.8.1-1 -y
@@ -84,14 +83,6 @@ EOF'
 else
   echo "PROTOCOL=tcp" >> setup_minion_args.sh
 fi
-
-# XXX: We only need this for ovn-k8s-gateway-helper
-git clone https://github.com/openvswitch/ovn-kubernetes
-pushd ovn-kubernetes
-sudo -H pip install .
-popd
-sudo rm `which ovn-k8s-cni-overlay`
-sudo rm `which ovn-k8s-overlay`
 
 # Install golang
 wget -nv https://dl.google.com/go/go1.9.2.linux-amd64.tar.gz


### PR DESCRIPTION
Now that we have the golang gateway helper, use it
in vagrant. This means that we no longer need
pip and the python installation. Also, since
passing -nodeport to '-init-node' now means that
ovnkube will run forever, we need to run it in
background.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>