### PR TITLE
cluster/master: restart ovn-controller.

### DIFF
--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -9,6 +9,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 
@@ -96,6 +97,11 @@ func (cluster *OvnClusterController) SetupMaster(masterNodeName string, masterSw
 	}
 
 	if err := setupOVNMaster(masterNodeName); err != nil {
+		return err
+	}
+
+	err = util.RestartOvnController(config.OvnSouth.ClientAuth)
+	if err != nil {
 		return err
 	}
 

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -67,12 +67,6 @@ if [ -n "$SSL" ]; then
     sudo ovs-pki req ovncontroller
     sudo ovs-pki -b -d /vagrant/pki sign ovncontroller switch
     popd
-
-    # Set ovn-controller SSL options in /etc/default/ovn-host
-    sudo bash -c 'cat >> /etc/default/ovn-host <<EOF
-OVN_CTL_OPTS="--ovn-controller-ssl-key=/etc/openvswitch/ovncontroller-privkey.pem  --ovn-controller-ssl-cert=/etc/openvswitch/ovncontroller-cert.pem --ovn-controller-ssl-bootstrap-ca-cert=/etc/openvswitch/ovnsb-ca.cert"
-EOF'
-   sudo service ovn-host restart
 else
     echo "PROTOCOL=tcp" >> setup_master_args.sh
 fi


### PR DESCRIPTION
On a master node too, we run ovn-controller (because
we create a logical switch and a management port for
master.). This keeps the behavior consistent with
ovnkube when run for nodes.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>