### PR TITLE
ovnkube: persist k8s CA certificate file path in Open_vSwitch external_ids column

### DIFF
--- a/go-controller/cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
+++ b/go-controller/cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
@@ -154,6 +154,7 @@ func main() {
 		if err := config.InitConfig(ctx, &config.Defaults{
 			K8sAPIServer: true,
 			K8sToken:     true,
+			K8sCert:      true,
 		}); err != nil {
 			return err
 		}

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -68,7 +68,7 @@ func setOVSExternalIDs(nodeName string, ids ...string) error {
 	return nil
 }
 
-func setupOVNNode(nodeName, kubeServer, kubeToken string) error {
+func setupOVNNode(nodeName, kubeServer, kubeToken, kubeCACert string) error {
 	// Tell ovn-*bctl how to talk to the database
 	for _, auth := range []*config.OvnDBAuth{
 		config.OvnNorth.ClientAuth,
@@ -85,7 +85,8 @@ func setupOVNNode(nodeName, kubeServer, kubeToken string) error {
 	return setOVSExternalIDs(
 		nodeName,
 		fmt.Sprintf("k8s-api-server=\"%s\"", kubeServer),
-		fmt.Sprintf("k8s-api-token=\"%s\"", kubeToken))
+		fmt.Sprintf("k8s-api-token=\"%s\"", kubeToken),
+		fmt.Sprintf("k8s-ca-certificate=\"%s\"", kubeCACert))
 }
 
 func setupOVNMaster(nodeName string) error {

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -61,7 +61,9 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 
 	logrus.Infof("Node %s ready for ovn initialization with subnet %s", node.Name, subnet.String())
 
-	if err = setupOVNNode(name, config.Kubernetes.APIServer, config.Kubernetes.Token); err != nil {
+	err = setupOVNNode(name, config.Kubernetes.APIServer, config.Kubernetes.Token,
+		config.Kubernetes.CACert)
+	if err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -314,6 +314,7 @@ type Defaults struct {
 	OvnNorthAddress bool
 	K8sAPIServer    bool
 	K8sToken        bool
+	K8sCert         bool
 }
 
 const (
@@ -364,6 +365,9 @@ func buildKubernetesConfig(cli, file *config, defaults *Defaults) error {
 	}
 	if defaults.K8sToken {
 		Kubernetes.Token = getOVSExternalID("k8s-api-token")
+	}
+	if defaults.K8sCert {
+		Kubernetes.CACert = getOVSExternalID("k8s-ca-certificate")
 	}
 
 	// Copy config file values over default values


### PR DESCRIPTION
    In the case where ovnkube was executed with all the information provided on
    the CLI, we only persist k8s-api-server and k8s-api-token as external IDs in
    Open_vSwitch table. This results in ovn-k8s-cni-overlay to fail in
    InitConfig()  and as a result no networking is configured for the pod.
    
    When SSL is in use, the CNI looks for CA certificate and it cannot find
    it. This patch fixes the issue by persisting k8s-ca-certificate in
    Open_vSwitch table.