### PR TITLE
pkg/util: fall back to reading kubeconfig from container environment

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -38,7 +38,10 @@ func NewClientset(conf *config.KubernetesConfig) (*kubernetes.Clientset, error) 
 	} else if strings.HasPrefix(conf.APIServer, "http") {
 		kconfig, err = clientcmd.BuildConfigFromFlags(conf.APIServer, "")
 	} else {
-		err = fmt.Errorf("a kubeconfig file or server/token/tls credentials are required")
+		// Assume we are running from a container managed by kubernetes
+		// and read the apiserver address and tokens from the
+		// container's environment.
+		kconfig, err = rest.InClusterConfig()
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In a daemonset Kubernetes will provide the apiserver address via
the container environment and will map the token and CAcert into
/var/run/secrets/kubernetes.io/serviceaccount/.

So if neither the kubeconfig nor the apiserver are given via
configuration, try to read the necessary information from the
container environment instead.

@rajatchopra @shettyg @pecameron 