### PR TITLE
Added service-cluster-ip-range subnet to in-use array

### DIFF
--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -46,6 +46,9 @@ func (cluster *OvnClusterController) StartClusterMaster(masterNodeName string) e
 	}
 	// Add the masterSwitchNetwork to subrange so that it is counted as one already taken
 	subrange = append(subrange, masterSwitchNetwork)
+	// Add the service subnet to subrange so that it is counted as one already taken
+	subrange = append(subrange, cluster.ClusterServicesSubnet)
+
 	// NewSubnetAllocator is a subnet IPAM, which takes a CIDR (first argument)
 	// and gives out subnets of length 'hostSubnetLength' (second argument)
 	// but omitting any that exist in 'subrange' (third argument)


### PR DESCRIPTION
This change will prevent the service-cluster-ip-range from being assigned as ovn_host_subnet for a nodes.

Prior to this change, if the service-cluster-ip-range was set to 10.0.2.0/24, nothing prevents the second node added to the cluster from being assigned 10.0.2.0/24 as it's ovn_host_subnet.

Signed-off-by: Bob Steciuk <bsteciuk@apprenda.com>