### PR TITLE
Add ovnkube --pidfile

### DIFF
--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -69,6 +69,9 @@ Log verbosity and level: 5=debug, 4=info, 3=warn, 2=error, 1=fatal (default: 0).
 \fB\--logfile\fR string
 Logfile name (with path) for ovnkube to write to.
 .TP
+\fB\--pidfile\fR string
+(Optional) file name that will contain the pid.
+.TP
 \fB\--cni-conf-dir\fR string
 The CNI config directory in which to write the overlay CNI config file.
 .TP


### PR DESCRIPTION
When ovnkube is being used as a daemon the --pidfile \<path-to-pidfile\>
option creates a file containing the pid.
If ovnkube tries to start and the file exists, the attempt fails.
The file is deleted when ovnkube terminates.

ovn-kubernetes issue: 310 add flag to generate pid file

Signed-off-by: pecameron <pcameron@redhat.com>