### PR TITLE
cluster: don't start OVS, ovn-northd, or ovn-controller services

### DIFF
--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -9,7 +9,6 @@ import (
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 
@@ -87,22 +86,7 @@ func calculateMasterSwitchNetwork(clusterNetwork string, hostSubnetLength uint32
 
 // SetupMaster calls the external script to create the switch and central routers for the network
 func (cluster *OvnClusterController) SetupMaster(masterNodeName string, masterSwitchNetwork string) error {
-	err := util.StartOVS()
-	if err != nil {
-		return err
-	}
-
-	err = util.StartOvnNorthd()
-	if err != nil {
-		return err
-	}
-
 	if err := setupOVNMaster(masterNodeName); err != nil {
-		return err
-	}
-
-	err = util.RestartOvnController(config.OvnSouth.ClientAuth)
-	if err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/ovn"
-	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
 )
@@ -63,11 +62,6 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 
 	err = setupOVNNode(name, config.Kubernetes.APIServer, config.Kubernetes.Token,
 		config.Kubernetes.CACert)
-	if err != nil {
-		return err
-	}
-
-	err = util.RestartOvnController(config.OvnSouth.ClientAuth)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -339,39 +339,43 @@ const (
 	ovsVsctlCommand = "ovs-vsctl"
 )
 
-// Can't use pkg/ovs here because that package imports this one
-func getOVSExternalID(name string) string {
+// Can't use pkg/ovs or pkg/util here because those package import this one
+func runOVSVsctl(args ...string) (string, error) {
 	cmdPath, err := exec.LookPath(ovsVsctlCommand)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	out, err := exec.Command(
-		cmdPath,
+
+	newArgs := append([]string{"--timeout=5"}, args...)
+	out, err := exec.Command(cmdPath, newArgs...).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(strings.TrimSpace(string(out)), "\""), nil
+}
+
+func getOVSExternalID(name string) string {
+	out, err := runOVSVsctl(
 		"--if-exists",
 		"get",
 		"Open_vSwitch",
 		".",
-		"external_ids:"+name).CombinedOutput()
+		"external_ids:"+name)
 	if err != nil {
 		logrus.Debugf("failed to get OVS external_id %s: %v\n\t%s", name, err, out)
 		return ""
 	}
-	return strings.Trim(strings.TrimSpace(string(out)), "\"")
+	return out
 }
 
 func setOVSExternalID(key, value string) error {
-	cmdPath, err := exec.LookPath(ovsVsctlCommand)
-	if err != nil {
-		return err
-	}
-	out, err := exec.Command(
-		cmdPath,
+	out, err := runOVSVsctl(
 		"set",
 		"Open_vSwitch",
 		".",
-		fmt.Sprintf("external_ids:%s=%s", key, value)).CombinedOutput()
+		fmt.Sprintf("external_ids:%s=%s", key, value))
 	if err != nil {
-		return fmt.Errorf("Error setting OVS external ID '%s=%s': %v\n  %q", key, value, err, string(out))
+		return fmt.Errorf("Error setting OVS external ID '%s=%s': %v\n  %q", key, value, err, out)
 	}
 	return nil
 }
@@ -634,8 +638,12 @@ func (a *OvnDBAuth) ensureCACert() error {
 		return fmt.Errorf("CA certificate file %s not found", a.CACert)
 	}
 
-	// Client can bootstrap the CA from the OVN API
-	cmdPath, err := exec.LookPath(a.ctlCmd)
+	// Client can bootstrap the CA from the OVN API.  Use nbctl for both
+	// SB and NB since ovn-sbctl only supports --bootstrap-ca-cert from
+	// 2.9.90+.
+	// FIXME: change back to a.ctlCmd when sbctl supports --bootstrap-ca-cert
+	// https://github.com/openvswitch/ovs/pull/226
+	cmdPath, err := exec.LookPath("ovn-nbctl")
 	if err != nil {
 		return err
 	}
@@ -707,14 +715,26 @@ func (a *OvnDBAuth) SetDBAuth() error {
 			}
 		}
 	} else {
-		if err := setOVSExternalID(a.externalID, "\""+a.GetURL()+"\""); err != nil {
-			return err
-		}
 		if a.Scheme == OvnDBSchemeSSL {
 			// Client can bootstrap the CA cert from the DB
 			if err := a.ensureCACert(); err != nil {
 				return err
 			}
+
+			// Tell Southbound DB clients (like ovn-controller)
+			// which certificates to use to talk to the DB.
+			// Must happen *before* setting the "ovn-remote"
+			// external-id.
+			if a.ctlCmd == "ovn-sbctl" {
+				out, err := runOVSVsctl("set-ssl", a.PrivKey, a.Cert, a.CACert)
+				if err != nil {
+					return fmt.Errorf("error setting client southbound DB SSL options: %v\n  %q", err, out)
+				}
+			}
+		}
+
+		if err := setOVSExternalID(a.externalID, "\""+a.GetURL()+"\""); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -13,16 +13,14 @@ import (
 )
 
 const (
-	ovsCommandTimeout    = 5
-	ovsVsctlCommand      = "ovs-vsctl"
-	ovsOfctlCommand      = "ovs-ofctl"
-	ovnNbctlCommand      = "ovn-nbctl"
-	osRelease            = "/etc/os-release"
-	rhel                 = "RHEL"
-	ubuntu               = "Ubuntu"
-	windowsOS            = "windows"
-	ovnHostOptFileUbuntu = "/etc/default/ovn-host"
-	ovnHostOptFileRhel   = "/etc/sysconfig/ovn-controller"
+	ovsCommandTimeout = 5
+	ovsVsctlCommand   = "ovs-vsctl"
+	ovsOfctlCommand   = "ovs-ofctl"
+	ovnNbctlCommand   = "ovn-nbctl"
+	osRelease         = "/etc/os-release"
+	rhel              = "RHEL"
+	ubuntu            = "Ubuntu"
+	windowsOS         = "windows"
 )
 
 // PathExist checks the path exist or not.
@@ -69,156 +67,6 @@ func runningPlatform() (string, error) {
 		return "Photon", nil
 	}
 	return "", fmt.Errorf("Unknown platform")
-}
-
-// StartOVS starts OVS service
-func StartOVS() error {
-	platform, err := runningPlatform()
-	if err != nil {
-		return err
-	}
-	if platform == rhel {
-		out, err := exec.Command("systemctl", "start",
-			"openvswitch").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("error starting openvswitch "+
-				"service: %v\n  %q", err, string(out))
-		}
-	} else if platform == ubuntu {
-		out, err := exec.Command("service", "openvswitch-switch",
-			"start").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("error starting openvswitch "+
-				"service: %v\n  %q", err, string(out))
-		}
-	} else if platform == windowsOS {
-		out, err := exec.Command("powershell", "Start-Service",
-			"ovs*").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("error starting openvswitch "+
-				"service: %v\n  %q", err, string(out))
-		}
-	}
-	return nil
-}
-
-// StartOvnNorthd starts ovn-northd
-func StartOvnNorthd() error {
-	platform, err := runningPlatform()
-	if err != nil {
-		return err
-	}
-	if platform == rhel {
-		out, err := exec.Command("systemctl", "start",
-			"ovn-northd").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("error starting ovn-northd "+
-				"service: %v\n  %q", err, string(out))
-		}
-	} else if platform == ubuntu {
-		out, err := exec.Command("service", "ovn-central",
-			"start").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("error starting ovn-central "+
-				"service: %v\n  %q", err, string(out))
-		}
-	}
-	return nil
-}
-
-func persistOvnControllerOptions(clientAuth *config.OvnDBAuth,
-	platform string) error {
-	var ovnHostOptFile, textKey string
-	if platform == ubuntu {
-		ovnHostOptFile = ovnHostOptFileUbuntu
-		textKey = "OVN_CTL_OPTS"
-	} else if platform == rhel {
-		ovnHostOptFile = ovnHostOptFileRhel
-		textKey = "OVN_CONTROLLER_OPTS"
-	} else {
-		return nil
-	}
-
-	fileBytes, err := ioutil.ReadFile(ovnHostOptFile)
-	// if the file doesn't exist, then we will create the file as part of
-	// ioutil.Writefile() call later
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	index := 0
-	found := false
-	lines := []string{}
-	if len(fileBytes) != 0 {
-		lines = strings.Split(string(fileBytes), "\n")
-	}
-
-	for i, line := range lines {
-		line = strings.TrimLeft(line, "\n\t\r")
-		if !strings.HasPrefix(line, textKey) {
-			continue
-		}
-		index = i
-		found = true
-		break
-	}
-
-	ovnCtlOpt := fmt.Sprintf("%s=\"--ovn-controller-ssl-key=%s "+
-		"--ovn-controller-ssl-cert=%s "+
-		"--ovn-controller-ssl-bootstrap-ca-cert=%s\"\n",
-		textKey,
-		clientAuth.PrivKey,
-		clientAuth.Cert,
-		clientAuth.CACert)
-	if !found {
-		lines = append(lines, ovnCtlOpt)
-	} else {
-		lines[index] = ovnCtlOpt
-	}
-
-	// Note that if "/etc/default" directory itself is missing, then we error
-	// out here and we don't want to go about creating system directory with
-	// correct permissions
-	return ioutil.WriteFile(ovnHostOptFile, []byte(strings.Join(lines, "\n")),
-		0644)
-}
-
-// RestartOvnController restarts ovn-controller
-func RestartOvnController(clientAuth *config.OvnDBAuth) error {
-	platform, err := runningPlatform()
-	if err != nil {
-		return err
-	}
-	if clientAuth.Scheme == config.OvnDBSchemeSSL {
-		err := persistOvnControllerOptions(clientAuth, platform)
-		if err != nil {
-			return fmt.Errorf("error persisting OVN client certificate info "+
-				"(%v)", err)
-		}
-	}
-	if platform == rhel {
-		out, err := exec.Command("systemctl", "restart",
-			"ovn-controller").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("error starting ovn-controller "+
-				"service: %v\n  %q", err, string(out))
-		}
-	} else if platform == ubuntu {
-		out, err := exec.Command("service", "ovn-host",
-			"restart").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("error starting ovn-host "+
-				"service: %v\n  %q", err, string(out))
-		}
-	} else if platform == windowsOS {
-		out, err := exec.Command("powershell", "Restart-Service",
-			"ovn-controller").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("error starting ovn-controller "+
-				"service: %v\n  %q", err, string(out))
-		}
-	}
-	return nil
 }
 
 // RunOVSOfctl runs a command via ovs-ofctl.

--- a/vagrant/provisioning/setup-k8s-master.sh
+++ b/vagrant/provisioning/setup-k8s-master.sh
@@ -95,17 +95,9 @@ users:
 KUBECONFIG
 
 if [ $PROTOCOL = "ssl" ]; then
-  nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -net-controller -loglevel=4 \
- -k8s-apiserver="http://$OVERLAY_IP:8080" \
- -logfile="/var/log/openvswitch/ovnkube.log" \
- -init-master="k8smaster" -cluster-subnet="192.168.0.0/16" \
- -service-cluster-ip-range=172.16.1.0/24 \
- -nodeport \
- -nb-address="$PROTOCOL://$OVERLAY_IP:6631" \
- -nb-server-privkey /etc/openvswitch/ovnnb-privkey.pem \
+ SSL_ARGS="-nb-server-privkey /etc/openvswitch/ovnnb-privkey.pem \
  -nb-server-cert /etc/openvswitch/ovnnb-cert.pem \
  -nb-server-cacert /vagrant/pki/switchca/cacert.pem \
- -sb-address="$PROTOCOL://$OVERLAY_IP:6632" \
  -sb-server-privkey /etc/openvswitch/ovnsb-privkey.pem \
  -sb-server-cert /etc/openvswitch/ovnsb-cert.pem \
  -sb-server-cacert /vagrant/pki/switchca/cacert.pem  \
@@ -114,17 +106,18 @@ if [ $PROTOCOL = "ssl" ]; then
  -nb-client-cacert /etc/openvswitch/ovnnb-ca.cert \
  -sb-client-privkey /etc/openvswitch/ovncontroller-privkey.pem \
  -sb-client-cert /etc/openvswitch/ovncontroller-cert.pem \
- -sb-client-cacert /etc/openvswitch/ovnsb-ca.cert 2>&1 &
-else
-  nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -net-controller -loglevel=4 \
+ -sb-client-cacert /etc/openvswitch/ovnsb-ca.cert"
+fi
+
+nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -net-controller -loglevel=4 \
  -k8s-apiserver="http://$OVERLAY_IP:8080" \
  -logfile="/var/log/openvswitch/ovnkube.log" \
  -init-master="k8smaster" -cluster-subnet="192.168.0.0/16" \
  -service-cluster-ip-range=172.16.1.0/24 \
  -nodeport \
  -nb-address="$PROTOCOL://$OVERLAY_IP:6631" \
- -sb-address="$PROTOCOL://$OVERLAY_IP:6632" 2>&1 &
-fi
+ -sb-address="$PROTOCOL://$OVERLAY_IP:6632" \
+ ${SSL_ARGS} 2>&1 &
 
 
 # Setup some example yaml files

--- a/vagrant/provisioning/setup-k8s-minion.sh
+++ b/vagrant/provisioning/setup-k8s-minion.sh
@@ -65,34 +65,26 @@ popd
 
 # Initialize the minion and gateway.
 if [ $PROTOCOL = "ssl" ]; then
-nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
-    -logfile="/var/log/openvswitch/ovnkube.log" \
-    -k8s-apiserver="http://$MASTER_OVERLAY_IP:8080" \
-    -init-node="$MINION_NAME"  \
-    -nodeport \
-    -nb-address="$PROTOCOL://$MASTER_OVERLAY_IP:6631" \
-    -sb-address="$PROTOCOL://$MASTER_OVERLAY_IP:6632" -k8s-token="test" \
-    -nb-client-privkey /etc/openvswitch/ovncontroller-privkey.pem \
+  SSL_ARGS="-nb-client-privkey /etc/openvswitch/ovncontroller-privkey.pem \
     -nb-client-cert /etc/openvswitch/ovncontroller-cert.pem \
     -nb-client-cacert /etc/openvswitch/ovnnb-ca.cert \
     -sb-client-privkey /etc/openvswitch/ovncontroller-privkey.pem \
     -sb-client-cert /etc/openvswitch/ovncontroller-cert.pem \
-    -sb-client-cacert /etc/openvswitch/ovnsb-ca.cert \
-    -init-gateways -gateway-interface=enp0s9 -gateway-nexthop="$GW_IP" \
-    -service-cluster-ip-range=172.16.1.0/24 \
-    -cluster-subnet="192.168.0.0/16" 2>&1 &
-else
+    -sb-client-cacert /etc/openvswitch/ovnsb-ca.cert"
+fi
+
 nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -logfile="/var/log/openvswitch/ovnkube.log" \
     -k8s-apiserver="http://$MASTER_OVERLAY_IP:8080" \
     -init-node="$MINION_NAME"  \
     -nodeport \
     -nb-address="$PROTOCOL://$MASTER_OVERLAY_IP:6631" \
-    -sb-address="$PROTOCOL://$MASTER_OVERLAY_IP:6632" -k8s-token="test" \
+    -sb-address="$PROTOCOL://$MASTER_OVERLAY_IP:6632" \
+    ${SSL_ARGS} \
+    -k8s-token="test" \
     -init-gateways -gateway-interface=enp0s9 -gateway-nexthop="$GW_IP" \
     -service-cluster-ip-range=172.16.1.0/24 \
     -cluster-subnet="192.168.0.0/16" 2>&1 &
-fi
 
 # Restore xtrace
 $XTRACE

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -66,7 +66,7 @@ sudo apt-get install openvswitch-datapath-dkms=2.8.1-1 -y
 sudo apt-get install openvswitch-switch=2.8.1-1 openvswitch-common=2.8.1-1 libopenvswitch=2.8.1-1 -y
 sudo -H pip install ovs
 
-sudo apt-get install ovn-central=2.8.1-1 ovn-common=2.8.1-1 ovn-host=2.8.1-1 -y
+sudo apt-get install ovn-common=2.8.1-1 ovn-host=2.8.1-1 -y
 
 if [ -n "$SSL" ]; then
     echo "PROTOCOL=ssl" >> setup_minion_args.sh


### PR DESCRIPTION
Containerized/daemonset ovnkube shouldn't talk to service managers to
start/restart things it depends on.  Those things may even be containers
themselves which are not managed by systemd.

Instead, dependencies on OVS and northd should be handled by whatever
manages the lifecycle of ovnkube, whether that's systemd (via .service
files and Requires:) or Kubernetes (via front-end scripts that wait for
the dependencies to be ready).

For ovn-controller, we have verified that 2.8 and later automatically
pick up new ovn-remote external-ids and SSL certificates pushed to
the OVSDB via 'set-ssl'.  It no longer needs to be restarted or have
certificates persisted in config files, since all that information
is available from the OVSDB.

@alinbalutoiu anything we need to do on Windows to make sure the service dependencies work correctly, now that ovnkube no longer starts OVS/OVN?

@rajatchopra @shettyg @pecameron anything else you can think of here that I may have missed?  A 'vagrant up' works for me and I can start/stop pods and they appear to work from different nodes.