### PR TITLE
go-controller: Use a timeout for local unix socket calls.

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -54,9 +54,6 @@ type Controller struct {
 }
 
 const (
-	// OvnNbctl is the constant string for the ovn-nbctl shell command
-	OvnNbctl = "ovn-nbctl"
-
 	// TCP is the constant string for the string "TCP"
 	TCP = "TCP"
 

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -91,9 +91,10 @@ func (ovn *Controller) syncServices(services []interface{}) {
 
 	// For each gateway, remove any VIP that does not exist in
 	// 'nodeportServices'.
-	gateways, err := ovn.getOvnGateways()
+	gateways, stderr, err := ovn.getOvnGateways()
 	if err != nil {
-		logrus.Errorf("failed to get ovn gateways. Not syncing nodeport")
+		logrus.Errorf("failed to get ovn gateways. Not syncing nodeport"+
+			"stdout: %q, stderr: %q (%v)", gateways, stderr, err)
 		return
 	}
 

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -105,7 +105,28 @@ func RunOVSVsctl(args ...string) (string, string, error) {
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 
-// RunOVNNbctlWithTimeout runs command via ovs-nbctl with a specific timeout
+// RunOVNNbctlUnix runs command via ovn-nbctl, with ovn-nbctl using the unix
+// domain sockets to connect to the ovsdb-server backing the OVN NB database.
+func RunOVNNbctlUnix(args ...string) (string, string, error) {
+	cmdPath, err := exec.LookPath(ovnNbctlCommand)
+	if err != nil {
+		return "", "", err
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmdArgs := []string{fmt.Sprintf("--timeout=%d", ovsCommandTimeout)}
+	cmdArgs = append(cmdArgs, args...)
+	cmd := exec.Command(cmdPath, cmdArgs...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err = cmd.Run()
+	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
+}
+
+// RunOVNNbctlWithTimeout runs command via ovn-nbctl with a specific timeout
 func RunOVNNbctlWithTimeout(timeout int, args ...string) (string, string,
 	error) {
 	cmdPath, err := exec.LookPath(ovnNbctlCommand)
@@ -143,7 +164,7 @@ func RunOVNNbctlWithTimeout(timeout int, args ...string) (string, string,
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 
-// RunOVNNbctl runs a command via ovs-nbctl.
+// RunOVNNbctl runs a command via ovn-nbctl.
 func RunOVNNbctl(args ...string) (string, string, error) {
 	return RunOVNNbctlWithTimeout(ovsCommandTimeout, args...)
 }

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"unicode"
 
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
 )
@@ -123,7 +124,8 @@ func RunOVNNbctlUnix(args ...string) (string, string, error) {
 	cmd.Stderr = stderr
 
 	err = cmd.Run()
-	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
+	return strings.Trim(strings.TrimFunc(stdout.String(), unicode.IsSpace), "\""),
+		stderr.String(), err
 }
 
 // RunOVNNbctlWithTimeout runs command via ovn-nbctl with a specific timeout


### PR DESCRIPTION
    go-controller: Use a timeout for local unix socket calls.

    Currently, we are running ovn-nbctl commands in the watcher
    to program OVN NB database whenever there are events from
    kubernetes. But there is no timeout for these calls. If for
    some reason, the command hangs, then our watcher will be
    blocked.

    With this commit, we will use RunOVNNbctlUnix() function
    from util package. The return type is alredy stringified
    with spaces and quotes removed. So at some places, I
    had to remove the string conversions and trimming spaces
    and quotes.

    Signed-off-by: Gurucharan Shetty <guru@ovn.org>