### PR TITLE
support named ports for services

### DIFF
--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -160,16 +160,8 @@ func (ovn *Controller) deleteService(service *kapi.Service) {
 			protocol = TCP
 		}
 
-		// TODO: Support named ports.
-		if svcPort.TargetPort.Type == 1 {
-			continue
-		}
-
-		targetPort := svcPort.TargetPort.IntVal
-		if targetPort == 0 {
-			targetPort = svcPort.Port
-		}
-
+		// targetPort can be anything, the deletion logic does not use it
+		var targetPort int32
 		if service.Spec.Type == kapi.ServiceTypeNodePort && ovn.nodePortEnable {
 			// Delete the 'NodePort' service from a load-balancer instantiated in gateways.
 			err := ovn.createGatewaysVIP(string(protocol), port, targetPort, ips)


### PR DESCRIPTION
Fixes #134 
We do not need to maintain a cache of container port names to integers. Matching the endpoint's ports are created after resolving the port names. To match the correct svcPort to the matching endpointPort, we can just match the servicePortName.
Tested by hand.
Signed-off-by: Rajat Chopra <rchopra@redhat.com>