### PR TITLE
Fix a network policy typo

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -77,7 +77,7 @@ const (
 func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 	expectedPolicies := make(map[string]map[string]bool)
 	for _, npInterface := range networkPolicies {
-		policy, ok := npInterface.(kapisnetworking.NetworkPolicy)
+		policy, ok := npInterface.(*kapisnetworking.NetworkPolicy)
 		if !ok {
 			logrus.Errorf("Spurious object in syncNetworkPolicies: %v",
 				npInterface)


### PR DESCRIPTION
When syncing network policy, it reports "Spurious object" error.
This patch fix the correct way to get network policies.