### PR TITLE
README/vagrant: Run ovnkube in background for minions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -loglevel=4 \
     -sb-address="tcp://$CENTRAL_IP:6632" -k8s-token="$TOKEN" \
     -init-gateways \
     -service-cluster-ip-range=$SERVICE_IP_SUBNET \
+    -cluster-subnet=$CLUSTER_IP_SUBNET 2>&1
+```
+
+You can run the above command in the background instead, with:
+
+```
+nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -loglevel=4 \
+    -logfile="/var/log/openvswitch/ovnkube.log" \
+    -k8s-apiserver="http://$CENTRAL_IP:8080" \
+    -init-node="$NODE_NAME"  \
+    -nodeport \
+    -nb-address="tcp://$CENTRAL_IP:6631" \
+    -sb-address="tcp://$CENTRAL_IP:6632" -k8s-token="$TOKEN" \
+    -init-gateways \
+    -service-cluster-ip-range=$SERVICE_IP_SUBNET \
     -cluster-subnet=$CLUSTER_IP_SUBNET 2>&1 &
 ```
 

--- a/vagrant/provisioning/setup-k8s-minion.sh
+++ b/vagrant/provisioning/setup-k8s-minion.sh
@@ -65,7 +65,7 @@ popd
 
 # Initialize the minion and gateway.
 if [ $PROTOCOL = "ssl" ]; then
-sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
+nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -logfile="/var/log/openvswitch/ovnkube.log" \
     -k8s-apiserver="http://$MASTER_OVERLAY_IP:8080" \
     -init-node="$MINION_NAME"  \
@@ -82,7 +82,7 @@ sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -service-cluster-ip-range=172.16.1.0/24 \
     -cluster-subnet="192.168.0.0/16" 2>&1 &
 else
-sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
+nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -logfile="/var/log/openvswitch/ovnkube.log" \
     -k8s-apiserver="http://$MASTER_OVERLAY_IP:8080" \
     -init-node="$MINION_NAME"  \


### PR DESCRIPTION
With -nodeport as an option, ovnkube will run continuosly
on minions. So it needs to be sent to background.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>