### PR TITLE
vagrant: Use a custom debian server.

### DIFF
--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -31,8 +31,8 @@ sudo rm -rf /var/lib/apt/lists/*
 # Add external repos to install docker and OVS from packages.
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates
-echo "deb https://packages.wand.net.nz $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/wand.list
-sudo curl https://packages.wand.net.nz/keyring.gpg -o /etc/apt/trusted.gpg.d/wand.gpg
+echo "deb http://18.191.116.101/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
+wget -O - http://18.191.116.101/openvswitch/keyFile |  sudo apt-key add -
 sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 sudo su -c "echo \"deb https://apt.dockerproject.org/repo ubuntu-xenial main\" >> /etc/apt/sources.list.d/docker.list"
 sudo apt-get update
@@ -48,11 +48,11 @@ sudo apt-get build-dep dkms
 sudo apt-get install python-six openssl python-pip -y
 sudo -H pip install --upgrade pip
 
-sudo apt-get install openvswitch-datapath-dkms=2.8.1-1 -y
-sudo apt-get install openvswitch-switch=2.8.1-1 openvswitch-common=2.8.1-1 libopenvswitch=2.8.1-1 -y
+sudo apt-get install openvswitch-datapath-dkms=2.9.2-1 -y
+sudo apt-get install openvswitch-switch=2.9.2-1 openvswitch-common=2.9.2-1 libopenvswitch=2.9.2-1 -y
 sudo -H pip install ovs
 
-sudo apt-get install ovn-central=2.8.1-1 ovn-common=2.8.1-1 ovn-host=2.8.1-1 -y
+sudo apt-get install ovn-central=2.9.2-1 ovn-common=2.9.2-1 ovn-host=2.9.2-1 -y
 
 
 if [ -n "$SSL" ]; then

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -46,8 +46,8 @@ sudo rm -rf /var/lib/apt/lists/*
 # Add external repos to install docker and OVS from packages.
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates
-echo "deb https://packages.wand.net.nz $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/wand.list
-sudo curl https://packages.wand.net.nz/keyring.gpg -o /etc/apt/trusted.gpg.d/wand.gpg
+echo "deb http://18.191.116.101/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
+wget -O - http://18.191.116.101/openvswitch/keyFile |  sudo apt-key add -
 sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 sudo su -c "echo \"deb https://apt.dockerproject.org/repo ubuntu-xenial main\" >> /etc/apt/sources.list.d/docker.list"
 sudo apt-get update
@@ -62,11 +62,11 @@ sudo service docker start
 sudo apt-get build-dep dkms
 sudo apt-get install python-six openssl -y
 
-sudo apt-get install openvswitch-datapath-dkms=2.8.1-1 -y
-sudo apt-get install openvswitch-switch=2.8.1-1 openvswitch-common=2.8.1-1 libopenvswitch=2.8.1-1 -y
+sudo apt-get install openvswitch-datapath-dkms=2.9.2-1 -y
+sudo apt-get install openvswitch-switch=2.9.2-1 openvswitch-common=2.9.2-1 libopenvswitch=2.9.2-1 -y
 sudo -H pip install ovs
 
-sudo apt-get install ovn-common=2.8.1-1 ovn-host=2.8.1-1 -y
+sudo apt-get install ovn-common=2.9.2-1 ovn-host=2.9.2-1 -y
 
 if [ -n "$SSL" ]; then
     echo "PROTOCOL=ssl" >> setup_minion_args.sh


### PR DESCRIPTION
We were using packages.wand.net.nz to download deb files for OVS/OVN.
But, with OVS 2.9.x, they have changed the startup scripts
to be different than what we provide in OVS. Their startup
scripts have bugs in them.

So I decided to create a new debian repo for ovn-kubernetes
project - till we have a better solution.  We need this
because OVS 2.9.1 was released last week and it has fixes
that we can take.

OVS 2.9.1 also has raft based clustering for OVSDB databases.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>