### PR TITLE
ovn-k8s-overlay: Ability to remove node.

### DIFF
--- a/go-controller/cmd/ovn-k8s-overlay/app/remove-node.go
+++ b/go-controller/cmd/ovn-k8s-overlay/app/remove-node.go
@@ -1,0 +1,117 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+// RemoveNode removes all the NB DB objects created for that node.
+var RemoveNode = cli.Command{
+	Name:  "remove-node",
+	Usage: "Remove a node from the OVN cluster",
+	Flags: append([]cli.Flag{
+		cli.StringFlag{
+			Name:  "node-name",
+			Usage: "A unique node name.",
+		},
+	}, config.Flags...),
+	Action: func(context *cli.Context) error {
+		if err := removeNode(context); err != nil {
+			return fmt.Errorf("failed init gateway: %v", err)
+		}
+		return nil
+	},
+}
+
+func removeNode(context *cli.Context) error {
+	if err := config.InitConfig(context, nil); err != nil {
+		return err
+	}
+
+	nodeName := context.String("node-name")
+	if nodeName == "" {
+		return fmt.Errorf("argument --node-name should be non-null")
+	}
+
+	// Get the cluster router
+	clusterRouter, err := util.GetK8sClusterRouter()
+	if err != nil {
+		return fmt.Errorf("failed to get cluster router")
+	}
+
+	// Remove the logical switch associated with nodeName
+	_, stderr, err := util.RunOVNNbctl("--if-exist", "ls-del", nodeName)
+	if err != nil {
+		return fmt.Errorf("Failed to delete logical switch %s, "+
+			"stderr: %q, error: %v", nodeName, stderr, err)
+	}
+
+	gatewayRouter := fmt.Sprintf("GR_%s", nodeName)
+
+	// Get the gateway router port's IP address (connected to join switch)
+	var routerIP string
+	routerIPNetwork, stderr, err := util.RunOVNNbctl("--if-exist", "get",
+		"logical_router_port", "rtoj-"+gatewayRouter, "networks")
+	if err != nil {
+		return fmt.Errorf("Failed to get logical router port, stderr: %q, "+
+			"error: %v", stderr, err)
+	}
+
+	if routerIPNetwork != "" {
+		routerIPNetwork = strings.Trim(routerIPNetwork, "[]\"")
+		if routerIPNetwork != "" {
+			routerIP = strings.Split(routerIPNetwork, "/")[0]
+		}
+	}
+
+	if routerIP != "" {
+		// Get a list of all the routes in cluster router with this gateway
+		// Router as the next hop.
+		var uuids string
+		uuids, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading",
+			"--columns=_uuid", "find", "logical_router_static_route",
+			"nexthop="+routerIP)
+		if err != nil {
+			return fmt.Errorf("Failed to fetch all routes with gateway "+
+				"router %s as nexthop, stderr: %q, "+
+				"error: %v", gatewayRouter, stderr, err)
+		}
+
+		// Remove all the routes in cluster router with this gateway Router
+		// as the nexthop.
+		routes := strings.Fields(uuids)
+		for _, route := range routes {
+			_, stderr, err = util.RunOVNNbctl("--if-exists", "remove",
+				"logical_router", clusterRouter, "static_routes", route)
+			if err != nil {
+				logrus.Errorf("Failed to delete static route %s"+
+					", stderr: %q, err = %v", route, stderr, err)
+				continue
+			}
+		}
+	}
+
+	// Remove any gateway routers associated with nodeName
+	_, stderr, err = util.RunOVNNbctl("--if-exist", "lr-del",
+		gatewayRouter)
+	if err != nil {
+		return fmt.Errorf("Failed to delete gateway router %s, stderr: %q, "+
+			"error: %v", gatewayRouter, stderr, err)
+	}
+
+	// Remove external switch
+	externalSwitch := "ext_" + nodeName
+	_, stderr, err = util.RunOVNNbctl("--if-exist", "ls-del",
+		externalSwitch)
+	if err != nil {
+		return fmt.Errorf("Failed to delete external switch %s, stderr: %q, "+
+			"error: %v", externalSwitch, stderr, err)
+	}
+
+	return nil
+}

--- a/go-controller/cmd/ovn-k8s-overlay/ovn-k8s-overlay.go
+++ b/go-controller/cmd/ovn-k8s-overlay/ovn-k8s-overlay.go
@@ -16,6 +16,7 @@ func main() {
 
 	c.Commands = []cli.Command{
 		app.InitGatewayCmd,
+		app.RemoveNode,
 	}
 
 	if err := c.Run(os.Args); err != nil {

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -140,25 +140,23 @@ func RunOVNNbctlWithTimeout(timeout int, args ...string) (string, string,
 	stderr := &bytes.Buffer{}
 
 	var cmd *exec.Cmd
+	var cmdArgs []string
 	if config.OvnNorth.ClientAuth.Scheme == config.OvnDBSchemeSSL {
-		cmdArgs := []string{
+		cmdArgs = []string{
 			fmt.Sprintf("--private-key=%s", config.OvnNorth.ClientAuth.PrivKey),
 			fmt.Sprintf("--certificate=%s", config.OvnNorth.ClientAuth.Cert),
 			fmt.Sprintf("--bootstrap-ca-cert=%s", config.OvnNorth.ClientAuth.CACert),
 			fmt.Sprintf("--db=%s", config.OvnNorth.ClientAuth.GetURL()),
-			fmt.Sprintf("--timeout=%d", timeout),
 		}
-		cmdArgs = append(cmdArgs, args...)
-		cmd = exec.Command(cmdPath, cmdArgs...)
-	} else {
-		cmdArgs := []string{
+	} else if config.OvnNorth.ClientAuth.Scheme == config.OvnDBSchemeTCP {
+		cmdArgs = []string{
 			fmt.Sprintf("--db=%s", config.OvnNorth.ClientAuth.GetURL()),
-			fmt.Sprintf("--timeout=%d", timeout),
 		}
-		cmdArgs = append(cmdArgs, args...)
-		cmd = exec.Command(cmdPath, cmdArgs...)
 	}
 
+	cmdArgs = append(cmdArgs, fmt.Sprintf("--timeout=%d", timeout))
+	cmdArgs = append(cmdArgs, args...)
+	cmd = exec.Command(cmdPath, cmdArgs...)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 


### PR DESCRIPTION
    You can run this on a master node:
    ovn-k8s-overlay remove-node --node-name k8sminion2

    Or run this on any other node:
    ovn-k8s-overlay remove-node --node-name k8sminion2 \
    -nb-address=$NB_ADDRESS \
    -nb-client-privkey /etc/openvswitch/ovncontroller-privkey.pem \
    -nb-client-cert /etc/openvswitch/ovncontroller-cert.pem \
    -nb-client-cacert /etc/openvswitch/ovnnb-ca.cert

    The code does not try to remove the OVS bridge on the node. The
    thought process is that:
    1. We already have a 'ovn-kube-util bridges-to-nic' option for that.
    2. We want to be able to run this command on the master.
    3. We can in the future have a node watcher in master that will
    call this whenever a node gets deleted.

    Signed-off-by: Gurucharan Shetty <guru@ovn.org>