### PR TITLE
gateway-init: Prevent duplicate NAT entries.

### DIFF
--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -397,9 +397,8 @@ func GatewayInit(clusterIPSubnet, nodeName, nicIP, physicalInterface,
 	}
 
 	// Default SNAT rules.
-	stdout, stderr, err = RunOVNNbctl("--", "--id=@nat", "create", "nat",
-		"type=snat", "logical_ip="+clusterIPSubnet, "external_ip="+physicalIP,
-		"--", "add", "logical_router", gatewayRouter, "nat", "@nat")
+	stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-nat-add",
+		gatewayRouter, "snat", physicalIP, clusterIPSubnet)
 	if err != nil {
 		logrus.Errorf("Failed to create default SNAT rules, stdout: %q, "+
 			"stderr: %q, error: %v", stdout, stderr, err)


### PR DESCRIPTION
Running gateway-init multiple times (a valid scenario
with a reboot) would create multiple duplicate NAT entries.
This prevents it.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>