### PR TITLE
ovn-k8s-cni-overlay: implement bandwidth shaping outside OVN

### DIFF
--- a/go-controller/cmd/ovn-k8s-cni-overlay/app/bandwidth.go
+++ b/go-controller/cmd/ovn-k8s-cni-overlay/app/bandwidth.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"fmt"
+)
+
+func clearPodBandwidth(sandboxID string) error {
+	// interfaces will have the same name as ports
+	portList, err := ovsFind("interface", "name", "external-ids:sandbox="+sandboxID)
+	if err != nil {
+		return err
+	}
+
+	// Clear the QoS for any ports of this sandbox
+	for _, port := range portList {
+		if err = ovsClear("port", port, "qos"); err != nil {
+			return err
+		}
+	}
+
+	// Now that the QoS is unused remove it
+	qosList, err := ovsFind("qos", "_uuid", "external-ids:sandbox="+sandboxID)
+	if err != nil {
+		return err
+	}
+	for _, qos := range qosList {
+		if err := ovsDestroy("qos", qos); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func setPodBandwidth(sandboxID, ifname string, ingressBPS, egressBPS int64) error {
+	// note pod ingress == OVS egress and vice versa
+
+	if ingressBPS > 0 {
+		qos, err := ovsCreate("qos", "type=linux-htb", fmt.Sprintf("other-config:max-rate=%d", ingressBPS), "external-ids=sandbox="+sandboxID)
+		if err != nil {
+			return err
+		}
+		err = ovsSet("port", ifname, fmt.Sprintf("qos=%s", qos))
+		if err != nil {
+			return err
+		}
+	}
+	if egressBPS > 0 {
+		// ingress_policing_rate is in Kbps
+		err := ovsSet("interface", ifname, fmt.Sprintf("ingress_policing_rate=%d", egressBPS/1000))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go-controller/cmd/ovn-k8s-cni-overlay/app/helper_windows.go
+++ b/go-controller/cmd/ovn-k8s-cni-overlay/app/helper_windows.go
@@ -110,7 +110,9 @@ func deleteHNSEndpoint(endpointName string) error {
 // The fact that CNI add should be idempotent on Windows is stated here:
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/network/cni/cni_windows.go#L38
 // TODO: add proper MTU config (GetCurrentThreadId/SetCurrentThreadId) or via OVS properties
-func ConfigureInterface(args *skel.CmdArgs, namespace string, conf *config.OVNNetConf, podName string, macAddress string, ipAddress string, gatewayIP string, mtu int) ([]*current.Interface, error) {
+func ConfigureInterface(args *skel.CmdArgs, namespace string, conf *config.OVNNetConf,
+	podName string, macAddress string, ipAddress string, gatewayIP string,
+	mtu int, ingress, egress int64) ([]*current.Interface, error) {
 	ipAddr, ipNet, err := net.ParseCIDR(ipAddress)
 	if err != nil {
 		return nil, err
@@ -196,6 +198,14 @@ func ConfigureInterface(args *skel.CmdArgs, namespace string, conf *config.OVNNe
 		logrus.Warningf("Failed to set MTU on endpoint, reason: %q", err)
 	}
 
+	// TODO: uncomment when OVS QoS is supported on Windows
+	//if err = clearPodBandwidth(args.ContainerID); err != nil {
+	//	return nil, err
+	//}
+	//if err = setPodBandwidth(args.ContainerID, endpointName, ingress, egress); err != nil {
+	//	return nil, err
+	//}
+
 	return []*current.Interface{}, nil
 }
 
@@ -225,5 +235,7 @@ func PlatformSpecificCleanup(args *skel.CmdArgs, argsMap map[string]string) erro
 	if err = deleteHNSEndpoint(endpointName); err != nil {
 		logrus.Warningf("failed to delete HNSEndpoint %v: %v", endpointName, err)
 	}
+	// TODO: uncomment when OVS QoS is supported on Windows
+	// _ = clearPodBandwidth(args.ContainerID)
 	return nil
 }

--- a/go-controller/cmd/ovn-k8s-cni-overlay/app/ovs.go
+++ b/go-controller/cmd/ovn-k8s-cni-overlay/app/ovs.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func ovsExec(args ...string) (string, error) {
+	args = append([]string{"--timeout=30"}, args...)
+	output, err := exec.Command("ovs-vsctl", args...).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to run 'ovs-vsctl %s': %v\n  %q", strings.Join(args, " "), err, string(output))
+	}
+
+	outStr := string(output)
+	trimmed := strings.TrimSpace(outStr)
+	// If output is a single line, strip the trailing newline
+	if strings.Count(trimmed, "\n") == 0 {
+		outStr = trimmed
+	}
+
+	return outStr, nil
+}
+
+func ovsCreate(table string, values ...string) (string, error) {
+	args := append([]string{"create", table}, values...)
+	return ovsExec(args...)
+}
+
+func ovsDestroy(table, record string) error {
+	_, err := ovsExec("--if-exists", "destroy", table, record)
+	return err
+}
+
+func ovsSet(table, record string, values ...string) error {
+	args := append([]string{"set", table, record}, values...)
+	_, err := ovsExec(args...)
+	return err
+}
+
+// Returns the given column of records that match the condition
+func ovsFind(table, column, condition string) ([]string, error) {
+	output, err := ovsExec("--no-heading", "--columns="+column, "find", table, condition)
+	if err != nil {
+		return nil, err
+	}
+	values := strings.Split(output, "\n\n")
+	// We want "bare" values for strings, but we can't pass --bare to ovs-vsctl because
+	// it breaks more complicated types. So try passing each value through Unquote();
+	// if it fails, that means the value wasn't a quoted string, so use it as-is.
+	for i, val := range values {
+		if unquoted, err := strconv.Unquote(val); err == nil {
+			values[i] = unquoted
+		}
+	}
+	return values, nil
+}
+
+func ovsClear(table, record string, columns ...string) error {
+	args := append([]string{"--if-exists", "clear", table, record}, columns...)
+	_, err := ovsExec(args...)
+	return err
+}

--- a/go-controller/vendor/github.com/vishvananda/netlink/handle_unspecified.go
+++ b/go-controller/vendor/github.com/vishvananda/netlink/handle_unspecified.go
@@ -145,6 +145,10 @@ func (h *Handle) LinkSetFlood(link Link, mode bool) error {
 	return ErrNotImplemented
 }
 
+func (h *Handle) LinkSetTxQLen(link Link, qlen int) error {
+	return ErrNotImplemented
+}
+
 func (h *Handle) setProtinfoAttr(link Link, mode bool, attr int) error {
 	return ErrNotImplemented
 }

--- a/go-controller/vendor/github.com/vishvananda/netlink/link.go
+++ b/go-controller/vendor/github.com/vishvananda/netlink/link.go
@@ -732,6 +732,28 @@ func (iptun *Vti) Type() string {
 	return "vti"
 }
 
+type Gretun struct {
+	LinkAttrs
+	Link     uint32
+	IFlags   uint16
+	OFlags   uint16
+	IKey     uint32
+	OKey     uint32
+	Local    net.IP
+	Remote   net.IP
+	Ttl      uint8
+	Tos      uint8
+	PMtuDisc uint8
+}
+
+func (gretun *Gretun) Attrs() *LinkAttrs {
+	return &gretun.LinkAttrs
+}
+
+func (gretun *Gretun) Type() string {
+	return "gre"
+}
+
 type Vrf struct {
 	LinkAttrs
 	Table uint32

--- a/go-controller/vendor/github.com/vishvananda/netlink/neigh.go
+++ b/go-controller/vendor/github.com/vishvananda/netlink/neigh.go
@@ -14,6 +14,7 @@ type Neigh struct {
 	Flags        int
 	IP           net.IP
 	HardwareAddr net.HardwareAddr
+	LLIPAddr     net.IP //Used in the case of NHRP
 }
 
 // String returns $ip/$hwaddr $label

--- a/go-controller/vendor/github.com/vishvananda/netlink/netlink_unspecified.go
+++ b/go-controller/vendor/github.com/vishvananda/netlink/netlink_unspecified.go
@@ -108,6 +108,10 @@ func LinkSetFlood(link Link, mode bool) error {
 	return ErrNotImplemented
 }
 
+func LinkSetTxQLen(link Link, qlen int) error {
+	return ErrNotImplemented
+}
+
 func LinkAdd(link Link) error {
 	return ErrNotImplemented
 }

--- a/go-controller/vendor/github.com/vishvananda/netlink/rule.go
+++ b/go-controller/vendor/github.com/vishvananda/netlink/rule.go
@@ -8,6 +8,7 @@ import (
 // Rule represents a netlink rule.
 type Rule struct {
 	Priority          int
+	Family            int
 	Table             int
 	Mark              int
 	Mask              int

--- a/go-controller/vendor/github.com/vishvananda/netlink/rule_linux.go
+++ b/go-controller/vendor/github.com/vishvananda/netlink/rule_linux.go
@@ -37,6 +37,9 @@ func (h *Handle) RuleDel(rule *Rule) error {
 func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 	msg := nl.NewRtMsg()
 	msg.Family = syscall.AF_INET
+	if rule.Family != 0 {
+		msg.Family = uint8(rule.Family)
+	}
 	var dstFamily uint8
 
 	var rtAttrs []*nl.RtAttr

--- a/go-controller/vendor/vendor.json
+++ b/go-controller/vendor/vendor.json
@@ -81,10 +81,10 @@
 			"revisionTime": "2017-12-12T16:34:29Z"
 		},
 		{
-			"checksumSHA1": "Xx7Xi4y9emMxnLBmffT4znp4kj0=",
+			"checksumSHA1": "DSXZnN+OjzFCR1qoAo49MAfaVgI=",
 			"path": "github.com/vishvananda/netlink",
-			"revision": "f5a6f697a596c788d474984a38a0ac4ba0719e93",
-			"revisionTime": "2017-07-24T20:03:20Z"
+			"revision": "933b978eae8c18daa1077a0eb7186b689cd9f82d",
+			"revisionTime": "2017-09-02T20:36:53Z"
 		},
 		{
 			"checksumSHA1": "sCVVNugUvrGiFLA0nBNcWHoEhRI=",


### PR DESCRIPTION
OVN's QoS needs some clarification, as the manpages state that the QoS table only works with userspace DPDK.  Until that happens (and if true, QoS gets implemented for non-DPDK), implement bandwidth shaping by porting the openshift-sdn code over that handles it directly in OVS.

Not supported on Windows for now; @alinbalutoiu any idea what that would take?

@rajatchopra @shettyg 