### PR TITLE
ovn-k8s-cni-overlay: Update Windows CNI and remove the workarounds

### DIFF
--- a/go-controller/cmd/ovn-k8s-cni-overlay/app/helper_linux.go
+++ b/go-controller/cmd/ovn-k8s-cni-overlay/app/helper_linux.go
@@ -133,7 +133,7 @@ func ConfigureInterface(args *skel.CmdArgs, namespace string, podName string, ma
 }
 
 // PlatformSpecificCleanup deletes the OVS port
-func PlatformSpecificCleanup(args *skel.CmdArgs) error {
+func PlatformSpecificCleanup(args *skel.CmdArgs, argsMap map[string]string) error {
 	ifaceName := args.ContainerID[:15]
 	ovsArgs := []string{
 		"del-port", "br-int", ifaceName,
@@ -144,9 +144,4 @@ func PlatformSpecificCleanup(args *skel.CmdArgs) error {
 		logrus.Warningf("failed to delete OVS port %s: %v\n  %q", ifaceName, err, string(out))
 	}
 	return nil
-}
-
-// InitialPlatformCheck does nothing on Linux.
-func InitialPlatformCheck(args *skel.CmdArgs) (bool, *current.Result) {
-	return false, &current.Result{}
 }

--- a/go-controller/cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
+++ b/go-controller/cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
@@ -80,15 +80,6 @@ func cmdAdd(ctx *cli.Context, args *skel.CmdArgs) error {
 	}
 	kubecli := &kube.Kube{KClient: clientset}
 
-	// TODO: Remove the following once the Kubernetes will get
-	// proper Windows CNI support.
-	// NOTE Windows ONLY: there are some cases where we want to return here
-	// and not to continue
-	stop, fakeResult := app.InitialPlatformCheck(args)
-	if stop {
-		return types.PrintResult(fakeResult, conf.CNIVersion)
-	}
-
 	// Get the IP address and MAC address from the API server.
 	// Exponential back off ~32 seconds + 7* t(api call)
 	var annotationBackoff = wait.Backoff{Duration: 1 * time.Second, Steps: 7, Factor: 1.5, Jitter: 0.1}
@@ -158,7 +149,10 @@ func cmdAdd(ctx *cli.Context, args *skel.CmdArgs) error {
 }
 
 func cmdDel(args *skel.CmdArgs) error {
-	return app.PlatformSpecificCleanup(args)
+	// argsMap is used only on Windows. Ignore the error, DEL should be idempotent
+	argsMap, _ := argString2Map(args.Args)
+
+	return app.PlatformSpecificCleanup(args, argsMap)
 }
 
 func main() {


### PR DESCRIPTION
This commit removes the Windows specific workarounds and makes it
look more similar to the Linux code.

The endpoint name should not depend on the container details passed
to the CNI (e.g. container ID). This is because kubelet calls
at the moment the CNI for every container within a pod when it should
be called only for the sandbox container.

Signed-off-by: Alin Balutoiu <abalutoiu@cloudbasesolutions.com>