### PR TITLE
contrib: Add ansible playbooks to deploy kubernetes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ vagrant/k8s/
 vagrant/.vagrant/
 vagrant/ubuntu-xenial-16.04-cloudimg-console.log
 
+# Ansible specific
+contrib/*.retry
+contrib/tmp

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,57 @@
+# Ansible playbooks to deploy ovn-kubernetes
+
+The ansible playbooks are able to deploy a kubernetes cluster with
+Linux and Windows minion nodes.
+
+## How to use
+
+Make sure to update first the [inventory](/contrib/inventory) with
+details about the nodes.
+
+To start the playbook, please run the following:
+```
+ansible-playbook ovn-kubernetes-cluster.yml
+```
+
+Currently supported Linux nodes:
+- Ubuntu 14.04 and 16.04
+
+Currently supported Windows nodes:
+- Windows Server 2016 build version 1709
+
+Note: minimum required ansible version is 2.4.2.0
+
+## Work in progress
+
+- Support for hybrid cluster with master/minion nodes on different cloud providers.
+
+- Windows Server 2016 build number 14393
+
+- Different Linux versions support (currently only Ubuntu 14.04 and 16.04 supported)
+
+### Known issues
+
+- Windows Server 2016 build version 1709 requires the Hyper-V feature for the moment. This will be fixed with the next release of Open vSwitch on Windows
+
+- The interface on Windows should be able to receive the IP via DHCP
+
+- Warning: the firewall on Windows gets disabled for this test
+
+## Ansible requirements
+
+For Linux: Make sure that you are able to SSH into the target nodes without being
+asked for the password. You can read more [here](http://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html).
+
+For Windows: Follow [this guide](https://docs.ansible.com/ansible/devel/user_guide/windows_setup.html)
+to setup the node to be used with ansible.
+
+#### Verifying the setup
+
+To verify the setup and that ansible has been successfully configured you can run the following:
+
+```
+ansible -m setup all
+```
+
+This will connect to the target hosts and will gather host facts.
+If the command succeeds and everything is green, you're good to go with running the playbook.

--- a/contrib/ansible.cfg
+++ b/contrib/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+inventory = inventory

--- a/contrib/inventory/README.md
+++ b/contrib/inventory/README.md
@@ -1,0 +1,12 @@
+# Ansible inventory
+
+Make sure to update the [hosts](/contrib/inventory/hosts) file with the nodes details.
+
+Ensure that [group_vars](/contrib/inventory/group_vars) contain the right details to connect to the target servers.
+
+For Linux nodes make sure that the username is set up correctly in variable ``ansible_ssh_user`` inside file [kube-master](/contrib/inventory/group_vars/kube-master).
+Check the same for [kube-minions-linux](/contrib/inventory/group_vars/kube-minions-linux).
+
+For Windows nodes, check the login credentials stored in [kube-minions-windows](/contrib/inventory/group_vars/kube-minions-windows). Make sure that ``ansible_user`` and ``ansible_password`` match to your target Windows servers.
+
+Optional, in case you want to define different ssh users or login credentials for different minion nodes, please look into [host_vars](/contrib/inventory/host_vars).

--- a/contrib/inventory/group_vars/all
+++ b/contrib/inventory/group_vars/all
@@ -1,0 +1,20 @@
+# the master node will overwrite this value
+master: false
+# the minion nodes will overwrite this value
+minion: false
+
+CLUSTER_SUBNET: "10.0.0.0/16"
+MASTER_INTERNAL_IP: "10.0.0.2" # Should always be the second IP of CLUSTER_SUBNET
+
+SERVICE_CLUSTER_IP_RANGE: "10.1.0.0/24"
+K8S_DNS_DOMAIN: "cluster.local"
+K8S_DNS_SERVICE_IP: "10.0.9.10"
+K8S_API_SERVICE_IP: "10.0.9.1"
+
+# set this to true to build ovn-kubernetes only on master and then
+# distribute on the minion nodes. Set this to false if you have different
+# Linux versions
+distribute_binaries: true
+
+# the place where the temporary binaries and files are stored
+ansible_tmp_dir: "{{playbook_dir}}/tmp"

--- a/contrib/inventory/group_vars/kube-master
+++ b/contrib/inventory/group_vars/kube-master
@@ -1,0 +1,7 @@
+ansible_ssh_user: ubuntu
+docker_bin_dir: /usr/bin
+
+# this will be the master node
+master: true
+minion: false
+controller: true

--- a/contrib/inventory/group_vars/kube-minions-linux
+++ b/contrib/inventory/group_vars/kube-minions-linux
@@ -1,0 +1,6 @@
+ansible_ssh_user: ubuntu
+docker_bin_dir: /usr/bin
+
+master: false
+minion: true
+controller: false

--- a/contrib/inventory/group_vars/kube-minions-windows
+++ b/contrib/inventory/group_vars/kube-minions-windows
@@ -1,0 +1,17 @@
+# username and password of the nodes (if the nodes have different passwords, please look into host_vars folder)
+ansible_user: Administrator
+ansible_password: Passw0rd
+# This is the default port for HTTPS used by winrm
+ansible_port: 5986
+ansible_connection: winrm
+# The following is necessary for Python 2.7.9+ (or any older Python that has backported SSLContext, eg, Python 2.7.5 on RHEL7) when using default WinRM self-signed certificates:
+ansible_winrm_server_cert_validation: ignore
+
+master: false
+minion: true
+controller: false
+
+docker_version: 17.10.0-ce
+# install_path: where kubernetes binaries and CNI plugin will be installed
+install_path: C:\kubernetes
+install_beta_ovs: true

--- a/contrib/inventory/host_vars/README.md
+++ b/contrib/inventory/host_vars/README.md
@@ -1,0 +1,20 @@
+# host variables
+
+To assign variables only for some specific groups use this directory.
+Create a file here with the node name and then put the vars inside.
+
+Example: create the file "node1" (is the node name from hosts file)
+```
+GCE: true
+```
+
+This place is the most useful when using different Windows nodes with
+different passwords. For example 2 Windows Server nodes can have the
+same username and different passwords.
+
+Just create a file for the nodes that have different password from the
+one present in group_vars. Example for "node5":
+```
+ansible_user: Administrator
+ansible_password: different_password
+```

--- a/contrib/inventory/hosts
+++ b/contrib/inventory/hosts
@@ -1,0 +1,10 @@
+[kube-master]
+node1
+
+[kube-minions-linux]
+node2
+node3
+
+[kube-minions-windows]
+node4
+node5

--- a/contrib/ovn-kubernetes-cluster.yml
+++ b/contrib/ovn-kubernetes-cluster.yml
@@ -1,0 +1,78 @@
+---
+- hosts: kube-master
+  any_errors_fatal: true
+  gather_facts: true
+  become: true
+  tasks:
+    - import_role:
+        name: linux/version_check
+    - import_role:
+        name: linux/docker
+    - import_role:
+        name: linux/openvswitch
+      vars:
+        force_ovs_reinstall: false # clean reinstall OVS if it exists
+        # make sure to give the link to prebuilt OVS packages in
+        # roles/linux/openvswitch/vars/ubuntu.yml if this var is set to true
+        ovs_install_prebuilt_packages: false
+    - import_role:
+        name: linux/ovn-kubernetes
+    - import_role:
+        name: linux/kubernetes
+      vars:
+        force_redownload: false # force redownload kubernetes binaries even if they exists
+        force_regen_certs: false # force to generate new certs even if they exist
+
+- hosts: kube-minions-linux
+  any_errors_fatal: true
+  gather_facts: true
+  become: true
+  vars:
+    # This will init the gateway on the first minion from the hosts
+    init_gateway: true
+  tasks:
+    - import_role:
+        name: linux/version_check
+    - import_role:
+        name: linux/docker
+    - import_role:
+        name: linux/openvswitch
+      vars:
+        force_ovs_reinstall: false # clean reinstall OVS if it exists
+        # make sure to give the link to prebuilt OVS packages in
+        # roles/linux/openvswitch/vars/ubuntu.yml if this var is set to true
+        ovs_install_prebuilt_packages: false
+    - import_role:
+        name: linux/ovn-kubernetes
+    - import_role:
+        name: linux/kubernetes
+      vars:
+        force_redownload: false # force redownload kubernetes binaries even if they exists
+        force_regen_certs: false # force to generate new certs even if they exist
+
+- hosts: kube-minions-windows
+  remote_user: Administrator
+  gather_facts: true
+  become_method: runas
+  any_errors_fatal: true
+  tasks:
+    - import_role:
+        name: windows/version_check
+    - import_role:
+        name: windows/docker
+    - import_role:
+        name: windows/openvswitch
+      vars:
+        # This is useful when using custom OVS MSI, it should also provide the link
+        # to the certificates which need to be added in certstore in order to be able
+        # to install the MSI in unattended mode
+        # Setting install_beta_ovs to false will install the latest stable OVS
+        install_custom_ovs: true
+        custom_ovs_link: "https://docs.google.com/uc?export=download&id=1QnAtn8EhfbBFwn-1KPCkJ4EqCmEiT8g_"
+        ovs_certs_link: "https://docs.google.com/uc?export=download&id=1tGbGalZ6gDQOgjQuWAfIqGCNy-9RTpAF"
+        # This is useful for dev purposes and when using custom MSI which is not signed
+        bcdedit_needed: true
+    - import_role:
+        name: windows/ovn-kubernetes
+    - import_role:
+        name: windows/kubernetes

--- a/contrib/roles/linux/docker/tasks/main.yml
+++ b/contrib/roles/linux/docker/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Docker | include global vars for minions
+  include_vars: "{{ansible_tmp_dir}}/generated_global_vars.yml"
+  when: not master
+
+- name: Docker | include vars
+  include_vars: "{{ ansible_distribution|lower }}.yml"
+  tags:
+    - facts
+
+- name: Docker | ensure docker repository public key is installed
+  action: "{{ docker_repo_key_info.pkg_key }}"
+  args:
+    id: "{{item}}"
+    url: "{{docker_repo_key_info.url}}"
+    state: present
+  register: keyserver_task_result
+  until: keyserver_task_result|succeeded
+  retries: 3
+  with_items: "{{ docker_repo_key_info.repo_keys }}"
+
+- name: Docker | ensure docker repository is enabled
+  action: "{{ docker_repo_info.pkg_repo }}"
+  args:
+    repo: "{{item}}"
+    state: present
+  with_items: "{{ docker_repo_info.repos }}"
+
+- name: Docker | ensure docker packages are installed
+  action: "{{ docker_package_info.pkg_mgr }}"
+  args:
+    pkg: "{{item.name}}"
+    force: "{{item.force|default(omit)}}"
+    state: present
+  register: docker_task_result
+  until: docker_task_result|succeeded
+  retries: 3
+  with_items: "{{ docker_package_info.pkgs }}"
+
+- name: Docker | restart docker
+  include_tasks: ./restart_docker.yml
+  when: docker_task_result.changed

--- a/contrib/roles/linux/docker/tasks/restart_docker.yml
+++ b/contrib/roles/linux/docker/tasks/restart_docker.yml
@@ -1,0 +1,25 @@
+---
+- name: Docker | reload systemd
+  shell: systemctl daemon-reload
+
+- name: Docker | reload docker.socket
+  service:
+    name: docker.socket
+    state: restarted
+
+- name: Docker | reload docker
+  service:
+    name: docker
+    state: restarted
+
+- name: Docker | pause while Docker restarts
+  pause:
+    seconds: 10
+    prompt: "Waiting for docker restart"
+
+- name: Docker | wait for docker
+  command: "{{ docker_bin_dir }}/docker images"
+  register: docker_ready
+  retries: 10
+  delay: 5
+  until: docker_ready.rc == 0

--- a/contrib/roles/linux/docker/vars/ubuntu.yml
+++ b/contrib/roles/linux/docker/vars/ubuntu.yml
@@ -1,0 +1,20 @@
+---
+docker_package_info:
+  pkg_mgr: apt
+  pkgs:
+    - name: "docker-engine"
+      force: yes
+
+docker_repo_key_info:
+  pkg_key: apt_key
+  url: https://apt.dockerproject.org/gpg
+  repo_keys:
+    - 58118E89F3A912897C070ADBF76221572C52609D
+
+docker_repo_info:
+  pkg_repo: apt_repository
+  repos:
+    - >
+       deb https://apt.dockerproject.org/repo
+       {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
+       main

--- a/contrib/roles/linux/kubernetes/tasks/distribute_binaries.yml
+++ b/contrib/roles/linux/kubernetes/tasks/distribute_binaries.yml
@@ -1,0 +1,15 @@
+---
+- name: Kubernetes bins | distribute Linux minion binaries
+  copy:
+    src: "{{ansible_tmp_dir}}/{{item}}"
+    dest: "{{ kubernetes_binaries_info.install_path }}/{{item}}"
+    owner: root
+    group: root
+    mode: 0755
+  with_items:
+    - kube-apiserver
+    - kube-scheduler
+    - kube-controller-manager
+    - kubelet
+    - kube-proxy
+    - kubectl

--- a/contrib/roles/linux/kubernetes/tasks/download_k8s_binaries.yml
+++ b/contrib/roles/linux/kubernetes/tasks/download_k8s_binaries.yml
@@ -1,0 +1,59 @@
+---
+- name: Kubernetes bins | create temp directory
+  file:
+    path: "{{ kubernetes_binaries_info.tmp_download_path }}"
+    state: directory
+    mode: 0755
+
+- name: Kubernetes bins | get kubernetes.tar.gz archive
+  get_url:
+    url: "{{ kubernetes_binaries_info.kubernetes_targz_link }}"
+    dest: "{{ kubernetes_binaries_info.tmp_download_path }}/kubernetes.tar.gz"
+    force_basic_auth: yes
+    timeout: 30
+  retries: 3
+
+- name: Kubernetes bins | unarchive tar.gz
+  unarchive:
+    src: "{{ kubernetes_binaries_info.tmp_download_path }}/kubernetes.tar.gz"
+    dest: "{{ kubernetes_binaries_info.tmp_download_path }}"
+    remote_src: yes
+
+- name: Kubernetes bins | download kubernetes binaries
+  action: shell yes | "{{ kubernetes_binaries_info.tmp_download_path }}/kubernetes/cluster/get-kube-binaries.sh"
+
+- name: Kubernetes bins | unarchive binaries
+  unarchive:
+    src: "{{ kubernetes_binaries_info.tmp_download_path }}/kubernetes/server/kubernetes-server-linux-amd64.tar.gz"
+    dest: "{{ kubernetes_binaries_info.tmp_download_path }}/kubernetes/server"
+    remote_src: yes
+
+- name: Kubernetes bins | install Linux master binaries
+  copy:
+    src: "{{ kubernetes_binaries_info.tmp_download_path }}/kubernetes/server/kubernetes/server/bin/{{item}}"
+    dest: "{{ kubernetes_binaries_info.install_path }}/{{item}}"
+    owner: root
+    group: root
+    mode: 0755
+    remote_src: yes
+  with_items:
+    - kube-apiserver
+    - kube-scheduler
+    - kube-controller-manager
+    - kubelet
+    - kube-proxy
+    - kubectl
+
+- name: Kubernetes bins | downloading Windows binaries
+  get_url:
+    url: "{{ kubernetes_binaries_info.windows_bins_link }}"
+    dest: "{{ kubernetes_binaries_info.tmp_download_path }}/winbins.tar.gz"
+    force_basic_auth: yes
+    timeout: 30
+  retries: 3
+
+- name: Kubernetes bins | unarchive Windows binaries
+  unarchive:
+    src: "{{ kubernetes_binaries_info.tmp_download_path }}/winbins.tar.gz"
+    dest: "{{ kubernetes_binaries_info.tmp_download_path }}/"
+    remote_src: yes

--- a/contrib/roles/linux/kubernetes/tasks/fetch_k8s_binaries.yml
+++ b/contrib/roles/linux/kubernetes/tasks/fetch_k8s_binaries.yml
@@ -1,0 +1,24 @@
+---
+- name: Kubernetes bins | fetch Linux binaries to the ansible host
+  fetch:
+    fail_on_missing: yes
+    flat: yes
+    src: "{{kubernetes_binaries_info.tmp_download_path}}/kubernetes/server/kubernetes/server/bin/{{item}}"
+    dest: "{{ansible_tmp_dir}}/{{item}}"
+  with_items:
+    - kube-apiserver
+    - kube-scheduler
+    - kube-controller-manager
+    - kubelet
+    - kube-proxy
+    - kubectl
+
+- name: Kubernetes bins | fetch Windows binaries to the ansible host
+  fetch:
+    fail_on_missing: yes
+    flat: yes
+    src: "{{kubernetes_binaries_info.tmp_download_path}}/kubernetes/node/bin/{{item}}"
+    dest: "{{ansible_tmp_dir}}/{{item}}"
+  with_items:
+    - kubelet.exe
+    - kubectl.exe

--- a/contrib/roles/linux/kubernetes/tasks/generate_certs_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/generate_certs_master.yml
@@ -1,0 +1,97 @@
+---
+- name: Kubernetes Certs | create temp folder
+  file:
+    path: "{{ kubernetes_certificates.tmp_generate_path }}"
+    state: directory
+    mode: 0755
+
+- name: Kubernetes Certs | create make-certs
+  lineinfile:
+    path: "{{ kubernetes_certificates.tmp_generate_path }}/make-certs"
+    create: yes
+    mode: 0755
+    line: |
+      #!/bin/bash -
+
+      set -o errexit
+      set -o nounset
+      set -o pipefail
+
+      cert_group=kube-cert
+      cert_dir=/etc/kubernetes/tls
+
+      pem_ca=$cert_dir/ca.pem
+      pem_ca_key=$cert_dir/ca-key.pem
+      pem_server=$cert_dir/apiserver.pem
+      pem_server_key=$cert_dir/apiserver-key.pem
+      pem_server_csr=$cert_dir/apiserver-csr.pem
+
+      pem_admin=$cert_dir/admin.pem
+      pem_admin_key=$cert_dir/admin-key.pem
+      pem_admin_csr=$cert_dir/admin-csr.pem
+
+      # Make sure cert group exists
+      [ $(getent group $cert_group) ] || groupadd -r $cert_group
+
+      # Generate TLS artifacts
+      mkdir -p "$cert_dir"
+      rm -rf "$cert_dir/*"
+
+      openssl genrsa -out $pem_ca_key 2048
+      openssl req -x509 -new -nodes -key $pem_ca_key -days 10000 -out $pem_ca -subj "/CN=kube-ca"
+
+      openssl genrsa -out $pem_server_key 2048
+      openssl req -new -key $pem_server_key -out $pem_server_csr -subj "/CN={{ansible_hostname}}" -config openssl.cnf
+      openssl x509 -req -in $pem_server_csr -CA $pem_ca -CAkey $pem_ca_key -CAcreateserial -out $pem_server -days 365 -extensions v3_req -extfile openssl.cnf
+
+      # Make server certs accessible to apiserver.
+      chgrp $cert_group $pem_ca $pem_ca_key $pem_server $pem_server_key
+      chmod 600 $pem_ca_key $pem_server_key
+      chmod 660 $pem_ca $pem_server
+
+      # Generate admin
+      openssl genrsa -out $pem_admin_key 2048
+      openssl req -new -key $pem_admin_key -out $pem_admin_csr -subj "/CN=kube-admin"
+      openssl x509 -req -in $pem_admin_csr -CA $pem_ca -CAkey $pem_ca_key -CAcreateserial -out $pem_admin -days 365
+
+- name: Kubernetes Certs | create openssl.cnf
+  lineinfile:
+    path: "{{ kubernetes_certificates.tmp_generate_path }}/openssl.cnf"
+    create: yes
+    line: |
+      [req]
+      req_extensions = v3_req
+      distinguished_name = req_distinguished_name
+      [req_distinguished_name]
+      [ v3_req ]
+      basicConstraints = CA:FALSE
+      keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+      subjectAltName = @alt_names
+      [alt_names]
+      DNS.1 = kubernetes
+      DNS.2 = kubernetes.default
+      DNS.3 = kubernetes.default.svc
+      DNS.4 = kubernetes.default.svc.{{ kubernetes_cluster_info.K8S_DNS_DOMAIN }}
+      IP.1 = {{ kubernetes_cluster_info.K8S_API_SERVICE_IP }}
+      IP.2 = {{ host_internal_ip }}
+
+- name: Kubernetes Certs | remove existing kubernetes certs
+  file:
+    path: /etc/kubernetes
+    state: absent
+
+- name: Kubernetes Certs | create kubernetes certs folder
+  file:
+    path: /etc/kubernetes
+    state: directory
+    mode: 0755
+
+- name: Kubernetes Certs | Generating Certificates
+  shell: |
+    cd {{ kubernetes_certificates.tmp_generate_path }}
+    ./make-certs
+
+- name: Kubernetes Certs | Removing temp directory
+  file:
+    path: "{{ kubernetes_certificates.tmp_generate_path }}"
+    state: absent

--- a/contrib/roles/linux/kubernetes/tasks/generate_certs_minion.yml
+++ b/contrib/roles/linux/kubernetes/tasks/generate_certs_minion.yml
@@ -1,0 +1,106 @@
+---
+- file:
+    path: /etc/kubernetes/tls/
+    state: directory
+    mode: 0755
+
+- copy:
+    src: "{{ansible_tmp_dir}}/k8s_{{item}}"
+    dest: "/etc/kubernetes/tls/{{item}}"
+  with_items:
+    - ca.pem
+    - ca-key.pem
+
+- file:
+    path: "{{ kubernetes_certificates.tmp_generate_path }}"
+    state: directory
+    mode: 0755
+
+- lineinfile:
+    path: "{{ kubernetes_certificates.tmp_generate_path }}/make-certs"
+    mode: 0755
+    create: yes
+    line: |
+      #!/bin/bash -
+
+      #set -o errexit
+      set -o nounset
+      set -o pipefail
+
+      cert_group=kube-cert
+      cert_dir=/etc/kubernetes/tls
+
+      mkdir -p "$cert_dir"
+      rm -rf "$cert_dir/*"
+
+      pem_ca=$cert_dir/ca.pem
+      pem_ca_key=$cert_dir/ca-key.pem
+
+      pem_node=$cert_dir/node.pem
+      pem_node_key=$cert_dir/node-key.pem
+      pem_node_csr=$cert_dir/node-csr.pem
+
+      # Make sure cert group exists
+      #groupadd -r $cert_group
+
+      # Make sure perms are right
+      chgrp $cert_group $pem_ca $pem_ca_key
+      chmod 600 $pem_ca_key
+      chmod 660 $pem_ca
+
+      # Generate TLS artifacts
+      openssl genrsa -out $pem_node_key 2048
+      openssl req -new -key $pem_node_key -out $pem_node_csr -subj "/CN={{ ansible_hostname }}" -config openssl.cnf
+      openssl x509 -req -in $pem_node_csr -CA $pem_ca -CAkey $pem_ca_key -CAcreateserial -out $pem_node -days 365 -extensions v3_req -extfile openssl.cnf
+
+      # Make server certs accessible to apiserver.
+      chgrp $cert_group $pem_node $pem_node_key
+      chmod 600 $pem_node_key
+      chmod 660 $pem_node $pem_ca
+
+- lineinfile:
+    path: "{{ kubernetes_certificates.tmp_generate_path }}/openssl.cnf"
+    create: yes
+    line: |
+      [req]
+      req_extensions = v3_req
+      distinguished_name = req_distinguished_name
+      [req_distinguished_name]
+      [ v3_req ]
+      basicConstraints = CA:FALSE
+      keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+      subjectAltName = @alt_names
+      [alt_names]
+      IP.1 = {{ host_internal_ip }}
+
+- lineinfile:
+    path: /etc/kubernetes/kubeconfig.yaml
+    create: yes
+    line: |
+      apiVersion: v1
+      kind: Config
+      clusters:
+      - cluster:
+          certificate-authority: /etc/kubernetes/tls/ca.pem
+          server: https://{{ kubernetes_cluster_info.MASTER_IP }}
+        name: local
+      users:
+      - name: kubelet
+        user:
+          client-certificate: /etc/kubernetes/tls/node.pem
+          client-key: /etc/kubernetes/tls/node-key.pem
+      contexts:
+      - context:
+          cluster: local
+          user: kubelet
+        name: kubelet-context
+      current-context: kubelet-context
+
+- name: Kubernetes certs | Generating Certificates
+  shell: |
+    cd {{ kubernetes_certificates.tmp_generate_path }}
+    ./make-certs
+
+- file:
+    path: "{{ kubernetes_certificates.tmp_generate_path }}"
+    state: absent

--- a/contrib/roles/linux/kubernetes/tasks/generate_global_vars.yml
+++ b/contrib/roles/linux/kubernetes/tasks/generate_global_vars.yml
@@ -1,0 +1,39 @@
+---
+- name: Kubernetes global vars | Delete global vars
+  file:
+    path: "/tmp/generated_global_vars.yml"
+    state: absent
+  changed_when: false
+
+- name: Kubernetes global vars | Fetch Token
+  shell: kubectl describe secret $(kubectl get secrets | grep default | cut -f1 -d ' ') | grep -E '^token' | cut -f2 -d':' | tr -d '\t'
+  register: fetch_token
+  changed_when: false
+
+- name: Kubernetes global vars | Register Token
+  set_fact:
+    TOKEN: "{{fetch_token.stdout | trim}}"
+
+- name: Kubernetes global vars | Fetch global variables
+  lineinfile:
+    path: "/tmp/generated_global_vars.yml"
+    create: yes
+    line: |
+      ---
+      MASTER_IP: {{host_public_ip}}
+      MASTER_INTERNAL_IP_OVN: {{MASTER_INTERNAL_IP}}
+      MASTER_INTERNAL_IP: {{host_internal_ip}}
+      TOKEN: {{TOKEN}}
+      CLUSTER_SUBNET: {{CLUSTER_SUBNET}}
+      SERVICE_CLUSTER_IP_RANGE: {{SERVICE_CLUSTER_IP_RANGE}}
+      K8S_DNS_DOMAIN: {{K8S_DNS_DOMAIN}}
+      K8S_DNS_SERVICE_IP: {{K8S_DNS_SERVICE_IP}}
+      K8S_API_SERVICE_IP: {{K8S_API_SERVICE_IP}}
+  changed_when: false
+
+- name: Kubernetes global vars | Fetch vars
+  fetch:
+    fail_on_missing: yes
+    flat: yes
+    src: /tmp/generated_global_vars.yml
+    dest: "{{ansible_tmp_dir}}/generated_global_vars.yml"

--- a/contrib/roles/linux/kubernetes/tasks/init_gateway.yml
+++ b/contrib/roles/linux/kubernetes/tasks/init_gateway.yml
@@ -1,0 +1,52 @@
+---
+- name: OVN Gateway | Set init_gateway to false
+  set_fact:
+    init_gateway: false
+
+# The following makes sure that the second time we enter init_gateway we actually
+# fetch the physical interface name and not the bridge name
+# TODO: interfaces that start with 'br' are not supported
+- name: OVN Gateway | Physical interface
+  set_fact:
+    physical_interface_name: "{{ interface_name }}"
+  when: interface_name[0:2] != "br"
+
+- name: OVN Gateway | Physical interface
+  set_fact:
+    physical_interface_name: "{{ interface_name[2:] }}"
+  when: interface_name[0:2] == "br"
+
+- name: OVN Gateway | Create service OVN Kube Gateway
+  lineinfile:
+    path: /etc/systemd/system/ovnkube-gateway-helper.service
+    create: yes
+    line: |
+      [Unit]
+      Description=OVN Gateway Helper
+      Documentation=https://github.com/openvswitch/ovn-kubernetes
+      [Service]
+      ExecStart=/usr/bin/ovnkube \
+        -init-node "{{ ansible_hostname }}" \
+        -cluster-subnet "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
+        -k8s-token {{TOKEN}} \
+        -k8s-cacert /etc/openvswitch/k8s-ca.crt \
+        -k8s-apiserver "http://{{ kubernetes_cluster_info.MASTER_IP }}:8080" \
+        -service-cluster-ip-range "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
+        -nodeport \
+        -init-gateways \
+        -gateway-interface={{interface_name}} \
+        -gateway-nexthop="{{gateway_next_hop}}" \
+        -nb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6641 \
+        -sb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6642
+      Restart=on-failure
+      RestartSec=10
+      WorkingDirectory=/root/
+      [Install]
+      WantedBy=multi-user.target
+
+- name: OVN Gateway | start OVN Kube Gateway Helper
+  service:
+    name: "ovnkube-gateway-helper"
+    enabled: yes
+    state: restarted
+    daemon_reload: yes

--- a/contrib/roles/linux/kubernetes/tasks/main.yml
+++ b/contrib/roles/linux/kubernetes/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+- name: Kubernetes | include global vars for minions
+  include_vars: "{{ansible_tmp_dir}}/generated_global_vars.yml"
+  when: not master
+
+- name: Kubernetes | include vars
+  include_vars: "{{ ansible_distribution|lower }}.yml"
+  tags:
+    - facts
+
+- include_tasks: set_ip_facts.yml
+  tags:
+    - facts
+
+- name: debug
+  debug:
+    msg: "{{ansible_hostname}}"
+
+- name: Kubernetes | Expecting all binaries to be already present
+  set_fact:
+    binaries_missing: false
+
+- name: Kubernetes | Checking if binaries are already present on ansible machine
+  local_action: stat path="{{ansible_tmp_dir}}/{{item}}"
+  register: stat_bins_exists
+  with_items: "{{kubernetes_binaries}}"
+
+- name: Kubernetes | Checking all binaries
+  set_fact:
+    binaries_missing: true
+  with_items:
+    - "{{stat_bins_exists.results}}"
+  loop_control:
+    label: "{{item.item}}"
+  when: not item.stat.exists
+
+- debug:
+    msg: "Binaries are missing: {{binaries_missing}}"
+
+- name: Kubernetes | Get Kubernetes binaries
+  include_tasks: ./download_k8s_binaries.yml
+  when: binaries_missing or (binaries_missing and master)
+
+- name: Kubernetes | Get Kubernetes binaries
+  include_tasks: ./fetch_k8s_binaries.yml
+  when: binaries_missing
+
+- name: Kubernetes | Distribute binaries for minions
+  include_tasks: ./distribute_binaries.yml
+  when: minion
+
+# Using this as a check to see if the node has been already prepared to be a master node
+- stat:
+    path: "/etc/systemd/system/ovn-k8s-watcher.service"
+  register: ovnk8swatcher_stats
+
+- name: Kubernetes | Prepare master
+  include_tasks: ./prepare_master.yml
+  when: master and not ovnk8swatcher_stats.stat.exists or force_regen_certs
+
+# Using this as a check to see if the node has been already prepared to be a minion node
+- stat:
+    path: "/etc/openvswitch/k8s-ca.crt"
+  register: certovs
+
+- name: Kubernetes | Prepare minion
+  include_tasks: ./prepare_minion.yml
+  when: minion and not certovs.stat.exists or force_regen_certs
+
+- include_tasks: generate_global_vars.yml
+  when: master

--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -1,0 +1,328 @@
+---
+- file:
+    path: /etc/systemd/system/kube-apiserver.service
+    state: absent
+- name: Kubernetes Master | register kube-apiserver
+  lineinfile:
+    path: /etc/systemd/system/kube-apiserver.service
+    create: yes
+    line: |
+      [Unit]
+      Description=Kubernetes API Server
+      Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+      [Service]
+      ExecStart=/usr/bin/kube-apiserver \
+        --bind-address=0.0.0.0 \
+        --service-cluster-ip-range={{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }} \
+        --address=0.0.0.0 \
+        --etcd-servers=http://127.0.0.1:2379 \
+        --v=2 \
+        --insecure-bind-address={{ host_public_ip }} \
+        --allow-privileged=true \
+        --anonymous-auth=false \
+        --secure-port=443 \
+        --advertise-address={{ host_internal_ip }} \
+        --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota \
+        --tls-cert-file=/etc/kubernetes/tls/apiserver.pem \
+        --tls-private-key-file=/etc/kubernetes/tls/apiserver-key.pem \
+        --client-ca-file=/etc/kubernetes/tls/ca.pem \
+        --service-account-key-file=/etc/kubernetes/tls/apiserver-key.pem \
+        --runtime-config=extensions/v1beta1=true,extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true
+      Restart=on-failure
+      RestartSec=10
+      WorkingDirectory=/root/
+      [Install]
+      WantedBy=multi-user.target
+
+- file:
+    path: /etc/systemd/system/kube-controller-manager.service
+    state: absent
+- name: Kubernetes Master | register kube-controller-manager
+  lineinfile:
+    path: /etc/systemd/system/kube-controller-manager.service
+    create: yes
+    line: |
+      [Unit]
+      Description=Kubernetes Controller Manager
+      Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+      [Service]
+      ExecStart=/usr/bin/kube-controller-manager \
+        --master={{ host_public_ip }}:8080 \
+        --v=2 \
+        --cluster-cidr={{ kubernetes_cluster_info.CLUSTER_SUBNET }} \
+        --service-account-private-key-file=/etc/kubernetes/tls/apiserver-key.pem \
+        --root-ca-file=/etc/kubernetes/tls/ca.pem \
+        --cluster-signing-cert-file=/etc/kubernetes/tls/ca.pem \
+        --cluster-signing-key-file=/etc/kubernetes/tls/ca-key.pem \
+        --insecure-experimental-approve-all-kubelet-csrs-for-group=system:kubelet-bootstrap
+      Restart=on-failure
+      RestartSec=10
+      [Install]
+      WantedBy=multi-user.target
+
+- file:
+    path: /etc/systemd/system/kube-scheduler.service
+    state: absent
+- name: Kubernetes Master | register kube-scheduler
+  lineinfile:
+    path: /etc/systemd/system/kube-scheduler.service
+    create: yes
+    line: |
+      [Unit]
+      Description=Kubernetes Scheduler
+      Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+      [Service]
+      ExecStart=/usr/bin/kube-scheduler \
+        --master={{ host_public_ip }}:8080 \
+        --v=2 \
+        --leader-elect=true
+      Restart=on-failure
+      RestartSec=10
+      [Install]
+      WantedBy=multi-user.target
+
+- file:
+    path: /etc/systemd/system/etcd3.service
+    state: absent
+- name: Kubernetes Master | register etcd3
+  lineinfile:
+    path: /etc/systemd/system/etcd3.service
+    create: yes
+    line: |
+      [Unit]
+      Description=Etcd store
+      Documentation=https://github.com/coreos/etcd
+      [Service]
+      ExecStartPre=-/usr/bin/docker rm -f etcd
+      ExecStart=/usr/bin/docker run --name etcd \
+        --net=host \
+        --volume /var/etcd:/var/etcd \
+        quay.io/coreos/etcd:v{{ kubernetes_cluster_info.ETCD_VERSION }} \
+          /usr/local/bin/etcd \
+          --data-dir /var/etcd/data
+      Restart=on-failure
+      RestartSec=10
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Kubernetes Master | Checking certs
+  stat:
+    path: /etc/kubernetes/tls/admin.pem
+  register: certs_check
+
+- include_tasks: ./generate_certs_master.yml
+  when: not certs_check.stat.exists or force_regen_certs
+
+- name: Kubernetes Master | Fetching certificates on the ansible host
+  fetch:
+    flat: yes
+    src: /etc/kubernetes/tls/{{item}}
+    dest: "{{ansible_tmp_dir}}/k8s_{{item}}"
+  with_items:
+    - ca.pem
+    - ca-key.pem
+
+- name: Kubernetes Master | restart all services
+  service:
+    name: "{{item}}"
+    enabled: yes
+    state: restarted
+    daemon_reload: yes
+  with_items:
+    - etcd3
+    - kube-apiserver
+    - kube-controller-manager
+    - kube-scheduler
+
+- name: Kubernetes Master | Setting kubectl context
+  shell: |
+    kubectl config set-cluster default-cluster --server=https://{{ host_public_ip }} --certificate-authority=/etc/kubernetes/tls/ca.pem
+    kubectl config set-credentials default-admin --certificate-authority=/etc/kubernetes/tls/ca.pem --client-key=/etc/kubernetes/tls/admin-key.pem --client-certificate=/etc/kubernetes/tls/admin.pem
+    kubectl config set-context local --cluster=default-cluster --user=default-admin
+    kubectl config use-context local
+
+# TODO: Improve this wait
+- name: Wait 30 seconds for kube-apiserver to start
+  pause:
+    seconds: 30
+
+- name: Kubernetes Master | Fetch Token
+  shell: kubectl describe secret $(kubectl get secrets | grep default | cut -f1 -d ' ') | grep -E '^token' | cut -f2 -d':' | tr -d '\t'
+  register: fetch_token
+
+- name: Kubernetes Master | Register Token
+  set_fact:
+    TOKEN: "{{fetch_token.stdout | trim}}"
+
+- file:
+    path: /etc/systemd/system/ovn-k8s-watcher.service
+    state: absent
+- name: Kubernetes Master | Create service OVN Kube
+  lineinfile:
+    path: /etc/systemd/system/ovn-k8s-watcher.service
+    create: yes
+    line: |
+      [Unit]
+      Description=OVN watches the Kubernetes API
+      Documentation=https://github.com/openvswitch/ovn-kubernetes#watchers-on-master-node
+      [Service]
+      ExecStart=/usr/bin/ovnkube \
+        -init-master "{{ ansible_hostname }}" \
+        -cluster-subnet "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
+        -service-cluster-ip-range "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
+        -nodeport \
+        -net-controller \
+        -k8s-token {{TOKEN}} \
+        -k8s-cacert /etc/openvswitch/k8s-ca.crt \
+        -k8s-apiserver "https://{{ host_public_ip }}" \
+        -nb-address tcp://127.0.0.1:6641 \
+        -sb-address tcp://127.0.0.1:6642
+      Restart=on-failure
+      RestartSec=10
+      WorkingDirectory=/root/
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Kubernetes Master | Ensure /etc/hosts is updated
+  lineinfile:
+    path: /etc/hosts
+    line: "{{ host_public_ip }} {{ ansible_hostname }}"
+
+- name: Kubernetes Master | Enabling OVN to listen on 6641 and 6642
+  shell: |
+    ovn-nbctl set-connection ptcp:6641
+    ovn-sbctl set-connection ptcp:6642
+
+- name: Kubernetes Master | Setting OVN external_ids
+  shell: |
+    ovs-vsctl set Open_vSwitch . external_ids:ovn-remote="tcp:{{ host_public_ip }}:6642" \
+      external_ids:ovn-nb="tcp:{{ host_public_ip }}:6641" \
+      external_ids:ovn-encap-ip="{{ host_internal_ip }}" \
+      external_ids:ovn-encap-type="geneve"
+
+# TODO: enable this for future GCE support in the playbooks
+# - name: Kubernetes Master | Setting OVN external_ids when GCE
+#   shell: |
+#     ovs-vsctl set Open_vSwitch . external_ids:ovn-encap-ip="{{ host_public_ip }}"
+#   when: GCE
+
+- name: Kubernetes Master | Prepare OVN certs
+  shell: |
+    ovs-vsctl set Open_vSwitch . \
+      external_ids:k8s-api-server="https://{{ host_public_ip }}" \
+      external_ids:k8s-api-token="{{TOKEN}}"
+
+    ln -fs /etc/kubernetes/tls/ca.pem /etc/openvswitch/k8s-ca.crt
+
+- name: Kubernetes Master | start ovn-k8s-watcher
+  service:
+    name: "ovn-k8s-watcher"
+    enabled: yes
+    state: restarted
+    daemon_reload: yes
+
+- file:
+    path: /root/{{item}}.yaml
+    state: absent
+  with_items:
+    - apache-pod
+    - nginx-pod
+    - apache-e-w
+    - apache-n-s
+    - nano-pod-1709
+- name: Kubernetes Master | Create test yamls
+  lineinfile:
+    path: /root/apache-pod.yaml
+    create: yes
+    line: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: apachetwin
+        labels:
+          name: webserver
+      spec:
+        containers:
+        - name: apachetwin
+          image: fedora/apache
+        nodeSelector:
+          beta.kubernetes.io/os: linux
+- name: Create test yamls
+  lineinfile:
+    path: /root/apache-e-w.yaml
+    create: yes
+    line: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          name: apacheservice
+          role: service
+        name: apacheservice
+      spec:
+        ports:
+          - port: 8800
+            targetPort: 80
+            protocol: TCP
+            name: tcp
+        selector:
+          name: webserver
+- name: Create test yamls
+  lineinfile:
+    path: /root/apache-n-s.yaml
+    create: yes
+    line: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          name: apacheexternal
+          role: service
+        name: apacheexternal
+      spec:
+        ports:
+          - port: 8800
+            targetPort: 80
+            protocol: TCP
+            name: tcp
+        selector:
+          name: webserver
+        type: NodePort
+- name: Create test yamls
+  lineinfile:
+    path: /root/nginx-pod.yaml
+    create: yes
+    line: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: nginxtwin
+        labels:
+          name: webserver
+      spec:
+        containers:
+        - name: nginxtwin
+          image: nginx
+        nodeSelector:
+          beta.kubernetes.io/os: linux
+- name: Create test yamls
+  lineinfile:
+    path: /root/nano-pod-1709.yaml
+    create: yes
+    line: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: nano-1709
+        labels:
+          name: webserver
+      spec:
+        containers:
+        - name: nano
+          image: ovnkubernetes/pause
+          imagePullPolicy: IfNotPresent
+        - name: nano2
+          image: microsoft/iis:windowsservercore-1709
+          imagePullPolicy: IfNotPresent
+        nodeSelector:
+          beta.kubernetes.io/os: windows

--- a/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
@@ -1,0 +1,107 @@
+---
+- name: Kubernetes Minion | Setting OVN external_ids
+  shell: |
+    ovs-vsctl set Open_vSwitch . external_ids:ovn-remote="tcp:{{ kubernetes_cluster_info.MASTER_IP }}:6642" \
+      external_ids:ovn-nb="tcp:{{ kubernetes_cluster_info.MASTER_IP }}:6641" \
+      external_ids:ovn-encap-ip="{{ host_public_ip }}" \
+      external_ids:ovn-encap-type="geneve"
+
+- stat:
+    path: /etc/kubernetes/tls/ca.pem
+  register: certs_check
+
+- include_tasks: ./generate_certs_minion.yml
+  when: not certs_check.stat.exists
+
+- file:
+    path: /etc/systemd/system/kubelet.service
+    state: absent
+- name: Kubernetes Minion | Create service kubelet
+  lineinfile:
+    path: /etc/systemd/system/kubelet.service
+    create: yes
+    line: |
+      [Unit]
+      Description=Kubelet Server
+      Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+      [Service]
+      ExecStart=/usr/bin/kubelet \
+        --network-plugin=cni \
+        --allow-privileged=true \
+        --hostname-override={{ ansible_hostname }} \
+        --cluster-dns={{ kubernetes_cluster_info.K8S_DNS_SERVICE_IP }} \
+        --cluster-domain={{ kubernetes_cluster_info.K8S_DNS_DOMAIN }} \
+        --cni-bin-dir=/opt/cni/bin \
+        --cni-conf-dir=/etc/cni/net.d \
+        --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
+        --tls-cert-file=/etc/kubernetes/tls/node.pem \
+        --tls-private-key-file=/etc/kubernetes/tls/node-key.pem \
+        --fail-swap-on=false
+      Restart=on-failure
+      RestartSec=10
+      WorkingDirectory=/root/
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Kubernetes Minion | start kubelet
+  service:
+    name: "kubelet"
+    enabled: yes
+    state: restarted
+    daemon_reload: yes
+
+- name: Kubernetes Minion | Setting kubectl context
+  shell: |
+    kubectl config set-cluster default-cluster --server=https://{{ kubernetes_cluster_info.MASTER_IP }} --certificate-authority=/etc/kubernetes/tls/ca.pem
+    kubectl config set-credentials default-admin --certificate-authority=/etc/kubernetes/tls/ca.pem --client-key=/etc/kubernetes/tls/node-key.pem --client-certificate=/etc/kubernetes/tls/node.pem
+    kubectl config set-context local --cluster=default-cluster --user=default-admin
+    kubectl config use-context local
+
+- name: Kubernetes Minion | Prepare OVN certs
+  shell: |
+    ovs-vsctl set Open_vSwitch . \
+      external_ids:k8s-api-server="http://{{ host_public_ip }}:8080" \
+      external_ids:k8s-api-token="{{TOKEN}}"
+
+    ln -fs /etc/kubernetes/tls/ca.pem /etc/openvswitch/k8s-ca.crt
+
+- name: Kubernetes Minion | Ensure /etc/hosts is updated
+  lineinfile:
+    path: /etc/hosts
+    line: "{{ host_public_ip }} {{ ansible_hostname }}"
+
+- name: Kubernetes Minion | Create CNI binaries folder
+  file:
+    path: "/opt/cni/bin"
+    state: directory
+    mode: 0755
+
+- name: Kubernetes Minion | get cni archive
+  get_url:
+    url: "{{kubernetes_binaries_info.cni_linux_download_link}}"
+    dest: "/opt/cni/bin/cni.tgz"
+    force_basic_auth: yes
+    timeout: 30
+  retries: 3
+
+- name: Kubernetes Minion | unarchive tar.gz
+  unarchive:
+    src: "/opt/cni/bin/cni.tgz"
+    dest: "/opt/cni/bin/"
+    remote_src: yes
+
+- name: Kubernetes Minion | Minion init
+  shell: |
+    /usr/bin/ovnkube \
+        --init-node "{{ ansible_hostname }}" \
+        --cluster-subnet "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
+        --k8s-token {{TOKEN}} \
+        --k8s-cacert /etc/openvswitch/k8s-ca.crt \
+        --k8s-apiserver "http://{{ kubernetes_cluster_info.MASTER_IP }}:8080" \
+        --nb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6641 \
+        --sb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6642
+  when: not init_gateway
+
+- name: Kubernetes Minion | Minion init with gateway
+  include_tasks: ./init_gateway.yml
+  when: init_gateway

--- a/contrib/roles/linux/kubernetes/tasks/set_ip_facts.yml
+++ b/contrib/roles/linux/kubernetes/tasks/set_ip_facts.yml
@@ -1,0 +1,37 @@
+---
+# Gather IP facts from ipify.org
+- name: get my public IP
+  ipify_facts:
+  retries: 3
+
+- name: set internal IP
+  set_fact:
+    host_internal_ip: "{{ ansible_default_ipv4.address }}"
+
+# TODO: enable this for future GCE support in the playbooks
+# - name: set public IP
+#   set_fact:
+#     host_public_ip: "{{ ipify_public_ip }}"
+#   when: GCE
+
+- name: set public IP
+  set_fact:
+    host_public_ip: "{{ host_internal_ip }}"
+  # when: not GCE
+
+- name: set interface name
+  set_fact:
+    interface_name: "{{ ansible_default_ipv4.alias }}"
+
+- name: set interface gateway
+  set_fact:
+    interface_gateway: "{{ ansible_default_ipv4.gateway }}"
+
+- name: set gateway next hop
+  set_fact:
+    gateway_next_hop: "{{ ansible_default_ipv4.gateway }}"
+
+- debug: var=ansible_all_ipv4_addresses
+- debug: var=host_internal_ip
+- debug: var=host_public_ip
+- debug: var=gateway_next_hop

--- a/contrib/roles/linux/kubernetes/vars/ubuntu.yml
+++ b/contrib/roles/linux/kubernetes/vars/ubuntu.yml
@@ -1,0 +1,32 @@
+---
+kubernetes_binaries_info:
+  install_path: /usr/bin
+  tmp_download_path: /tmp/k8s_bins
+  # Download link from here https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.10.md#downloads-for-v1100
+  kubernetes_targz_link: https://dl.k8s.io/v1.10.0/kubernetes.tar.gz
+  # Download link from here https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.10.md#node-binaries
+  windows_bins_link: https://dl.k8s.io/v1.10.0/kubernetes-node-windows-amd64.tar.gz
+  cni_linux_download_link: https://github.com/containernetworking/cni/releases/download/v0.3.0/cni-v0.3.0.tgz
+
+kubernetes_cluster_info:
+  MASTER_IP: "{{MASTER_IP | default('the master node does not need this')}}"
+  CLUSTER_SUBNET: "{{CLUSTER_SUBNET}}"
+  MASTER_INTERNAL_IP: "{{MASTER_INTERNAL_IP}}"
+  SERVICE_CLUSTER_IP_RANGE: "{{SERVICE_CLUSTER_IP_RANGE}}"
+  K8S_DNS_DOMAIN: "{{K8S_DNS_DOMAIN}}"
+  K8S_DNS_SERVICE_IP: "{{K8S_DNS_SERVICE_IP}}"
+  K8S_API_SERVICE_IP: "{{K8S_API_SERVICE_IP}}"
+  ETCD_VERSION: "3.1.2"
+
+kubernetes_certificates:
+  tmp_generate_path: /tmp/k8s_certs
+
+kubernetes_binaries:
+  - kube-apiserver
+  - kube-scheduler
+  - kube-controller-manager
+  - kubelet
+  - kube-proxy
+  - kubectl
+  - kubelet.exe
+  - kubectl.exe

--- a/contrib/roles/linux/openvswitch/tasks/build_install_release_ovs.yml
+++ b/contrib/roles/linux/openvswitch/tasks/build_install_release_ovs.yml
@@ -1,0 +1,95 @@
+---
+- name: OVS | ensure requirements are installed
+  action: "{{ ovs_package_info.pkg_mgr }}"
+  args:
+    pkg: "{{item.name}}"
+    force: "{{item.force|default(omit)}}"
+    state: present
+  register: ovs_task_result
+  until: ovs_task_result|succeeded
+  retries: 3
+  with_items: "{{ ovs_package_info.pkgs }}"
+
+- name: OVS | get release build
+  get_url:
+    url: "{{ ovs_info.release_link }}"
+    dest: "{{ ovs_info.build_path }}/{{ ovs_info.release_name }}.tar.gz"
+    force_basic_auth: yes
+    mode: 0755
+    timeout: 30
+  retries: 3
+
+- name: OVS | unarchive tar.gz
+  unarchive:
+    src: "{{ ovs_info.build_path }}/{{ ovs_info.release_name }}.tar.gz"
+    dest: "{{ ovs_info.build_path }}"
+    remote_src: yes
+
+- name: OVS | build debs
+  action: shell cd {{ ovs_info.build_path }}/{{ ovs_info.release_name }}; make clean; make uninstall; dpkg-checkbuilddeps; fakeroot debian/rules clean; DEB_BUILD_OPTIONS='nocheck parallel=4' fakeroot debian/rules binary
+
+- name: OVS | install debs
+  apt: deb="{{ ovs_info.build_path }}/{{item}}{{ ovs_info.pkg_build_version }}_amd64.deb"
+  with_items:
+    - libopenvswitch_
+    - openvswitch-common_
+    - openvswitch-switch_
+    - ovn-common_
+    - ovn-host_
+
+- name: OVS | install additional debs
+  apt: deb="{{ ovs_info.build_path }}/{{item}}{{ ovs_info.pkg_build_version }}_all.deb"
+  with_items:
+    - openvswitch-datapath-dkms_
+    - python-openvswitch_         
+
+- name: OVS | install controller deb if applicable
+  apt: deb="{{ ovs_info.build_path }}/ovn-central_{{ ovs_info.pkg_build_version }}_amd64.deb"
+  when: controller
+
+- name: OVS | add modules
+  lineinfile:
+    path: "{{ ovs_info.modules_file_path }}"
+    create: yes
+    line: |
+      openvswitch
+      vport_stt
+      vport_geneve
+
+- name: OVS | reload modules
+  action: shell depmod -a
+
+- name: OVS | remove modprobe
+  modprobe:
+    name: "{{item}}"
+    state: absent
+  with_items:
+    - openvswitch
+    - vport-geneve
+
+- name: OVS | add modprobe
+  modprobe:
+    name: "{{item}}"
+    state: present
+  with_items:
+    - openvswitch
+    - vport-geneve
+
+# TODO: .deb packages are not creating services, we need this for ovnkube
+# when it tries to start/restart services
+- name: OVS | Mock OVS services
+  lineinfile:
+    path: "{{item}}"
+    create: yes
+    line: |
+      [Unit]
+      Description=openvswitch
+      Documentation=https://github.com/openvswitch/ovs
+      [Service]
+      ExecStart=/bin/bash sleep 1
+      [Install]
+      WantedBy=multi-user.target
+  with_items:
+    - /etc/systemd/system/openvswitch.service
+    - /etc/systemd/system/ovn-controller.service
+    - /etc/systemd/system/ovn-northd.service

--- a/contrib/roles/linux/openvswitch/tasks/download_install_packages.yml
+++ b/contrib/roles/linux/openvswitch/tasks/download_install_packages.yml
@@ -1,0 +1,81 @@
+---
+# Download debs:
+- name: OVS | downloading debs
+  get_url:
+    url: "{{ ovs_info.debs_targz_link }}"
+    dest: "{{ ovs_info.prebuilt_packages_download_path }}/ovs_debs.tar.gz"
+    force_basic_auth: yes
+    mode: 0755
+    timeout: 30
+  retries: 3
+
+- name: OVS | unarchive ovs_debs.tar.gz
+  unarchive:
+    src: "{{ ovs_info.prebuilt_packages_download_path }}/ovs_debs.tar.gz"
+    dest: "{{ ovs_info.prebuilt_packages_download_path }}"
+    remote_src: yes
+
+- name: OVS | install debs
+  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/{{item}}{{ ovs_info.prebuilt_version }}_amd64.deb"
+  with_items:
+    - libopenvswitch_
+    - openvswitch-common_
+    - openvswitch-switch_
+    - ovn-common_
+    - ovn-host_
+
+- name: OVS | install additional debs
+  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/{{item}}{{ ovs_info.prebuilt_version }}_all.deb"
+  with_items:
+    - openvswitch-datapath-dkms_
+    - python-openvswitch_         
+
+- name: OVS | install controller deb if applicable
+  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/ovn-central_{{ ovs_info.prebuilt_version }}_amd64.deb"
+  when: controller
+
+- name: OVS | add modules
+  lineinfile:
+    path: "{{ ovs_info.modules_file_path }}"
+    create: yes
+    line: |
+      openvswitch
+      vport_stt
+      vport_geneve
+
+- name: OVS | reload modules
+  action: shell depmod -a
+
+- name: OVS | remove modprobe
+  modprobe:
+    name: "{{item}}"
+    state: absent
+  with_items:
+    - openvswitch
+    - vport-geneve
+
+- name: OVS | add modprobe
+  modprobe:
+    name: "{{item}}"
+    state: present
+  with_items:
+    - openvswitch
+    - vport-geneve
+
+# TODO: make this better
+- name: OVS | Mock OVS services
+  lineinfile:
+    path: "{{item}}"
+    create: yes
+    line: |
+      [Unit]
+      Description=openvswitch
+      Documentation=https://github.com/openvswitch/ovs
+      [Service]
+      ExecStart=/bin/bash sleep 1
+      [Install]
+      WantedBy=multi-user.target
+  with_items:
+    - /etc/systemd/system/openvswitch.service
+    - /etc/systemd/system/ovn-controller.service
+    - /etc/systemd/system/ovn-northd.service

--- a/contrib/roles/linux/openvswitch/tasks/main.yml
+++ b/contrib/roles/linux/openvswitch/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: OVS | include global vars for minions
+  include_vars: "{{ansible_tmp_dir}}/generated_global_vars.yml"
+  when: not master
+
+- name: OVS | include vars
+  include_vars: "{{ ansible_distribution|lower }}.yml"
+  tags:
+    - facts
+
+- stat:
+    path: "{{ ovs_info.service_path }}"
+  register: ovs_service
+
+- name: OVS | build and install release ovs
+  include_tasks: ./build_install_release_ovs.yml
+  when: not ovs_service.stat.exists and not ovs_info.install_prebuilt_packages
+
+- name: OVS | Install OVS from prebuilt packages
+  include_tasks: ./download_install_packages.yml
+  when: not ovs_service.stat.exists and ovs_info.install_prebuilt_packages

--- a/contrib/roles/linux/openvswitch/vars/ubuntu.yml
+++ b/contrib/roles/linux/openvswitch/vars/ubuntu.yml
@@ -1,0 +1,39 @@
+---
+ovs_package_info:
+  pkg_mgr: apt
+  pkgs:
+    - name: "build-essential"
+    - name: "fakeroot"
+    - name: "debhelper"
+    - name: "autoconf"
+    - name: "automake"
+    - name: "bzip2"
+    - name: "libssl-dev"
+    - name: "openssl"
+    - name: "graphviz"
+    - name: "python-all"
+    - name: "procps"
+    - name: "python-dev"
+    - name: "python-setuptools"
+    - name: "python-twisted-conch"
+    - name: "libtool"
+    - name: "git"
+    - name: "dh-autoreconf"
+    - name: "dkms"
+    - name: "unzip"
+    - name: "linux-headers-{{ ansible_kernel }}"
+
+ovs_info:
+  git_url: https://github.com/openvswitch/ovs.git
+  build_path: /tmp
+  modules_file_path: /etc/modules-load.d/modules.conf
+  branch: branch-2.8
+  service_path: /etc/systemd/system/openvswitch.service
+  release_link: http://openvswitch.org/releases/openvswitch-2.8.2.tar.gz
+  release_name: openvswitch-2.8.2
+  pkg_build_version: 2.8.2-1
+  # Prebuilt packages info and download link
+  install_prebuilt_packages: "{{ovs_install_prebuilt_packages | default(false)}}"
+  prebuilt_packages_download_path: /tmp
+  prebuilt_version: "2.8.2-1"
+  debs_targz_link: "replace_me"

--- a/contrib/roles/linux/ovn-kubernetes/tasks/build_install_bins.yml
+++ b/contrib/roles/linux/ovn-kubernetes/tasks/build_install_bins.yml
@@ -1,0 +1,36 @@
+---
+- name: ovn-kubernetes | install golang
+  include_tasks: ./install_golang.yml
+
+- name: ovn-kubernetes | git clone
+  git:
+    repo: "{{ ovn_kubernetes_info.git_url }}"
+    dest: "{{ ovn_kubernetes_info.build_path }}/ovn-kubernetes-checkout"
+    version: "{{ ovn_kubernetes_info.branch }}"
+
+- name: ovn-kubernetes | compile sources - make clean
+  make:
+    chdir: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller"
+    target: clean
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"
+
+- name: ovn-kubernetes | compile sources - make linux
+  make:
+    chdir: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller"
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"
+
+- name: ovn-kubernetes | compile sources - make windows
+  make:
+    chdir: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller"
+    target: windows
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"
+
+- name: ovn-kubernetes | compile sources - make install
+  make:
+    chdir: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller"
+    target: install
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"

--- a/contrib/roles/linux/ovn-kubernetes/tasks/distribute_bins.yml
+++ b/contrib/roles/linux/ovn-kubernetes/tasks/distribute_bins.yml
@@ -1,0 +1,38 @@
+---
+#TODO: change this if /opt/cni/bin becomes a variable for kubelet
+- name: ovn-kubernetes | create cni binary folder /opt/cni/bin
+  file:
+    path: /opt/cni/bin
+    state: directory
+
+- name: ovn-kubernetes | get ovn-k8s-cni-overlay
+  copy:
+    src: "{{ansible_tmp_dir}}/ovn-k8s-cni-overlay"
+    dest: "/opt/cni/bin/ovn-k8s-cni-overlay"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: ovn-kubernetes | get ovn-k8s-overlay
+  copy:
+    src: "{{ansible_tmp_dir}}/ovn-k8s-overlay"
+    dest: "{{ ovn_kubernetes_info.install_path }}/ovn-k8s-overlay"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: ovn-kubernetes | get ovn-kube-util
+  copy:
+    src: "{{ansible_tmp_dir}}/ovn-kube-util"
+    dest: "{{ ovn_kubernetes_info.install_path }}/ovn-kube-util"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: ovn-kubernetes | get ovnkube
+  copy:
+    src: "{{ansible_tmp_dir}}/ovnkube"
+    dest: "{{ ovn_kubernetes_info.install_path }}/ovnkube"
+    owner: root
+    group: root
+    mode: 0755

--- a/contrib/roles/linux/ovn-kubernetes/tasks/fetch_bins.yml
+++ b/contrib/roles/linux/ovn-kubernetes/tasks/fetch_bins.yml
@@ -1,0 +1,42 @@
+---
+- name: ovn-kubernetes | fetch ovnkube
+  fetch:
+    fail_on_missing: yes
+    flat: yes
+    src: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller/_output/go/bin/ovnkube"
+    dest: "{{ansible_tmp_dir}}/ovnkube"
+
+- name: ovn-kubernetes | fetch ovn-k8s-overlay
+  fetch:
+    fail_on_missing: yes
+    flat: yes
+    src: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller/_output/go/bin/ovn-k8s-overlay"
+    dest: "{{ansible_tmp_dir}}/ovn-k8s-overlay"
+
+- name: ovn-kubernetes | fetch ovn-k8s-cni-overlay
+  fetch:
+    fail_on_missing: yes
+    flat: yes
+    src: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller/_output/go/bin/ovn-k8s-cni-overlay"
+    dest: "{{ansible_tmp_dir}}/ovn-k8s-cni-overlay"
+
+- name: ovn-kubernetes | fetch ovn-kube-util
+  fetch:
+    fail_on_missing: yes
+    flat: yes
+    src: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller/_output/go/bin/ovn-kube-util"
+    dest: "{{ansible_tmp_dir}}/ovn-kube-util"
+
+- name: ovn-kubernetes | fetch ovnkube.exe (windows version)
+  fetch:
+    fail_on_missing: yes
+    flat: yes
+    src: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller/_output/go/windows/ovnkube.exe"
+    dest: "{{ansible_tmp_dir}}/ovnkube.exe"
+
+- name: ovn-kubernetes | fetch ovn-k8s-cni-overlay.exe (windows version)
+  fetch:
+    fail_on_missing: yes
+    flat: yes
+    src: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller/_output/go/windows/ovn-k8s-cni-overlay.exe"
+    dest: "{{ansible_tmp_dir}}/ovn-k8s-cni-overlay.exe"

--- a/contrib/roles/linux/ovn-kubernetes/tasks/install_golang.yml
+++ b/contrib/roles/linux/ovn-kubernetes/tasks/install_golang.yml
@@ -1,0 +1,25 @@
+---
+- name: golang | Detecting golang architecture
+  set_fact:
+    golang_arch: "amd64"
+  when: ansible_architecture == "x86_64"
+
+- name: golang | Detecting golang architecture
+  set_fact:
+    golang_arch: "386"
+  when: ansible_architecture != "x86_64"
+
+- name: golang | get go1.9.4.{{ansible_system | lower}}-{{golang_arch}}.tar.gz
+  get_url:
+    url: "https://dl.google.com/go/go1.9.4.{{ansible_system | lower}}-{{golang_arch}}.tar.gz"
+    dest: "/tmp/go1.9.4.tar.gz"
+    force_basic_auth: yes
+    mode: 0755
+    timeout: 30
+  retries: 3
+
+- name: golang | Install golang
+  unarchive:
+    src: "/tmp/go1.9.4.tar.gz"
+    dest: "/usr/local/"
+    remote_src: yes

--- a/contrib/roles/linux/ovn-kubernetes/tasks/main.yml
+++ b/contrib/roles/linux/ovn-kubernetes/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: ovn-kubernetes | include global vars for minions
+  include_vars: "{{ansible_tmp_dir}}/generated_global_vars.yml"
+  when: not master
+
+- name: ovn-kubernetes | include vars
+  include_vars: "{{ ansible_distribution|lower }}.yml"
+  tags:
+    - facts
+
+- name: ovn-kubernetes | Checking if binaries are already present on ansible machine
+  local_action: stat path="{{playbook_dir}}/tmp/{{item}}"
+  register: stat_bins_exists
+  with_items: "{{ovn_kubernetes_binaries}}"
+
+- name: ovn-kubernetes | Expecting all binaries to be already present
+  set_fact:
+    binaries_missing: false
+
+- name: ovn-kubernetes | Checking all binaries
+  set_fact:
+    binaries_missing: true
+  with_items:
+    - "{{stat_bins_exists.results}}"
+  loop_control:
+    label: "{{item.item}}"
+  when: not item.stat.exists
+
+- debug:
+    msg: "Binaries are missing: {{binaries_missing}}"
+
+- name: ovn-kubernetes | Build and install binaries
+  include_tasks: ./build_install_bins.yml
+  when: binaries_missing or (binaries_missing and master) or not distribute_binaries
+
+- name: ovn-kubernetes | Fetching Linux and Windows binaries
+  include_tasks: ./fetch_bins.yml
+  when: binaries_missing
+
+- name: ovn-kubernetes | Distributing binaries to minion
+  include_tasks: ./distribute_bins.yml
+  when: minion and distribute_binaries

--- a/contrib/roles/linux/ovn-kubernetes/vars/ubuntu.yml
+++ b/contrib/roles/linux/ovn-kubernetes/vars/ubuntu.yml
@@ -1,0 +1,15 @@
+---
+ovn_kubernetes_info:
+  install_path: /usr/bin
+  # ovn-kubernetes build info
+  git_url: https://github.com/openvswitch/ovn-kubernetes
+  build_path: /tmp
+  branch: master
+
+ovn_kubernetes_binaries:
+  - ovnkube
+  - ovn-k8s-overlay
+  - ovn-k8s-cni-overlay
+  - ovn-kube-util
+  - ovnkube.exe
+  - ovn-k8s-cni-overlay.exe

--- a/contrib/roles/linux/version_check/tasks/main.yml
+++ b/contrib/roles/linux/version_check/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: version check | Checking if distro is supported by this playbook
+  fail:
+    msg: "Distribution {{ ansible_distribution | lower }} not supported by this playbook"
+  when: ansible_distribution | lower != 'ubuntu'
+
+- name: version check | Checking if distro version is supported by this playbook
+  fail:
+    msg: "Distribution version {{ ansible_distribution_version }} not supported by this playbook"
+  when: ansible_distribution_version != '16.04' and ansible_distribution_version != '14.04'

--- a/contrib/roles/windows/docker/tasks/install_docker.yml
+++ b/contrib/roles/windows/docker/tasks/install_docker.yml
@@ -1,0 +1,43 @@
+---
+# TODO: Fix this, always fails the first time
+- name: Docker | Download latest docker
+  win_get_url:
+    url: https://download.docker.com/win/static/test/x86_64/docker-{{ docker_download_info.docker_version }}.zip
+    dest: "{{ docker_download_info.temp_dir }}/docker-{{ docker_download_info.docker_version }}.zip"
+    timeout: 60
+  retries: 3
+  ignore_errors: yes
+
+- name: Docker | Download latest docker
+  win_get_url:
+    url: https://download.docker.com/win/static/test/x86_64/docker-{{ docker_download_info.docker_version }}.zip
+    dest: "{{ docker_download_info.temp_dir }}/docker-{{ docker_download_info.docker_version }}.zip"
+    timeout: 60
+  retries: 3
+
+- name: Docker | Unzip docker
+  win_unzip:
+    src: "{{ docker_download_info.temp_dir }}/docker-{{ docker_download_info.docker_version }}.zip"
+    dest: "{{ docker_download_info.install_dir }}"
+
+- name: Docker | Remove docker zip
+  win_file:
+    path: "{{ docker_download_info.temp_dir }}/docker-{{ docker_download_info.docker_version }}.zip"
+    state: absent
+
+- name: Docker | Add docker to path
+  win_path:
+    elements: "{{ docker_download_info.install_dir }}/docker"
+    scope: machine
+    state: present
+
+- name: Docker | Register docker Get-Service
+  win_shell: dockerd --register-service
+
+- name: Docker | Start docker service
+  win_service:
+    name: docker
+    state: started
+
+- name: Docker | Reboot computer to update Path with docker
+  win_reboot:

--- a/contrib/roles/windows/docker/tasks/main.yml
+++ b/contrib/roles/windows/docker/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Docker | include vars
+  include_vars: "{{ ansible_os_family|lower }}.yml"
+  tags:
+    - facts
+
+- name: Docker | Install required features
+  include_tasks: "./requirements-16299.yaml"
+  when: ansible_kernel == "10.0.16299.0"
+
+- name: Docker | Check if docker is installed
+  win_service:
+    name: docker
+  register: docker_service
+
+- name: Docker | Get Docker binaries
+  include_tasks: ./install_docker.yml
+  when: not docker_service.exists

--- a/contrib/roles/windows/docker/tasks/requirements-16299.yaml
+++ b/contrib/roles/windows/docker/tasks/requirements-16299.yaml
@@ -1,0 +1,30 @@
+---
+# TODO: Hyper-V feature is required at the moment for version 1709, it will be
+# fixed in OVS soon
+- name: Windows 1709 | Installing Required features
+  win_feature:
+    name: "{{item}}"
+    state: present
+  register: features_installed
+  with_items:
+    - Containers
+    - Hyper-V # TODO
+    - RSAT-Hyper-V-Tools # TODO
+    - Hyper-V-PowerShell # TODO
+
+- name: Windows 1709 | Expect reboot_required to false
+  set_fact:
+    reboot_required: false
+
+- name: Windows 1709 | Checking if reboot_required
+  set_fact:
+    reboot_required: true
+  with_items:
+    - "{{features_installed.results}}"
+  loop_control:
+    label: "{{item.item}}"
+  when: item.reboot_required
+
+- name: Windows 1709 | Reboot the node
+  win_reboot:
+  when: reboot_required

--- a/contrib/roles/windows/docker/vars/windows.yml
+++ b/contrib/roles/windows/docker/vars/windows.yml
@@ -1,0 +1,5 @@
+---
+docker_download_info:
+  temp_dir: "{{docker_temp_dir | default('C:/Windows/Temp')}}"
+  docker_version: "{{docker_version | default('17.10.0-ce')}}"
+  install_dir: C:/Program Files

--- a/contrib/roles/windows/kubernetes/tasks/create_infracontainer.yml
+++ b/contrib/roles/windows/kubernetes/tasks/create_infracontainer.yml
@@ -1,0 +1,21 @@
+---
+# Need to generate infra container image
+- name: Kubernetes infracontainer | Delete Dockerfile
+  win_file:
+    path: "{{ install_info.install_path }}/Dockerfile"
+    state: absent
+- name: Kubernetes infracontainer | Create Dockerfile
+  win_lineinfile:
+    path: "{{ install_info.install_path }}/Dockerfile"
+    create: yes
+    line: |
+      FROM microsoft/windowsservercore:1709
+
+      CMD ping 127.0.0.1 -t
+    newline: unix
+
+# TODO: switch to nanoserver, this takes a lot of time
+- name: Kubernetes infracontainer | Create container {{kubernetes_info.infracontainername_1709}}
+  win_shell: |
+    cd {{ install_info.install_path }}
+    docker image build -t {{kubernetes_info.infracontainername_1709}} .

--- a/contrib/roles/windows/kubernetes/tasks/get_ovn_subnet.yml
+++ b/contrib/roles/windows/kubernetes/tasks/get_ovn_subnet.yml
@@ -1,0 +1,27 @@
+---
+- name: OVN subnet | Get the ovn_host_annotation
+  win_shell: |
+    {{ install_info.install_path }}/kubectl.exe describe node {{ ansible_hostname|lower }} | sls ovn_host_subnet
+  register: kubectl_annotation_output
+  changed_when: false
+
+- name: OVN subnet | Set OVN_Host_Annotations
+  set_fact:
+    OVN_ANNOTATION: "{{kubectl_annotation_output.stdout | trim}}"
+
+- set_fact:
+    OVN_SUBNET: "{{ OVN_ANNOTATION.split('=')[1] }}"
+    OVN_IP: "{{ OVN_ANNOTATION.split('=')[1].split('/')[0] }}"
+
+- name: OVN subnet | Get gateway ip
+  win_shell: '"{{OVN_IP}}".Substring(0,"{{OVN_IP}}".Length - 1) + 1'
+  register: gateway_ip_output
+  changed_when: false
+
+- name: OVN subnet | Set OVN Gateway
+  set_fact:
+    OVN_GATEWAY_IP: "{{gateway_ip_output.stdout | trim}}"
+
+- debug: var=OVN_SUBNET
+- debug: var=OVN_IP
+- debug: var=OVN_GATEWAY_IP

--- a/contrib/roles/windows/kubernetes/tasks/main.yml
+++ b/contrib/roles/windows/kubernetes/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+- name: Kubernetes | include global vars for minions
+  include_vars: "{{ansible_tmp_dir}}/generated_global_vars.yml"
+  when: not master
+
+- name: Kubernetes | include vars
+  include_vars: "{{ ansible_os_family|lower }}.yml"
+  tags:
+    - facts
+
+- include_tasks: set_ip_facts.yml
+  tags:
+    - facts
+
+- name: Kubernetes | check if Kubelet is installed
+  win_service:
+    name: kubelet
+  register: kubelet_service
+
+# We need to start kubelet in order to be able to retrieve the ovn_host_subnet from kubernetes
+# node annotations
+- include_tasks: ./start_kubelet.yml
+  when: not kubelet_service.exists
+
+- include_tasks: ./get_ovn_subnet.yml
+  tags:
+    - facts
+
+- name: Kubernetes | Check if transparent network was created
+  win_shell: "docker network inspect {{ docker_info.docker_network_name }}"
+  register: transparent_inspect
+  failed_when: transparent_inspect.rc != 0 and transparent_inspect.rc != 1
+  changed_when: false
+
+- include_tasks: ./setup_docker.yml
+  when: transparent_inspect.rc != 0
+
+# This creates a startup script which will be added to run once at login time.
+# This is due to the fact that connection drops while doing the initial setup
+# and it's safer to have everything inside a powershell script to run.
+- include_tasks: ./setup_ovs_docker.yml
+  when: transparent_inspect.rc != 0
+
+# This will create another powershell script for minion init. OVS on Windows
+# does not allow any commands to be ran through network. Ansible uses WinRM
+# for the connection.
+- include_tasks: ./run_minion_init.yml
+  when: transparent_inspect.rc != 0
+
+# There is no infra container for Windows Server 1709, this creates a custom
+# infra container
+- name: Kubernetes | Check if infra container exists
+  win_shell: "docker image inspect {{kubernetes_info.infracontainername_1709}}"
+  register: infra_inspect
+  failed_when: infra_inspect.rc != 0 and infra_inspect.rc != 1
+  changed_when: false
+  when: ansible_kernel == "10.0.16299.0"
+
+- include_tasks: ./create_infracontainer.yml
+  when: infra_inspect.rc != 0 and ansible_kernel == "10.0.16299.0"

--- a/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
+++ b/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
@@ -1,0 +1,55 @@
+---
+- name: Restart Kubelet
+  win_service:
+    name: kubelet
+    start_mode: auto
+    state: restarted
+
+- name: Kubernetes minion | Remove Startup-script if exists
+  win_file:
+    path: C:\startup.ps1
+    state: absent
+
+- name: Kubernetes minion | Update C:\Windows\System32\drivers\etc\hosts
+  win_lineinfile:
+    path: C:\Windows\System32\drivers\etc\hosts
+    line: "{{ host_public_ip }} {{ ansible_hostname|lower }}"
+
+- name: Kubernetes minion | Add "{{ install_info.install_path }}" to path
+  win_path:
+    elements: "{{ install_info.install_path }}"
+
+# TODO: add firewall rules instead of disabling it
+- name: Kubernetes minion | Create startup-script
+  win_lineinfile:
+    path: C:\startup.ps1
+    create: yes
+    line: |
+      $RegROPath = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+      Remove-ItemProperty $RegROPath "OVN_Init_Node" -ErrorAction SilentlyContinue
+      sleep 30
+      {{ install_info.install_path }}\\ovnkube.exe --k8s-kubeconfig={{ install_info.install_path }}\\kubeconfig.yaml --k8s-apiserver http://{{ kubernetes_info.MASTER_IP }}:8080 --init-node {{ ansible_hostname|lower }} --k8s-token {{TOKEN}} --nb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6641" --sb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6642" --cluster-subnet {{ kubernetes_info.CLUSTER_SUBNET }} --cni-conf-dir="{{ install_info.install_path }}/cni" --cni-plugin "ovn-k8s-cni-overlay.exe"
+      ovs-vsctl set open_vswitch . external_ids:ovn-encap-ip="{{ host_public_ip }}"
+      netsh firewall set opmode disable
+    newline: unix
+
+- name: Kubernetes minion | Make minion-init startup script Run
+  win_shell: |
+    $RegPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"
+    # HKCU to run after the user logs in
+    $RegROPath = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+
+    $script = "C:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -noexit C:\startup.ps1"
+
+    Set-ItemProperty $RegPath "AutoAdminLogon" -Value "1" -type String  
+    Set-ItemProperty $RegPath "DefaultUsername" -Value "{{ host_info.username }}" -type String  
+    Set-ItemProperty $RegPath "DefaultPassword" -Value "{{ host_info.password }}" -type String
+    Set-ItemProperty $RegPath "AutoLogonCount" -Value "1" -type DWord
+    Set-ItemProperty $RegROPath "OVN_Init_Node" -Value "$script" -type String
+
+- name: Kubernetes minion | Reboot
+  win_reboot:
+
+- name: Kubernetes minion | Wait for minion-init script 30 seconds
+  pause:
+    seconds: 30

--- a/contrib/roles/windows/kubernetes/tasks/set_ip_facts.yml
+++ b/contrib/roles/windows/kubernetes/tasks/set_ip_facts.yml
@@ -1,0 +1,54 @@
+---
+# Interface index changes after docker was installed, gather the facts again
+# to have the information up to date
+- name: IP facts | do facts module to get latest information
+  setup:
+
+- name: IP facts | set internal IP
+  set_fact:
+    host_internal_ip: "{{ ansible_ip_addresses[0] }}"
+
+# TODO: enable this for future GCE support in the playbooks
+# - name: IP facts | set public IP
+#   set_fact:
+#     host_public_ip: "{{ ansible_ip_addresses[0] }}"
+#   when: GCE
+
+- name: IP facts | set public IP
+  set_fact:
+    host_public_ip: "{{ ansible_ip_addresses[0] }}"
+  # when: not GCE
+
+- name: IP facts | set interface details
+  set_fact:
+    interface_description: "{{ ansible_interfaces[0].interface_name }}"
+    interface_mac_addr: "{{ ansible_interfaces[0].macaddress }}"
+    interface_default_gateway: "{{ ansible_interfaces[0].default_gateway }}"
+    interface_index: "{{ ansible_interfaces[0].interface_index }}"
+
+# Do not mark those as changed when executing the command
+- name: IP facts | Get Windows Prefix Length of {{interface_description}}
+  win_shell: (Get-NetIPAddress -InterfaceIndex "{{interface_index}}" -AddressFamily IPv4 -ErrorAction SilentlyContinue).PrefixLength
+  register: prefix_length_interface
+  changed_when: false
+
+- name: IP facts | Get Windows Interface name of {{interface_description}}
+  win_shell: (Get-NetAdapter -InterfaceIndex "{{interface_index}}" -ErrorAction SilentlyContinue).Name
+  register: interface_out_name
+  changed_when: false
+
+- name: IP facts | set interface details
+  set_fact:
+    interface_prefix_length: "{{prefix_length_interface.stdout | trim}}"
+
+- name: IP facts | set interface name
+  set_fact:
+    interface_name: "{{interface_out_name.stdout | trim}}"
+
+- debug: var=interface_mac_addr
+- debug: var=interface_default_gateway
+- debug: var=interface_index
+- debug: var=host_internal_ip
+- debug: var=host_public_ip
+- debug: var=interface_prefix_length
+- debug: var=interface_name

--- a/contrib/roles/windows/kubernetes/tasks/setup_docker.yml
+++ b/contrib/roles/windows/kubernetes/tasks/setup_docker.yml
@@ -1,0 +1,25 @@
+---
+- name: Docker network setup | Remove current default nat network
+  win_shell: |
+    Get-HNSNetwork | Remove-HNSNetwork
+
+- name: Docker network setup | Create docker config
+  win_lineinfile:
+    path: C:\ProgramData\docker\config\daemon.json
+    create: yes
+    line: |
+      { "bridge" : "none" }
+    newline: unix
+
+# Launch and do not wait for result, connection will drop
+- name: Docker network setup | Create transparent network
+  win_shell: |
+    docker network create -d transparent --gateway {{OVN_GATEWAY_IP}} --subnet {{OVN_SUBNET}} -o com.docker.network.windowsshim.interface="{{ interface_name }}" {{ docker_info.docker_network_name }}
+  async: 10
+  poll: 0
+
+# Wait for docker to create the HNS Network and the new adapter. Connection will
+# drop shortly when doing this, wait for the connection to come back
+- name: Docker network setup | Wait 15 seconds
+  pause:
+    seconds: 15

--- a/contrib/roles/windows/kubernetes/tasks/setup_ovs_docker.yml
+++ b/contrib/roles/windows/kubernetes/tasks/setup_ovs_docker.yml
@@ -1,0 +1,73 @@
+---
+- name: OVS Docker network setup | Remove Startup-script if exists
+  win_file:
+    path: C:\startup.ps1
+    state: absent
+- name: OVS Docker network setup | Create startup-script
+  win_lineinfile:
+    path: C:\startup.ps1
+    create: yes
+    line: |
+      # Get Admin rights in case the current powershell doesnt have admin rights
+      if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) { Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs; exit }
+      $RegROPath = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+      Remove-ItemProperty $RegROPath "OVN_Init_Node" -ErrorAction SilentlyContinue
+
+      # Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/hns.psm1
+      # Import-Module ./hns.psm1
+
+      # # There should be only one transparent network
+      # $HNS_NW=Get-HNSNetworks | where {$_.type -eq "transparent"}
+      # $HNS_ID=$HNS_NW.Id
+      # $OVS_EXTENSION_ID="583cc151-73ec-4a6a-8b47-578297ad7623"
+
+      # Set-HnsSwitchExtension -NetworkId $HNS_ID -ExtensionId $OVS_EXTENSION_ID -state 0
+      # # Rename-NetAdapter -Name "vEthernet ({{interface_name}})" -NewName "Management_Interface"
+      # ovs-vsctl --if-exists --no-wait del-br br-ex
+      # ovs-vsctl --no-wait --may-exist add-br br-ex
+      # ovs-vsctl --no-wait add-port br-ex "{{interface_name}}"
+      # Stop-Service ovs-vswitchd
+      # Set-HnsSwitchExtension -NetworkId $HNS_ID -ExtensionId $OVS_EXTENSION_ID -state 1
+      Get-VMSwitch -SwitchType External | Disable-VMSwitchExtension "Cloudbase Open vSwitch Extension"
+      ovs-vsctl --if-exists --no-wait del-br br-ex
+      Get-VMSwitch -SwitchType External | Set-VMSwitch -AllowManagementOS $false
+      Get-VMSwitch -SwitchType External | Set-VMSwitch -AllowManagementOS $false
+      ovs-vsctl --no-wait --may-exist add-br br-ex
+      ovs-vsctl --no-wait add-port br-ex '{{interface_name}}'
+      Stop-Service ovs-vswitchd
+      Get-VMSwitch -SwitchType External | Enable-VMSwitchExtension "Cloudbase Open vSwitch Extension"
+
+      Start-Service ovs-vswitchd
+      sleep 2
+      Restart-Service ovs-vswitchd
+      # Clone the MAC addr
+      # TODO: this does not work if the mac ends in 99
+      Set-NetAdapter -Name "{{ interface_name }}" -MacAddress {{ interface_mac_addr[:-2] }}99 -Confirm:$false
+      Set-NetAdapter -Name br-ex -MacAddress {{ interface_mac_addr }} -Confirm:$false
+      Enable-NetAdapter br-ex
+      # Remove-NetIPAddress -ifAlias br-ex -Confirm:$false
+      # New-NetIPAddress -ifAlias br-ex -IPAddress {{ host_internal_ip }} -DefaultGateway {{ interface_default_gateway }} -PrefixLength {{ interface_prefix_length }}
+      # Set-DnsClientServerAddress -InterfaceAlias br-ex -ServerAddresses ("8.8.8.8")
+      $GUID = (New-Guid).Guid
+      ovs-vsctl set Open_vSwitch . external_ids:system-id="$($GUID)"
+      ovs-vsctl set Open_vSwitch . external_ids:k8s-api-server="http://{{ kubernetes_info.MASTER_IP }}:8080"
+      ovs-vsctl set Open_vSwitch . external_ids:ovn-remote="tcp:{{ kubernetes_info.MASTER_IP }}:6642" external_ids:ovn-nb="tcp:{{ kubernetes_info.MASTER_IP }}:6641" external_ids:ovn-encap-ip={{ host_public_ip }} external_ids:ovn-encap-type="geneve"
+    newline: unix
+- name: OVS Docker network setup | Make startup script Run
+  win_shell: |
+    $RegPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"
+    # HKCU to run after the user logs in
+    $RegROPath = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+
+    $script = "C:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -noexit C:\startup.ps1"
+
+    Set-ItemProperty $RegPath "AutoAdminLogon" -Value "1" -type String
+    Set-ItemProperty $RegPath "DefaultUsername" -Value "{{ host_info.username }}" -type String  
+    Set-ItemProperty $RegPath "DefaultPassword" -Value "{{ host_info.password }}" -type String
+    Set-ItemProperty $RegPath "AutoLogonCount" -Value "1" -type DWord
+    Set-ItemProperty $RegROPath "OVN_Init_Node" -Value "$script" -type String
+- name: OVS Docker network setup | Reboot
+  win_reboot:
+- name: OVS Docker network setup | Wait for startup script 60 seconds
+  pause:
+    seconds: 60

--- a/contrib/roles/windows/kubernetes/tasks/start_kubelet.yml
+++ b/contrib/roles/windows/kubernetes/tasks/start_kubelet.yml
@@ -1,0 +1,50 @@
+---
+- name: Kubelet | Delete kubeconfig
+  win_file:
+    path: "{{ install_info.install_path }}/kubeconfig.yaml"
+    state: absent
+- name: Kubelet | Create kubeconfig
+  win_lineinfile:
+    path: "{{ install_info.install_path }}/kubeconfig.yaml"
+    create: yes
+    line: |
+      apiVersion: v1
+      kind: Config
+      clusters:
+      - name: local
+        cluster:
+          server: http://{{ kubernetes_info.MASTER_IP }}:8080
+      users:
+      - name: kubelet
+      contexts:
+      - context:
+          cluster: local
+          user: kubelet
+        name: kubelet-context
+      current-context: kubelet-context
+    newline: unix
+
+- name: Kubelet | Create Kubelet service
+  win_service:
+    name: kubelet
+    path: '"{{ install_info.install_path }}\\servicewrapper.exe" kubelet "{{ install_info.install_path }}\\kubelet.exe" --hostname-override="{{ ansible_hostname }}" --cluster-dns="{{ kubernetes_info.K8S_DNS_SERVICE_IP }}" --cluster-domain="{{ kubernetes_info.K8S_DNS_DOMAIN }}" --pod-infra-container-image="{{kubernetes_info.infracontainername_1709}}" --resolv-conf="" --kubeconfig="{{ install_info.install_path }}\\kubeconfig.yaml" --network-plugin=cni --cni-bin-dir="{{ install_info.install_path }}\\cni" --cni-conf-dir="{{ install_info.install_path }}\\cni" --log-dir="{{ install_info.install_path }}"'
+    display_name: Kubernetes Kubelet
+    description: Kubernetes Kubelet service
+    username: LocalSystem
+    password: ""
+
+- name: Kubelet | Set kubectl context
+  win_shell: |
+    {{ install_info.install_path }}\\kubectl.exe config set-cluster default-cluster --server={{ kubernetes_info.MASTER_IP }}:8080
+    {{ install_info.install_path }}\\kubectl.exe config set-context local --cluster=default-cluster --user=default-admin
+    {{ install_info.install_path }}\\kubectl.exe config use-context local
+
+# Start the kubelet to ensure OVN gives subnet to this minion
+- name: Kubelet | Start service kubelet
+  win_service:
+    name: kubelet
+    state: started
+
+- name: Kubelet | Wait 15 seconds for kubelet to register this node
+  pause:
+    seconds: 15

--- a/contrib/roles/windows/kubernetes/vars/windows.yml
+++ b/contrib/roles/windows/kubernetes/vars/windows.yml
@@ -1,0 +1,20 @@
+---
+install_info:
+  install_path: C:/kubernetes
+
+docker_info:
+  docker_network_name: external
+
+kubernetes_info:
+  MASTER_IP: "{{MASTER_IP}}"
+  CLUSTER_SUBNET: "{{CLUSTER_SUBNET | default('10.0.0.0/16')}}"
+  MASTER_INTERNAL_IP: "{{MASTER_INTERNAL_IP | default('10.0.0.2')}}" # Will always be the second IP of CLUSTER_SUBNET
+  SERVICE_CLUSTER_IP_RANGE: "{{SERVICE_CLUSTER_IP_RANGE | default('10.0.9.0/24')}}"
+  K8S_DNS_DOMAIN: "{{K8S_DNS_DOMAIN | default('cluster.local')}}"
+  K8S_DNS_SERVICE_IP: "{{K8S_DNS_SERVICE_IP | default('10.0.9.10')}}"
+  K8S_API_SERVICE_IP: "{{K8S_API_SERVICE_IP | default('10.0.9.1')}}"
+  infracontainername_1709: "ovnkubernetes/pause"
+
+host_info:
+  username: "{{ ansible_user }}"
+  password: "{{ ansible_password }}"

--- a/contrib/roles/windows/openvswitch/tasks/install_custom_ovs.yml
+++ b/contrib/roles/windows/openvswitch/tasks/install_custom_ovs.yml
@@ -1,0 +1,45 @@
+---
+# BCEDIT
+- name: OVS | Running bcdedit
+  win_shell: bcdedit /set testsigning yes
+  when: bcdedit_needed
+
+- name: OVS | Restarting computer
+  win_reboot:
+  when: bcdedit_needed
+
+- name: OVS | Downloading OVS
+  win_get_url:
+    url: "{{custom_ovs_link}}"
+    dest: "{{ovs_info.tmp_dir}}\\ovs.msi"
+    timeout: 60
+  retries: 3
+
+- name: OVS | Download certificate beta
+  win_get_url:
+    url: "{{ovs_certs_link}}"
+    dest: "{{ovs_info.tmp_dir}}\\certificate.cer"
+    timeout: 60
+  retries: 3
+
+- name: OVS | Install certificate
+  win_shell: |
+    $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2("{{ovs_info.tmp_dir}}\certificate.cer")
+    $rootStore = Get-Item cert:\LocalMachine\TrustedPublisher
+    $rootStore.Open("ReadWrite")
+    $rootStore.Add($cert)
+    $rootStore.Close()
+    $rootStore = Get-Item cert:\LocalMachine\Root
+    $rootStore.Open("ReadWrite")
+    $rootStore.Add($cert)
+    $rootStore.Close()
+
+- name: OVS | Installing OVS
+  win_package:
+    path: "{{ovs_info.tmp_dir}}\\ovs.msi"
+    wait: yes
+    state: present
+    arguments: ADDLOCAL="OpenvSwitchServices,OpenvSwitchCLI,OpenvSwitchDriver,OVNHost"
+
+- name: OVS | Restarting after OVS install
+  win_reboot:

--- a/contrib/roles/windows/openvswitch/tasks/install_ovs.yml
+++ b/contrib/roles/windows/openvswitch/tasks/install_ovs.yml
@@ -1,0 +1,16 @@
+---
+- name: OVS | Downloading OVS
+  win_get_url:
+    url: "{{ ovs_info.download_link }}"
+    dest: "{{ ovs_info.tmp_dir }}\\ovs.msi"
+  retries: 3
+
+- name: OVS | Installing OVS
+  win_package:
+    path: "{{ ovs_info.tmp_dir }}\\ovs.msi"
+    wait: yes
+    state: present
+    arguments: ADDLOCAL="OpenvSwitchCLI,OpenvSwitchDriver,OVNHost"
+
+- name: OVS | Restarting after OVS install
+  win_reboot:

--- a/contrib/roles/windows/openvswitch/tasks/main.yml
+++ b/contrib/roles/windows/openvswitch/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: OVS | include vars
+  include_vars: "{{ ansible_os_family|lower }}.yml"
+  tags:
+    - facts
+
+- name: OVS | check if OVS is installed
+  win_service:
+    name: ovsdb-server
+  register: ovs_service
+
+- name: OVS | Install beta OVS
+  include_tasks: "./install_custom_ovs.yml"
+  when: install_custom_ovs and not ovs_service.exists
+
+- name: OVS | Install OVS
+  include_tasks: ./install_ovs.yml
+  when: not install_custom_ovs and not ovs_service.exists

--- a/contrib/roles/windows/openvswitch/vars/windows.yml
+++ b/contrib/roles/windows/openvswitch/vars/windows.yml
@@ -1,0 +1,4 @@
+---
+ovs_info:
+  download_link: https://cloudbase.it/downloads/openvswitch-hyperv-2.7.0-certified.msi
+  tmp_dir: C:\\Windows\\Temp

--- a/contrib/roles/windows/ovn-kubernetes/tasks/distribute_binaries.yml
+++ b/contrib/roles/windows/ovn-kubernetes/tasks/distribute_binaries.yml
@@ -1,0 +1,38 @@
+---
+- name: ovn-kubernetes | Create kubernetes dir
+  win_file:
+    path: "{{ download_info.install_path }}"
+    state: directory
+
+- name: ovn-kubernetes | Create CNI dir
+  win_file:
+    path: "{{ download_info.install_path }}/cni"
+    state: directory
+
+- name: ovn-kubernetes | get kubernetes binaries
+  win_copy:
+    src: "{{ansible_tmp_dir}}/{{item}}"
+    dest: "{{ download_info.install_path }}/{{item}}"
+  with_items:
+    - ovnkube.exe
+    - kubectl.exe
+    - kubelet.exe
+
+- name: ovn-kubernetes | get cni binary
+  win_copy:
+    src: "{{ansible_tmp_dir}}/ovn-k8s-cni-overlay.exe"
+    dest: "{{ download_info.install_path }}\\cni\\ovn-k8s-cni-overlay.exe"
+
+- name: ovn-kubernetes | check if servicewrapper exists
+  win_stat:
+    path: "{{ download_info.install_path }}/servicewrapper.exe"
+  register: servicewrapper_info
+
+# TODO: Use this only for older kubernetes versions (version less than 1.11)
+- name: ovn-kubernetes | Download service wrapper
+  win_get_url:
+    url: "{{ download_info.service_wrapper_link }}"
+    dest: "{{ download_info.install_path }}/servicewrapper.exe"
+    timeout: 60
+  retries: 3
+  when: not servicewrapper_info.stat.exists

--- a/contrib/roles/windows/ovn-kubernetes/tasks/main.yml
+++ b/contrib/roles/windows/ovn-kubernetes/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: ovn-kubernetes | include vars
+  include_vars: "{{ ansible_os_family|lower }}.yml"
+  tags:
+    - facts
+
+- include_tasks: ./distribute_binaries.yml

--- a/contrib/roles/windows/ovn-kubernetes/vars/windows.yml
+++ b/contrib/roles/windows/ovn-kubernetes/vars/windows.yml
@@ -1,0 +1,4 @@
+---
+download_info:
+  service_wrapper_link: https://docs.google.com/uc?export=download&id=1uqUHyM4F-zMlTBdkWmG9j8aSV6Yux6f9
+  install_path: "{{install_path | default('C:/kubernetes')}}"

--- a/contrib/roles/windows/version_check/tasks/main.yml
+++ b/contrib/roles/windows/version_check/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: version check | Check if the Windows version is supported by the playbooks
+  fail:
+    msg: The system distribution is not supported yet by the playbooks
+  when: ansible_kernel != "10.0.16299.0"


### PR DESCRIPTION
This patch adds some ansible playbooks which deploy a kubernetes
cluster. It also adds Windows Server minion nodes to the cluster.

More details can be found in the README.md from contrib folder.

Signed-off-by: Alin Balutoiu <abalutoiu@cloudbasesolutions.com>
Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
Co-authored-by: Alin Gabriel Serdean <aserdean@ovn.org>