### PR TITLE
nicstobridge: Make nicstobridge transient.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ provide '-gateway-interface' and '-gateway-nexthop' as options. For e.g:
 -init-gateways -gateway-interface=enp0s9 -gateway-nexthop="$NEXTHOP"
 ```
 
+* For both the above cases, ovnkube will create a OVS bridge on top of
+your physical interface and move the IP address and route informations
+from the physical interface to OVS bridge.  If you are using Ubuntu
+and OVS startup scripts are systemd (e.g: there is a file called
+/lib/systemd/system/ovsdb-server.service) , you will have to add the
+following line to /etc/default/openvswitch
+
+```
+OPTIONS=--delete-transient-ports
+```
+
 * If you have a spare interface that you want to exclusively use for OVN
 gateway on a node, you also need to pass the -gateway-spare-interface option.
 Foe e.g:

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -103,7 +103,8 @@ func NicToBridge(iface string) error {
 		"--", "br-set-external-id", bridge, "bridge-id", bridge,
 		"--", "set", "bridge", bridge, "fail-mode=standalone",
 		fmt.Sprintf("other_config:hwaddr=%s", ifaceLink.Attrs().HardwareAddr),
-		"--", "--may-exist", "add-port", bridge, iface)
+		"--", "--may-exist", "add-port", bridge, iface,
+		"--", "set", "port", iface, "other-config:transient=true")
 	if err != nil {
 		logrus.Errorf("Failed to create OVS bridge, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err


### PR DESCRIPTION
    When we create a gateway, we automatically add the
    physical interface as a port of OVS bridge and move
    the IP address from physical interface to OVS bridge.

    When the machine is rebooted, this will cause OVS
    to recreate the bridge - but not move the IP address
    resulting in not being able to ssh to the box.

    With this, we will add '--delete-transient-ports' to
    /etc/default/openvswitch[-switch] so that when OVS
    is restarted it will not add the physical interface
    to the bridge.

    You will have to run ovnkube again for it to be readded
    to the bridge.

    Signed-off-by: Gurucharan Shetty <guru@ovn.org>