### PR TITLE
gateway: try to recover from already-initialized nic-to-bridge

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
+++ b/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
@@ -21,7 +21,7 @@ var NicsToBridgeCommand = cli.Command{
 
 		var errorList []error
 		for _, nic := range args {
-			if err := util.NicToBridge(nic); err != nil {
+			if _, err := util.NicToBridge(nic); err != nil {
 				errorList = append(errorList, err)
 			}
 		}

--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -401,16 +401,7 @@ func (cluster *OvnClusterController) initGateway(
 		}
 	}
 
-	if !cluster.NodePortEnable && !cluster.GatewaySpareIntf {
-		// Program cluster.GatewayIntf to let non-pod traffic to go to host
-		// stack
-		err = cluster.addDefaultConntrackRules()
-		if err != nil {
-			return err
-		}
-	}
-
-	if cluster.NodePortEnable && !cluster.GatewaySpareIntf {
+	if !cluster.GatewaySpareIntf {
 		// Program cluster.GatewayIntf to let non-pod traffic to go to host
 		// stack
 		err = cluster.addDefaultConntrackRules()
@@ -418,10 +409,12 @@ func (cluster *OvnClusterController) initGateway(
 			return err
 		}
 
-		// Program cluster.GatewayIntf to let nodePort traffic to go to pods.
-		err = cluster.nodePortWatcher()
-		if err != nil {
-			return err
+		if cluster.NodePortEnable {
+			// Program cluster.GatewayIntf to let nodePort traffic to go to pods.
+			err = cluster.nodePortWatcher()
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -963,7 +963,7 @@ func (oc *Controller) handlePeerPodSelector(
 }
 
 func (oc *Controller) handlePeerNamespaceSelectorModify(
-	namespace *kapi.Namespace, gress *gressPolicy, gressNum int,
+	gress *gressPolicy, gressNum int,
 	np *namespacePolicy, oldl3Match, newl3Match, policyType string) {
 
 	for logicalPort := range np.localPods {
@@ -1043,7 +1043,7 @@ func (oc *Controller) handlePeerNamespaceSelector(
 				newL3Match := getL3MatchFromAddressSet(
 					gress.sortedPeerAddressSets, policyType)
 
-				oc.handlePeerNamespaceSelectorModify(namespace, gress,
+				oc.handlePeerNamespaceSelectorModify(gress,
 					gressNum, np, oldL3Match, newL3Match, policyType)
 				gress.peerAddressSets[hashedAddressSet] = true
 
@@ -1074,7 +1074,7 @@ func (oc *Controller) handlePeerNamespaceSelector(
 				newL3Match := getL3MatchFromAddressSet(
 					gress.sortedPeerAddressSets, policyType)
 
-				oc.handlePeerNamespaceSelectorModify(namespace, gress,
+				oc.handlePeerNamespaceSelectorModify(gress,
 					gressNum, np, oldL3Match, newL3Match, policyType)
 
 				delete(gress.peerAddressSets, hashedAddressSet)


### PR DESCRIPTION
Instead of just bailing out of the given (or autodetected) gateway interface is already an OVS bridge, check if it looks like an already configured nic-to-bridge and try to use it.

@rajatchopra @shettyg @alinbalutoiu 