### PR TITLE
ovn-k8s-cni-overlay: Add Windows Server 2016 RTM support

### DIFF
--- a/contrib/inventory/group_vars/kube-minions-windows
+++ b/contrib/inventory/group_vars/kube-minions-windows
@@ -16,4 +16,4 @@ docker_version: 17.10.0-ce
 install_path: C:\kubernetes
 install_beta_ovs: true
 
-windows1709: 10.0.16299.0
+windows1709: 10.0.17134.0

--- a/contrib/inventory/hosts
+++ b/contrib/inventory/hosts
@@ -1,10 +1,14 @@
 [kube-master]
-node1
+#192.168.85.100
+35.205.201.254
 
 [kube-minions-linux]
-node2
-node3
+#192.168.85.101
+35.233.32.45
+#node2
+#node3
 
 [kube-minions-windows]
-node4
-node5
+#192.168.85.131
+#node4
+#node5

--- a/contrib/ovn-kubernetes-cluster.yml
+++ b/contrib/ovn-kubernetes-cluster.yml
@@ -62,7 +62,7 @@
         # to install the MSI in unattended mode
         # Setting install_beta_ovs to false will install the latest stable OVS
         install_custom_ovs: true
-        custom_ovs_link: "https://docs.google.com/uc?export=download&id=1QnAtn8EhfbBFwn-1KPCkJ4EqCmEiT8g_"
+        custom_ovs_link: "https://balutoiu.com/ionut/OpenvSwitch.msi"
         ovs_certs_link: "https://docs.google.com/uc?export=download&id=1tGbGalZ6gDQOgjQuWAfIqGCNy-9RTpAF"
         # This is useful for dev purposes and when using custom MSI which is not signed
         bcdedit_needed: true

--- a/contrib/roles/linux/ovn-kubernetes/vars/ubuntu.yml
+++ b/contrib/roles/linux/ovn-kubernetes/vars/ubuntu.yml
@@ -2,9 +2,9 @@
 ovn_kubernetes_info:
   install_path: /usr/bin
   # ovn-kubernetes build info
-  git_url: https://github.com/openvswitch/ovn-kubernetes
+  git_url:  https://github.com/aserdean/ovn-kubernetes
   build_path: /tmp
-  branch: master
+  branch: no_hyperv
 
 ovn_kubernetes_binaries:
   linux:

--- a/contrib/roles/linux/ovn-kubernetes/vars/ubuntu.yml
+++ b/contrib/roles/linux/ovn-kubernetes/vars/ubuntu.yml
@@ -2,9 +2,9 @@
 ovn_kubernetes_info:
   install_path: /usr/bin
   # ovn-kubernetes build info
-  git_url:  https://github.com/aserdean/ovn-kubernetes
+  git_url: https://github.com/alinbalutoiu/ovn-kubernetes
   build_path: /tmp
-  branch: no_hyperv
+  branch: master
 
 ovn_kubernetes_binaries:
   linux:

--- a/contrib/roles/windows/docker/tasks/requirements-16299.yaml
+++ b/contrib/roles/windows/docker/tasks/requirements-16299.yaml
@@ -8,9 +8,9 @@
   register: features_installed
   with_items:
     - Containers
-    - Hyper-V # TODO
-    - RSAT-Hyper-V-Tools # TODO
-    - Hyper-V-PowerShell # TODO
+    #- Hyper-V # TODO
+    #- RSAT-Hyper-V-Tools # TODO
+    #- Hyper-V-PowerShell # TODO
 
 - name: Windows 1709 | Expect reboot_required to false
   set_fact:

--- a/contrib/roles/windows/kubernetes/tasks/create_infracontainer.yml
+++ b/contrib/roles/windows/kubernetes/tasks/create_infracontainer.yml
@@ -9,7 +9,7 @@
     path: "{{ install_info.install_path }}/Dockerfile"
     create: yes
     line: |
-      FROM microsoft/nanoserver:1709
+      FROM microsoft/nanoserver:1803
 
       CMD ping 127.0.0.1 -t
     newline: unix

--- a/contrib/roles/windows/kubernetes/tasks/setup_ovs_docker.yml
+++ b/contrib/roles/windows/kubernetes/tasks/setup_ovs_docker.yml
@@ -12,42 +12,28 @@
       if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) { Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs; exit }
       $RegROPath = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
       Remove-ItemProperty $RegROPath "OVN_Init_Node" -ErrorAction SilentlyContinue
-
-      # Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/hns.psm1
-      # Import-Module ./hns.psm1
+      #TODO figure why they don't get automatically included
+      Import-Module "C:\Windows\System32\WindowsPowerShell\v1.0\Modules\HostNetworkingService\HostNetworkingService.psm1"
+      Get-HNSNetwork
+      Import-Module "C:\Windows\System32\WindowsPowerShell\v1.0\Modules\OVS\OVS.psm1"
+      Import-Module "C:\Windows\System32\WindowsPowerShell\v1.0\Modules\HNSHelper\HNSHelper.psm1"
 
       # # There should be only one transparent network
-      # $HNS_NW=Get-HNSNetworks | where {$_.type -eq "transparent"}
-      # $HNS_ID=$HNS_NW.Id
-      # $OVS_EXTENSION_ID="583cc151-73ec-4a6a-8b47-578297ad7623"
-
-      # Set-HnsSwitchExtension -NetworkId $HNS_ID -ExtensionId $OVS_EXTENSION_ID -state 0
-      # # Rename-NetAdapter -Name "vEthernet ({{interface_name}})" -NewName "Management_Interface"
-      # ovs-vsctl --if-exists --no-wait del-br br-ex
-      # ovs-vsctl --no-wait --may-exist add-br br-ex
-      # ovs-vsctl --no-wait add-port br-ex "{{interface_name}}"
-      # Stop-Service ovs-vswitchd
-      # Set-HnsSwitchExtension -NetworkId $HNS_ID -ExtensionId $OVS_EXTENSION_ID -state 1
-      Get-VMSwitch -SwitchType External | Disable-VMSwitchExtension "Cloudbase Open vSwitch Extension"
+      $HNS_NW = Get-HNSNetwork | where {$_.type -eq "transparent"}
+      $HNS_ID = $HNS_NW.Id
+      Disable-OVSOnHNSNetwork $HNS_ID
       ovs-vsctl --if-exists --no-wait del-br br-ex
-      Get-VMSwitch -SwitchType External | Set-VMSwitch -AllowManagementOS $false
-      Get-VMSwitch -SwitchType External | Set-VMSwitch -AllowManagementOS $false
       ovs-vsctl --no-wait --may-exist add-br br-ex
+      ovs-vsctl --no-wait add-port br-ex "vEthernet ({{interface_name}})" -- set interface  "vEthernet ({{interface_name}})" type=internal
       ovs-vsctl --no-wait add-port br-ex '{{interface_name}}'
       Stop-Service ovs-vswitchd
-      Get-VMSwitch -SwitchType External | Enable-VMSwitchExtension "Cloudbase Open vSwitch Extension"
+      Enable-OVSOnHNSNetwork $HNS_ID
 
       Start-Service ovs-vswitchd
       sleep 2
       Restart-Service ovs-vswitchd
       # Clone the MAC addr
-      # TODO: this does not work if the mac ends in 99
-      Set-NetAdapter -Name "{{ interface_name }}" -MacAddress {{ interface_mac_addr[:-2] }}99 -Confirm:$false
-      Set-NetAdapter -Name br-ex -MacAddress {{ interface_mac_addr }} -Confirm:$false
-      Enable-NetAdapter br-ex
-      # Remove-NetIPAddress -ifAlias br-ex -Confirm:$false
-      # New-NetIPAddress -ifAlias br-ex -IPAddress {{ host_internal_ip }} -DefaultGateway {{ interface_default_gateway }} -PrefixLength {{ interface_prefix_length }}
-      # Set-DnsClientServerAddress -InterfaceAlias br-ex -ServerAddresses ("8.8.8.8")
+      # TODO: Carry over MTU to the management interface
       $GUID = (New-Guid).Guid
       ovs-vsctl set Open_vSwitch . external_ids:system-id="$($GUID)"
       ovs-vsctl set Open_vSwitch . external_ids:k8s-api-server="http://{{ kubernetes_info.MASTER_IP }}:8080"

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -350,7 +350,7 @@ func runOVSVsctl(args ...string) (string, error) {
 		return "", err
 	}
 
-	newArgs := append([]string{"--timeout=5"}, args...)
+	newArgs := append([]string{"--timeout=15"}, args...)
 	out, err := exec.Command(cmdPath, newArgs...).CombinedOutput()
 	if err != nil {
 		return "", err

--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -19,7 +19,7 @@ const (
 func configureManagementPortWindows(clusterSubnet, clusterServicesSubnet,
 	routerIP, interfaceName, interfaceIP string) error {
 	// Up the interface.
-	args := []string{"Enable-NetAdapter", fmt.Sprintf("%s", interfaceName)}
+	args := []string{"Enable-NetAdapter", "-IncludeHidden", fmt.Sprintf("%s", interfaceName)}
 	logrus.Debugf("Executing 'powershell %s'", strings.Join(args, " "))
 
 	_, err := exec.Command("powershell", args...).CombinedOutput()
@@ -87,7 +87,7 @@ func configureManagementPortWindows(clusterSubnet, clusterServicesSubnet,
 	if strings.Contains(fmt.Sprintf("%s", stdoutStderr), fmt.Sprintf("%s", clusterIP)) {
 		logrus.Debugf("Route was found, skipping route add")
 	} else {
-		args = []string{"$(Get-NetAdapter", "|", "Where",
+		args = []string{"$(Get-NetAdapter", "-IncludeHidden", "|", "Where",
 			"{", "$_.Name", "-Match", fmt.Sprintf("\"%s\"", interfaceName), "}).ifIndex"}
 		logrus.Debugf("Executing 'powershell %s'", strings.Join(args, " "))
 
@@ -299,7 +299,7 @@ func CreateManagementPort(nodeName, localSubnet, clusterSubnet,
 
 	if runtime.GOOS == windowsOS && macAddress == "00:00:00:00:00:00" {
 		var stdoutStderr []byte
-		stdoutStderr, err = exec.Command("powershell", "$(Get-NetAdapter", "|", "Where", "{", "$_.Name",
+		stdoutStderr, err = exec.Command("powershell", "$(Get-NetAdapter", "-IncludeHidden", "|", "Where", "{", "$_.Name",
 			"-Match", fmt.Sprintf("\"%s\"", interfaceName), "}).MacAddress").CombinedOutput()
 		if err != nil {
 			logrus.Errorf("Failed to get mac address of ovn-k8s-master, stderr: %q, error: %v", fmt.Sprintf("%s", stdoutStderr), err)

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	ovsCommandTimeout = 5
+	ovsCommandTimeout = 15
 	ovsVsctlCommand   = "ovs-vsctl"
 	ovsOfctlCommand   = "ovs-ofctl"
 	ovnNbctlCommand   = "ovn-nbctl"


### PR DESCRIPTION
This patch adds Windows Server 2016 RTM (build number 14393).

Kubernetes supports only one container per pod in this mode.
This Windows version does not support setting custom
IP/MAC address (will be supported by OVS on Windows in the near
future).

The CNI will update the port from OVN with the assigned IP/MAC address.


Signed-off-by: Alin Balutoiu <abalutoiu@cloudbasesolutions.com>