### PR TITLE
go-controller: use exec interface to run external binaries to help unit-testing

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/gateway_init.go
+++ b/go-controller/cmd/ovn-kube-util/app/gateway_init.go
@@ -6,6 +6,8 @@ import (
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli"
+
+	kexec "k8s.io/utils/exec"
 )
 
 // InitGatewayCmd initializes k8s gateway node.
@@ -55,7 +57,12 @@ var InitGatewayCmd = cli.Command{
 }
 
 func initGateway(context *cli.Context) error {
-	if _, err := config.InitConfig(context, &config.Defaults{OvnNorthAddress: true}); err != nil {
+	exec := kexec.New()
+	if err := util.SetExec(exec); err != nil {
+		return err
+	}
+
+	if _, err := config.InitConfig(context, exec, &config.Defaults{OvnNorthAddress: true}); err != nil {
 		return err
 	}
 

--- a/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
+++ b/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli"
 	"k8s.io/apimachinery/pkg/util/errors"
+	kexec "k8s.io/utils/exec"
 )
 
 // NicsToBridgeCommand creates ovs bridge for provided nic interfaces.
@@ -17,6 +18,10 @@ var NicsToBridgeCommand = cli.Command{
 		args := context.Args()
 		if len(args) == 0 {
 			return fmt.Errorf("Please specify list of nic interfaces")
+		}
+
+		if err := util.SetExec(kexec.New()); err != nil {
+			return err
 		}
 
 		var errorList []error
@@ -39,6 +44,10 @@ var BridgesToNicCommand = cli.Command{
 		args := context.Args()
 		if len(args) == 0 {
 			return fmt.Errorf("Please specify list of bridges")
+		}
+
+		if err := util.SetExec(kexec.New()); err != nil {
+			return err
 		}
 
 		var errorList []error

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -17,6 +17,8 @@ import (
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/ovn"
 	util "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+
+	kexec "k8s.io/utils/exec"
 )
 
 func main() {
@@ -125,7 +127,8 @@ func delPidfile(pidfile string) {
 }
 
 func runOvnKube(ctx *cli.Context) error {
-	_, err := config.InitConfig(ctx, nil)
+	exec := kexec.New()
+	_, err := config.InitConfig(ctx, exec, nil)
 	if err != nil {
 		return err
 	}
@@ -168,6 +171,11 @@ func runOvnKube(ctx *cli.Context) error {
 				os.Exit(1)
 			}
 		}
+	}
+
+	if err = util.SetExec(exec); err != nil {
+		logrus.Errorf("Failed to initialize exec helper: %v", err)
+		return err
 	}
 
 	nodeToRemove := ctx.String("remove-node")

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -1,0 +1,97 @@
+package cluster
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/urfave/cli"
+	fakeexec "k8s.io/utils/exec/testing"
+
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClusterNode(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster Node Suite")
+}
+
+var tmpDir string
+
+var _ = AfterSuite(func() {
+	err := os.RemoveAll(tmpDir)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func createTempFile(name string) (string, error) {
+	fname := filepath.Join(tmpDir, name)
+	if err := ioutil.WriteFile(fname, []byte{0x20}, 0644); err != nil {
+		return "", err
+	}
+	return fname, nil
+}
+
+var _ = Describe("Node Operations", func() {
+	var tmpErr error
+	var app *cli.App
+
+	tmpDir, tmpErr = ioutil.TempDir("", "clusternodetest_certdir")
+	if tmpErr != nil {
+		GinkgoT().Errorf("failed to create tempdir: %v", tmpErr)
+	}
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.RestoreDefaultConfig()
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+	})
+
+	It("sets correct OVN external IDs", func() {
+		app.Action = func(ctx *cli.Context) error {
+			cacert, err := createTempFile("kube-cacert.pem")
+			Expect(err).NotTo(HaveOccurred())
+
+			const (
+				nodeName  string = "1.2.5.6"
+				apiserver string = "https://1.2.3.4:8080"
+				token     string = "adsfadsfasdfasdfasfaf"
+			)
+
+			fakeCmds := ovntest.AddFakeCmd(nil, &ovntest.ExpectedCmd{
+				Cmd: "ovs-vsctl --timeout=5 set Open_vSwitch . external_ids:ovn-encap-type=geneve external_ids:ovn-encap-ip=" + nodeName,
+			})
+
+			fexec := &fakeexec.FakeExec{
+				CommandScript: fakeCmds,
+				LookPathFunc: func(file string) (string, error) {
+					return fmt.Sprintf("/fake-bin/%s", file), nil
+				},
+			}
+
+			err = util.SetExec(fexec)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = setupOVNNode(nodeName, apiserver, token, cacert)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fexec.CommandCalls).To(Equal(len(fakeCmds)))
+			return nil
+		}
+
+		err := app.Run([]string{app.Name})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -128,7 +128,7 @@ const (
 	OvnDBSchemeUnix OvnDBScheme = "unix"
 )
 
-// config is used to read the structured config file
+// Config is used to read the structured config file and to cache config in testcases
 type config struct {
 	Default    DefaultConfig
 	Logging    LoggingConfig
@@ -136,6 +136,36 @@ type config struct {
 	Kubernetes KubernetesConfig
 	OvnNorth   rawOvnAuthConfig
 	OvnSouth   rawOvnAuthConfig
+}
+
+var (
+	savedDefault    DefaultConfig
+	savedLogging    LoggingConfig
+	savedCNI        CNIConfig
+	savedKubernetes KubernetesConfig
+	savedOvnNorth   OvnAuthConfig
+	savedOvnSouth   OvnAuthConfig
+)
+
+func init() {
+	// Cache original default config values so they can be restored by testcases
+	savedDefault = Default
+	savedLogging = Logging
+	savedCNI = CNI
+	savedKubernetes = Kubernetes
+	savedOvnNorth = OvnNorth
+	savedOvnSouth = OvnSouth
+}
+
+// RestoreDefaultConfig restores default config values. Used by testcases to
+// provide a pristine environment between tests.
+func RestoreDefaultConfig() {
+	Default = savedDefault
+	Logging = savedLogging
+	CNI = savedCNI
+	Kubernetes = savedKubernetes
+	OvnNorth = savedOvnNorth
+	OvnSouth = savedOvnSouth
 }
 
 // copy members of struct 'src' into the corresponding field in struct 'dst'

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/urfave/cli"
+	kexec "k8s.io/utils/exec"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -77,7 +78,7 @@ func writeConfigFile(cfgFile *os.File, randomOptData bool, args ...string) error
 // runType 3: command-line args and random config file option data to test CLI override
 func runInit(app *cli.App, runType int, cfgFile *os.File, args ...string) error {
 	app.Action = func(ctx *cli.Context) error {
-		_, err := InitConfig(ctx, nil)
+		_, err := InitConfig(ctx, kexec.New(), nil)
 		return err
 	}
 
@@ -170,7 +171,7 @@ var _ = Describe("Config Operations", func() {
 
 	It("uses expected defaults", func() {
 		app.Action = func(ctx *cli.Context) error {
-			cfgPath, err := InitConfig(ctx, nil)
+			cfgPath, err := InitConfig(ctx, kexec.New(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfgPath).To(Equal(cfgFile.Name()))
 
@@ -269,7 +270,7 @@ server-cacert=%s`, kubeconfigFile, kubeCAFile, nbServerCAFile, sbServerCAFile)
 
 		app.Action = func(ctx *cli.Context) error {
 			var cfgPath string
-			cfgPath, err = InitConfig(ctx, nil)
+			cfgPath, err = InitConfig(ctx, kexec.New(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfgPath).To(Equal(cfgFile.Name()))
 
@@ -382,7 +383,7 @@ server-cacert=/path/to/sb-ca.crt`), 0644)
 
 		app.Action = func(ctx *cli.Context) error {
 			var cfgPath string
-			cfgPath, err = InitConfig(ctx, nil)
+			cfgPath, err = InitConfig(ctx, kexec.New(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfgPath).To(Equal(cfgFile.Name()))
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -103,26 +103,7 @@ func runInit(app *cli.App, runType int, cfgFile *os.File, args ...string) error 
 	return app.Run(finalArgs)
 }
 
-var (
-	savedDefault    DefaultConfig
-	savedLogging    LoggingConfig
-	savedCNI        CNIConfig
-	savedKubernetes KubernetesConfig
-	savedOvnNorth   OvnAuthConfig
-	savedOvnSouth   OvnAuthConfig
-
-	tmpDir string
-)
-
-func init() {
-	// Cache original default config values so we can restore them before each testcase
-	savedDefault = Default
-	savedLogging = Logging
-	savedCNI = CNI
-	savedKubernetes = Kubernetes
-	savedOvnNorth = OvnNorth
-	savedOvnSouth = OvnSouth
-}
+var tmpDir string
 
 var _ = AfterSuite(func() {
 	err := os.RemoveAll(tmpDir)
@@ -149,12 +130,7 @@ var _ = Describe("Config Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		Default = savedDefault
-		Logging = savedLogging
-		CNI = savedCNI
-		Kubernetes = savedKubernetes
-		OvnNorth = savedOvnNorth
-		OvnSouth = savedOvnSouth
+		RestoreDefaultConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -155,46 +155,45 @@ func configureManagementPort(clusterSubnet, clusterServicesSubnet,
 	}
 
 	// Up the interface.
-	_, err := exec.Command("ip", "link", "set", interfaceName, "up").CombinedOutput()
+	_, _, err := util.RunIP("link", "set", interfaceName, "up")
 	if err != nil {
 		return err
 	}
 
 	// The interface may already exist, in which case delete the routes and IP.
-	_, err = exec.Command("ip", "addr", "flush", "dev", interfaceName).CombinedOutput()
+	_, _, err = util.RunIP("addr", "flush", "dev", interfaceName)
 	if err != nil {
 		return err
 	}
 
 	// Assign IP address to the internal interface.
-	_, err = exec.Command("ip", "addr", "add", interfaceIP, "dev", interfaceName).CombinedOutput()
+	_, _, err = util.RunIP("addr", "add", interfaceIP, "dev", interfaceName)
 	if err != nil {
 		return err
 	}
 
 	// Flush the route for the entire subnet (in case it was added before).
-	_, err = exec.Command("ip", "route", "flush", clusterSubnet).CombinedOutput()
+	_, _, err = util.RunIP("route", "flush", clusterSubnet)
 	if err != nil {
 		return err
 	}
 
 	// Create a route for the entire subnet.
-	_, err = exec.Command("ip", "route", "add", clusterSubnet, "via", routerIP).CombinedOutput()
+	_, _, err = util.RunIP("route", "add", clusterSubnet, "via", routerIP)
 	if err != nil {
 		return err
 	}
 
 	if clusterServicesSubnet != "" {
 		// Flush the route for the services subnet (in case it was added before).
-		_, err = exec.Command("ip", "route", "flush",
-			clusterServicesSubnet).CombinedOutput()
+		_, _, err = util.RunIP("route", "flush", clusterServicesSubnet)
 		if err != nil {
 			return err
 		}
 
 		// Create a route for the services subnet.
-		_, err = exec.Command("ip", "route", "add", clusterServicesSubnet,
-			"via", routerIP).CombinedOutput()
+		_, _, err = util.RunIP("route", "add", clusterServicesSubnet,
+			"via", routerIP)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/testing/testing.go
+++ b/go-controller/pkg/testing/testing.go
@@ -1,0 +1,46 @@
+package testing
+
+import (
+	"strings"
+
+	kexec "k8s.io/utils/exec"
+	fakeexec "k8s.io/utils/exec/testing"
+
+	"github.com/onsi/gomega"
+)
+
+// ExpectedCmd contains properties that the testcase expects a called command
+// to have as well as the output that the fake command should return
+type ExpectedCmd struct {
+	// Cmd should be the command-line string of the executable name and all arguments it is expected to be called with
+	Cmd string
+	// Output is any stdout output which Cmd should produce
+	Output string
+	// Stderr is any stderr output which Cmd should produce
+	Stderr string
+	// Err is any error that should be returned for the invocation of Cmd
+	Err error
+}
+
+// AddFakeCmd takes the ExpectedCmd and appends its runner function to
+// a fake command action list
+func AddFakeCmd(fakeCmds []fakeexec.FakeCommandAction, expected *ExpectedCmd) []fakeexec.FakeCommandAction {
+	return append(fakeCmds, func(cmd string, args ...string) kexec.Cmd {
+		parts := strings.Split(expected.Cmd, " ")
+		gomega.Expect(cmd).To(gomega.Equal("/fake-bin/" + parts[0]))
+		gomega.Expect(strings.Join(args, " ")).To(gomega.Equal(strings.Join(parts[1:], " ")))
+		return &fakeexec.FakeCmd{
+			Argv: parts[1:],
+			CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
+				func() ([]byte, error) {
+					return []byte(expected.Output), expected.Err
+				},
+			},
+			RunScript: []fakeexec.FakeRunAction{
+				func() ([]byte, []byte, error) {
+					return []byte(expected.Output), []byte(expected.Stderr), expected.Err
+				},
+			},
+		}
+	})
+}

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"net"
-	"os/exec"
 	"strings"
 )
 
@@ -305,7 +304,7 @@ func GatewayInit(clusterIPSubnet, nodeName, nicIP, physicalInterface,
 		}
 
 		// Flush the IP address of the physical interface.
-		_, err = exec.Command("ip", "addr", "flush", "dev", physicalInterface).CombinedOutput()
+		_, _, err = RunIP("addr", "flush", "dev", physicalInterface)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"unicode"
+
+	"github.com/sirupsen/logrus"
+	kexec "k8s.io/utils/exec"
 
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
 )
@@ -18,20 +19,12 @@ const (
 	ovsVsctlCommand   = "ovs-vsctl"
 	ovsOfctlCommand   = "ovs-ofctl"
 	ovnNbctlCommand   = "ovn-nbctl"
+	ipCommand         = "ip"
 	osRelease         = "/etc/os-release"
 	rhel              = "RHEL"
 	ubuntu            = "Ubuntu"
 	windowsOS         = "windows"
 )
-
-// PathExist checks the path exist or not.
-func PathExist(path string) bool {
-	_, err := os.Stat(path)
-	if err != nil && os.IsNotExist(err) {
-		return false
-	}
-	return true
-}
 
 func runningPlatform() (string, error) {
 	if runtime.GOOS == windowsOS {
@@ -70,60 +63,80 @@ func runningPlatform() (string, error) {
 	return "", fmt.Errorf("Unknown platform")
 }
 
-// RunOVSOfctl runs a command via ovs-ofctl.
-func RunOVSOfctl(args ...string) (string, string, error) {
-	cmdPath, err := exec.LookPath(ovsOfctlCommand)
-	if err != nil {
-		return "", "", err
-	}
+// Exec runs various OVN and OVS utilities
+type execHelper struct {
+	exec      kexec.Interface
+	ofctlPath string
+	vsctlPath string
+	nbctlPath string
+	ipPath    string
+}
 
+var runner *execHelper
+
+// SetExec validates executable paths and saves the given exec interface
+// to be used for running various OVS and OVN utilites
+func SetExec(exec kexec.Interface) error {
+	var err error
+
+	runner = &execHelper{exec: exec}
+	runner.ofctlPath, err = exec.LookPath(ovsOfctlCommand)
+	if err != nil {
+		return err
+	}
+	runner.vsctlPath, err = exec.LookPath(ovsVsctlCommand)
+	if err != nil {
+		return err
+	}
+	runner.nbctlPath, err = exec.LookPath(ovnNbctlCommand)
+	if err != nil {
+		return err
+	}
+	runner.ipPath, err = exec.LookPath(ipCommand)
+	return err
+}
+
+// GetExec returns the exec interface which can be used for running commands directly.
+// Only use for passing an exec interface into pkg/config which cannot call this
+// function directly because this module imports pkg/config already.
+func GetExec() kexec.Interface {
+	return runner.exec
+}
+
+func run(cmdPath string, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	cmd := exec.Command(cmdPath, args...)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	cmd := runner.exec.Command(cmdPath, args...)
+	cmd.SetStdout(stdout)
+	cmd.SetStderr(stderr)
+	logrus.Debugf("exec: %s %s", cmdPath, strings.Join(args, " "))
+	err := cmd.Run()
+	if err != nil {
+		logrus.Debugf("exec: %s %s => %v", cmdPath, strings.Join(args, " "), err)
+	}
+	return stdout, stderr, err
+}
 
-	err = cmd.Run()
+// RunOVSOfctl runs a command via ovs-ofctl.
+func RunOVSOfctl(args ...string) (string, string, error) {
+	stdout, stderr, err := run(runner.ofctlPath, args...)
 	return strings.Trim(stdout.String(), "\" \n"), stderr.String(), err
 }
 
 // RunOVSVsctl runs a command via ovs-vsctl.
 func RunOVSVsctl(args ...string) (string, string, error) {
-	cmdPath, err := exec.LookPath(ovsVsctlCommand)
-	if err != nil {
-		return "", "", err
-	}
-
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
 	cmdArgs := []string{fmt.Sprintf("--timeout=%d", ovsCommandTimeout)}
 	cmdArgs = append(cmdArgs, args...)
-	cmd := exec.Command(cmdPath, cmdArgs...)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-
-	err = cmd.Run()
+	stdout, stderr, err := run(runner.vsctlPath, cmdArgs...)
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 
 // RunOVNNbctlUnix runs command via ovn-nbctl, with ovn-nbctl using the unix
 // domain sockets to connect to the ovsdb-server backing the OVN NB database.
 func RunOVNNbctlUnix(args ...string) (string, string, error) {
-	cmdPath, err := exec.LookPath(ovnNbctlCommand)
-	if err != nil {
-		return "", "", err
-	}
-
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
 	cmdArgs := []string{fmt.Sprintf("--timeout=%d", ovsCommandTimeout)}
 	cmdArgs = append(cmdArgs, args...)
-	cmd := exec.Command(cmdPath, cmdArgs...)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-
-	err = cmd.Run()
+	stdout, stderr, err := run(runner.nbctlPath, cmdArgs...)
 	return strings.Trim(strings.TrimFunc(stdout.String(), unicode.IsSpace), "\""),
 		stderr.String(), err
 }
@@ -131,15 +144,6 @@ func RunOVNNbctlUnix(args ...string) (string, string, error) {
 // RunOVNNbctlWithTimeout runs command via ovn-nbctl with a specific timeout
 func RunOVNNbctlWithTimeout(timeout int, args ...string) (string, string,
 	error) {
-	cmdPath, err := exec.LookPath(ovnNbctlCommand)
-	if err != nil {
-		return "", "", err
-	}
-
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	var cmd *exec.Cmd
 	var cmdArgs []string
 	if config.OvnNorth.ClientAuth.Scheme == config.OvnDBSchemeSSL {
 		cmdArgs = []string{
@@ -156,15 +160,24 @@ func RunOVNNbctlWithTimeout(timeout int, args ...string) (string, string,
 
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--timeout=%d", timeout))
 	cmdArgs = append(cmdArgs, args...)
-	cmd = exec.Command(cmdPath, cmdArgs...)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-
-	err = cmd.Run()
+	stdout, stderr, err := run(runner.nbctlPath, cmdArgs...)
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 
 // RunOVNNbctl runs a command via ovn-nbctl.
 func RunOVNNbctl(args ...string) (string, string, error) {
 	return RunOVNNbctlWithTimeout(ovsCommandTimeout, args...)
+}
+
+// RunIP runs a command via the iproute2 "ip" utility
+func RunIP(args ...string) (string, string, error) {
+	stdout, stderr, err := run(runner.ipPath, args...)
+	return strings.TrimSpace(stdout.String()), stderr.String(), err
+}
+
+// RawExec runs the given command via the exec interface. Should only be used
+// for early calls before configuration is read.
+func RawExec(cmdPath string, args ...string) (string, string, error) {
+	stdout, stderr, err := run(cmdPath, args...)
+	return strings.TrimSpace(stdout.String()), stderr.String(), err
 }


### PR DESCRIPTION
@shettyg @rajatchopra this is the first bit.  An alternate approach is to make *all* exec commands filter through a central file that has a global for the runner, but that makes it a bit harder to manage unit testing.

Follow-on PR will more extensively test pkg/cluster.