### PR TITLE
ovn-kube-util: provide bridges-to-nic subcommand

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
+++ b/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
@@ -29,3 +29,25 @@ var NicsToBridgeCommand = cli.Command{
 		return errors.NewAggregate(errorList)
 	},
 }
+
+// BridgesToNicCommand removes a NIC interface from OVS bridge and deletes the bridge
+var BridgesToNicCommand = cli.Command{
+	Name:  "bridges-to-nic",
+	Usage: "Delete ovs bridge and move IP/routes to underlying NIC",
+	Flags: []cli.Flag{},
+	Action: func(context *cli.Context) error {
+		args := context.Args()
+		if len(args) == 0 {
+			return fmt.Errorf("Please specify list of bridges")
+		}
+
+		var errorList []error
+		for _, bridge := range args {
+			if err := util.BridgeToNic(bridge); err != nil {
+				errorList = append(errorList, err)
+			}
+		}
+
+		return errors.NewAggregate(errorList)
+	},
+}

--- a/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
+++ b/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
@@ -16,6 +16,7 @@ func main() {
 
 	c.Commands = []cli.Command{
 		app.NicsToBridgeCommand,
+		app.BridgesToNicCommand,
 	}
 
 	if err := c.Run(os.Args); err != nil {


### PR DESCRIPTION
This patch adds a subcommand bridges-to-nic to ovn-kube-util to restore back
the NIC interface that was added to OVS bridge as part of gateway
initialization. That is, given breth0 it moves the IP/routes associated with
breth0 to eth0 and then deletes the OVS bridge breth0.

I have renamed arguments to saveIPAddress(), delAddRoute(), and saveRoute()
so that I could reuse those functions to bridges-to-nic.
