### PR TITLE
ovnkube: restart ovn-controller with SSL keys for SouthBound DB

### DIFF
--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -65,7 +65,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		return err
 	}
 
-	err = util.RestartOvnController()
+	err = util.RestartOvnController(config.OvnSouth.ClientAuth)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Let us say that SSL is in use between OVN host and OVN central. So, when
ovn-controller is restarted it expects the SSL client keys to be specified in
/etc/default/ovn-host as below:

OVN_CTL_OPTS="--ovn-controller-ssl-key=/etc/openvswitch/ovncontroller-privkey.pem
--ovn-controller-ssl-cert=/etc/openvswitch/ovncontroller-cert.pem
--ovn-controller-ssl-bootstrap-ca-cert=/etc/openvswitch/ovnsb-cert.pem"

If these keys are not present when ovn-controller is restarted, then
ovn-controller will fail to connect to OVN Southbound DB. During the
invocation of ovnkube on a K8s node we take all the parameters required to
connect to OVN Southbound DB. This patch takes those parameters and adds it to
/etc/default/ovn-host as part of the bring up and avoids one extra manual step
of user populating /etc/default/ovn-host.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>
Reviewed-by: Ram Vepa <rvepa@nvidia.com>