### PR TITLE
ovn: Fix error catching when fetching the mac address

### DIFF
--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -260,11 +260,11 @@ func CreateManagementPort(nodeName, localSubnet, clusterSubnet,
 	}
 	macAddress, stderr, err := util.RunOVSVsctl("--if-exists", "get", "interface", interfaceName, "mac_in_use")
 	if err != nil {
-		logrus.Errorf("Failed to get mac address of ovn-k8s-master, stderr: %q, error: %v", stderr, err)
+		logrus.Errorf("Failed to get mac address of %v, stderr: %q, error: %v", interfaceName, stderr, err)
 		return err
 	}
-	if macAddress == "" {
-		return fmt.Errorf("Failed to get mac address of ovn-k8s-master")
+	if macAddress == "[]" {
+		return fmt.Errorf("Failed to get mac address of %v", interfaceName)
 	}
 
 	if runtime.GOOS == windowsOS && macAddress == "00:00:00:00:00:00" {


### PR DESCRIPTION
If OVS fails to retrieve the mac address of the k8s interface
created on the host, it will return "[]" instead of "".

This means that the error will not be catched and it will try
to continue which will give misleading error messages. This will
happen when it will try to add the port in OVN.

This patch also fixes some log messages which were not logging
the interface name variable.

Signed-off-by: Alin Balutoiu <abalutoiu@cloudbasesolutions.com>