### PR TITLE
fix platform string match for RHEL

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -60,7 +60,7 @@ func runningPlatform() (string, error) {
 	}
 
 	if strings.Contains(platform, "Fedora") ||
-		strings.Contains(platform, rhel) || strings.Contains(platform, "CentOS") {
+		strings.Contains(platform, "Red Hat") || strings.Contains(platform, "CentOS") {
 		return rhel, nil
 	} else if strings.Contains(platform, "Debian") ||
 		strings.Contains(platform, ubuntu) {


### PR DESCRIPTION
We check the platform value as specified in the key 'Name'/'NAME'. For RHEL an example os-release file is:

```
NAME="Red Hat Enterprise Linux Server"
VERSION="7.4 (Maipo)"
ID="rhel"
ID_LIKE="fedora"
VARIANT="Server"
VARIANT_ID="server"
VERSION_ID="7.4"
PRETTY_NAME="Red Hat Enterprise Linux Server 7.4 (Maipo)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:7.4:GA:server"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
REDHAT_BUGZILLA_PRODUCT_VERSION=7.4
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="7.4"
```
Perhaps, we should change the key from 'Name' to 'ID', but for now this fix is needed. Tested and verified for RHEL 7.4!

Signed-off-by: Rajat Chopra <rchopra@redhat.com>