### PR TITLE
vagrant: Don't add contents to default file manually.

### DIFF
--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -75,11 +75,6 @@ if [ -n "$SSL" ]; then
     sudo ovs-pki req ovncontroller
     sudo ovs-pki -b -d /vagrant/pki sign ovncontroller switch
     popd
-
-    # Set ovn-controller SSL options in /etc/default/ovn-host
-    sudo bash -c 'cat >> /etc/default/ovn-host <<EOF
-OVN_CTL_OPTS="--ovn-controller-ssl-key=/etc/openvswitch/ovncontroller-privkey.pem  --ovn-controller-ssl-cert=/etc/openvswitch/ovncontroller-cert.pem --ovn-controller-ssl-bootstrap-ca-cert=/etc/openvswitch/ovnsb-ca.cert"
-EOF'
 else
   echo "PROTOCOL=tcp" >> setup_minion_args.sh
 fi


### PR DESCRIPTION
Now that ovnkube populates /etc/default/ovn-host, let
ovnkube populate it.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>