### PR TITLE
pods: Avoid loop wait for pod.Spec.NodeName

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -96,9 +96,17 @@ func (oc *Controller) WatchPods() error {
 	_, err := oc.watchFactory.AddPodHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
-			oc.addLogicalPort(pod)
+			if pod.Spec.NodeName != "" {
+				oc.addLogicalPort(pod)
+			}
 		},
-		UpdateFunc: func(old, new interface{}) {},
+		UpdateFunc: func(old, newer interface{}) {
+			podNew := newer.(*kapi.Pod)
+			podOld := old.(*kapi.Pod)
+			if podOld.Spec.NodeName == "" && podNew.Spec.NodeName != "" {
+				oc.addLogicalPort(podNew)
+			}
+		},
 		DeleteFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
 			oc.deleteLogicalPort(pod)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -147,26 +147,9 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 }
 
 func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
-	count := 30
 	var out, stderr string
 	var err error
 	logicalSwitch := pod.Spec.NodeName
-	for count > 0 {
-		if logicalSwitch != "" {
-			break
-		}
-		if count != 30 {
-			time.Sleep(1 * time.Second)
-		}
-		count--
-		p, err := oc.kube.GetPod(pod.Namespace, pod.Name)
-		if err != nil {
-			logrus.Errorf("Failed to get pod %s/%s's information from kube "+
-				"API server", pod.Namespace, pod.Name)
-			continue
-		}
-		logicalSwitch = p.Spec.NodeName
-	}
 	if logicalSwitch == "" {
 		logrus.Errorf("Failed to find the logical switch for pod %s/%s",
 			pod.Namespace, pod.Name)
@@ -223,7 +206,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		return
 	}
 
-	count = 30
+	count := 30
 	for count > 0 {
 		if isStaticIP {
 			out, stderr, err = util.RunOVNNbctlUnix("get",


### PR DESCRIPTION
Instead, wait for pod modify event to come with
it set. Without this, even a single pod can
delay the logical port creation pipeline by 30 seconds.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>