### PR TITLE
Containerized ovn openshift/RHEL/centos/fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ installations.  If you use packages to install OVS, you should install both
 OVS and OVN related packages.  You can also read the following quick-start
 guide for Ubuntu that installs OVS and OVN from source and packages:
 [INSTALL.UBUNTU.md]
+The following guide explains setting up an OVN overlay network on Openshift
+running on RHEL/Centos/Fedora: [INSTALL.OPENSHIFT.md](docs/INSTALL.OPENSHIFT.md)
 
 On each node, you should also install the 'ovnkube' utility that comes with
 this repository. To install it, you can run:

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -35,6 +35,14 @@ rpmsnap: distsnap
 	--define "_rpmdir `pwd`" --define "_srcrpmdir `pwd`" \
 	-ba openvswitch-ovn-kubernetes.spec.snapshot
 
+.PHONY: ../go-controller/_output/go/bin/ovnkube
+
+../go-controller/_output/go/bin/ovnkube:
+	cd ../go-controller ; make
+
+container: ../go-controller/_output/go/bin/ovnkube
+	cp ../go-controller/_output/go/bin/* images
+
 .PHONY: clean
 clean:
 	-rm -rf *~ \#* .#*

--- a/dist/READMEcontainer.md
+++ b/dist/READMEcontainer.md
@@ -1,0 +1,66 @@
+ovn container construction and operation
+
+NOTES/LIMITS:
+- Uses node-role.kubernetes.io/master and compute labels. 
+  Eventually there will be ovn specific labels.
+- currently building in ../go_controller and copying files to
+  ../images and put in an image. This will likely change.
+NOTES/LIMITS:
+
+There are two daemonsets that support ovn. ovnkube-master runs
+on the cluster master node, ovnkube runs on the remaining nodes.
+The daemonsets run with hostNetwork: true.
+
+The both daemonsets run the node daemons, ovn-controller and ovn-node.
+In addition the daemonset runs ovn-northd and ovn-master.
+
+The startup sequence requires this startup order:
+- ovs 
+- ovnkube-master on the master node
+- ovnkube on the rest of the nodes.
+
+===============================
+
+There is one docker image that is used by both the ovnkube-master
+and ovnkube daemonsets. The master sets environmet variable
+OVN_MASTER="true".
+
+When this is present the image runs ovn-northd and ovn-master
+before running ovn-controller and ovn-node
+ 
+The image entrypoint is /root/ovnkube.sh
+This script sequences through the operations to bring up networking.
+Configuration is passed in via environment variables.
+
+===============================
+
+- ovnkube-master.yaml
+
+    metadata:
+      labels:
+        app: ovnkube-master
+        node-role.kubernetes.io/master: "true"
+
+- ovnkube.yaml
+
+    metadata:
+      labels:
+        app: ovnkube
+        node-role.kubernetes.io/compute: "true"
+
+===========================
+How networking is set up.
+
+The ovn cni plugin, ovn-k8s-cni-overlay, must be visible to kubelet so that 
+kubelet can use it. The ovn plugin and setup are in the container image so 
+they need to be moved to the host. This is done by mounting the following
+directories and copying files from the contianer to the mounted directories.
+
+/opt/cni/bin mounted on /host/opt/cni/bin
+/etc/cni/net.d
+/var/lib/cni/networks/ovn-k8s-cni-overlay
+
+/etc/cni/net.d and /opt/cni/bin are cleared and ovn-k8s-cni-overlay and
+loopback are copied into /opt/cni/bin. This makes the plugin available to
+kubelet.
+

--- a/dist/ansible/scripts/ovn-setup.sh
+++ b/dist/ansible/scripts/ovn-setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+  
+# Create a configmap of the ovn configuration information
+# This script runs on the ovn-master node on the cluster
+# This is run as part of installation after the cluster is
+# up and before the ovn daemonsets are created.
+
+health=$(kubectl get --raw /healthz/ready)
+if [ $health != 'ok' ]
+then
+  echo " cluster not ready"
+  exit 1
+fi
+
+svcacct=$(kubectl get serviceaccount | grep ovn)
+if [ $? -ne 0 ]
+then
+  kubectl create serviceaccount ovn
+  kubectl adm policy add-cluster-role-to-user cluster-admin -z ovn
+  kubectl adm policy add-scc-to-user anyuid -z ovn
+fi
+
+# get api server
+api=$(kubectl get po -n kube-system -o wide | gawk '/master-api/{ print $7 }')
+apiserver=https://${api}:8443
+
+# get the API token.
+token=$(kubectl sa get-token ovn)
+
+# get the network cidr (master-config.yaml clusterNetworkCIDR)
+net_cidr=10.128.0.0/14
+
+# get the service subnet cidr (master-config.yaml servicesSubnet)
+svc_cidr=172.30.0.0/16
+
+# get the ovn master's ip address
+host_ip=$(host $(hostname) | gawk '{ print $4 }' )
+
+OvnNorth="tcp://${host_ip}:6641"
+OvnSouth="tcp://${host_ip}:6642"
+
+# build the ovn.master file
+echo apiserver $apiserver
+echo token $token
+echo net_cidr $net_cidr
+echo svc_cidr $svc_cidr
+echo OvnNorth $OvnNorth
+echo OvnSouth $OvnSouth
+
+# if the config map exists, delete it.
+kubectl get configmap ovn-config > /dev/null
+if [[ $? = 0 ]]
+then
+  kubectl delete configmap ovn-config
+fi
+
+# create the ovn-config configmap
+cat << EOF | kubectl create -f -
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-config
+  namespace: ovn-kubernetes
+data:
+  k8s_apiserver: $apiserver
+  net_cidr:      $net_cidr
+  svc_cidr:      $svc_cidr
+  OvnNorth:      $OvnNorth
+  OvnSouth:      $OvnSouth
+EOF
+
+exit 0

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -1,0 +1,51 @@
+#
+# This is the OpenShift sdn-ovn image.
+# it provides an overlay network using ovs/ovn/ovnkube
+#
+# The standard name for this image is origin-network-ovn
+
+# Notes:
+# The ovn-kubernetes utilities can come from the openvswitch-ovn-kubernetes rpm
+# or built in go_controller, copied to this directory and copied to the container.
+# The question becomes one of determining which version are we using.
+#
+# At present this uses fedora:28, this may default to centos:7 
+# when the needed ovs/ovn rpms are at 2.8 or higher and the
+# openvswitch-ovn-kubernetes is available.
+#
+# So this file will change over time.
+
+FROM fedora:28
+
+MAINTAINER Phil Cameron <pcameron@redhat.com>
+
+USER root
+
+ENV PYTHONDONTWRITEBYTECODE yes
+
+RUN dnf install --refresh -y  \
+	PyYAML bind-utils procps-ng hostname \
+	openvswitch openvswitch-ovn-common openvswitch-ovn-host openvswitch-ovn-central \
+	openvswitch-ovn-docker python2-openvswitch openvswitch-ovn-vtep \
+	containernetworking-cni \
+	jq iproute strace socat && \
+	dnf clean all
+
+RUN mkdir -p /var/run/openvswitch
+RUN mkdir -p /etc/cni/net.d
+RUN mkdir -p /opt/cni/bin
+
+# Built in ../go_controller, then copied to ../image
+# alternatively, install openvswitch-ovn-kubernetes rpm
+COPY ovn-k8s-cni-overlay /opt/cni/bin/ovn-k8s-cni-overlay
+COPY ovn-k8s-overlay ovnkube ovn-kube-util /usr/bin/
+
+# ovnkube.sh is the entry point. This script examines environment
+# variables to direct operation and configure ovn
+COPY ovnkube.sh /root/
+COPY ovn-debug.sh /root/
+# override the rpm's ovn_k8s.conf with this local copy
+COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
+
+WORKDIR /root
+ENTRYPOINT /root/ovnkube.sh

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -1,0 +1,13 @@
+# build image for ovn cni
+
+# both ovnkube.yaml and onvkube-master.yaml use this image
+# this image is built from files in this directory and pushed to 
+# a docker repository that is accesseble on each node
+
+# The temprary (insecure) repository is netdev22:5000/ovn-kube:latest
+
+all:
+	docker build -t ovn-kube .
+	docker tag ovn-kube netdev22:5000/ovn-kube:latest
+	docker push netdev22:5000/ovn-kube:latest
+

--- a/dist/images/ovn-config.sh
+++ b/dist/images/ovn-config.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# run on master to configure ovn-kubernetes
+# The /etc/openvswitch/ovn_k8s.conf and /etc/sysconfig/ovn-kubernetes
+# are used by ovnkube to direct processing.
+# This script creates files that can be copied to the nodes
+
+oc create serviceaccount ovn  2>/dev/null
+oc adm policy add-cluster-role-to-user cluster-admin -z ovn  2>/dev/null
+oc adm policy add-scc-to-user anyuid -z ovn  2>/dev/null
+
+token=$(oc sa get-token ovn)
+
+cidr=$(gawk '/clusterNetworkCIDR:/{ print $2 }' /etc/origin/master/master-config.yaml)
+
+apifqn=$(hostname)
+apiip=$(host ${apifqn} | gawk '{ print $4 }')
+
+# edit the /etc/sysconfig/ovn-kubernetes file
+sed '/cluster_cidr=/d' < /etc/sysconfig/ovn-kubernetes > /tmp/ovn-kubernetes
+echo "cluster_cidr=${cidr}" >> /tmp/ovn-kubernetes
+
+# edit /etc/openvswitch/ovn_k8s.conf 
+sed "s/ovn_master_fqn/${apifqn}/
+s/token=/token=${token}/
+s/ovn_master_ip/${apiip}/" /etc/openvswitch/ovn_k8s.conf > /tmp/ovn_k8s.conf
+
+exit 0
+

--- a/dist/images/ovn-debug.sh
+++ b/dist/images/ovn-debug.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+#set -x
+set -euo pipefail
+
+# This script helps debug the container.
+
+# ====================
+# Environment variables are used to customize operation
+
+# There is a single image for both master node and compute node
+# setup. When OVN_MASTER is true, start the master daemons
+# in addition to the node daemons
+ovn_master=${OVN_MASTER:-"false"}
+
+# hostname is the host's hostname when using host networking,
+# otherwise it is the container ID (useful for debugging).
+ovn_host=$(hostname)
+
+# Cluster's internal network cidr
+ovn_cidr=$(OVN_CIDR:-"10.128.0.0/14"}
+
+# Used to test for ovn-northd coming up
+ovn_nbdb=${OVN_TEST_NDB:-"tcp:10.19.188.22:6641"}
+
+# ovn-northd - /etc/sysconfig/ovn-northd
+ovn_northd_opts=${OVN_NORTHD_OPTS:-"--db-nb-sock=/var/run/openvswitch/ovnnb_db.sock --db-sb-sock=/var/run/openvswitch/ovnsb_db.sock"}
+
+# ovn-controller
+#OVN_CONTROLLER_OPTS="--ovn-controller-log=-vconsole:emer --vsyslog:err -vfile:info"
+ovn_controller_opts=${OVN_CONTROLLER_OPTS:-"--ovn-controller-log=-vconsole:emer"}
+
+# =========================================
+
+# Master must be up before the nodes can come up.
+# This waits for northd to come up
+wait_for_northdb () {
+  # Wait for ovn-northd to come up
+  trap 'kill $(jobs -p); exit 0' TERM
+  retries=0
+  while true; do
+    # northd is up when this works
+    out=$(ovn-nbctl --db${ovn_nbdb} show >/dev/null)
+    if [[ ${out} .ne 0 ]] ; then
+      echo "info: Waiting for ovn-northd to come up, waiting 10s ..." 2>&1
+      sleep 10 & wait
+      (( retries += 1 ))
+    else
+      break
+    fi
+    if [[ "${retries}" -gt 40 ]]; then
+      echo "error: ovn-northd did not come up, exiting" 2>&1
+      exit 1
+    else
+      echo "ovn-northd came up in ${retries} 10sec tries"
+    fi
+  done
+}
+
+
+# Master control of ovn daemons
+# daemons come up in order
+# ovn-northd - master node only
+# ovn-master - master node only
+# ovn-controller - all nodes
+# ovn-node - all nodes
+
+# All services have start | stop | reload | check | logs
+
+ovn-northd () {
+  case $1 in
+  "start") echo "ovn-northd - START"
+	 if [ ! -f /var/run/openvswitch/ovn-northd.pid ] ; then
+	   /usr/share/openvswitch/scripts/ovn-ctl start_northd ${ovn_northd_opts}
+	 else
+	   echo "ovn-northd already running"
+	 fi
+	 ;;
+  "stop") echo "ovn-northd - STOP"
+	 if [ -f /var/run/openvswitch/ovn-northd.pid ] ; then
+	   /usr/share/openvswitch/scripts/ovn-ctl stop_northd
+	 else
+	   echo "ovn-northd already stopped"
+	 fi
+	 ;;
+  "reload") echo "ovn-northd - RELOAD"
+	 ;;
+  "check")
+	 if [ -f /var/run/openvswitch/ovn-northd.pid ] ; then
+	   echo "ovn-northd  - running"
+	 else
+	   echo "ovn-northd  - stopped"
+	 fi
+	 return 0
+	 ;;
+  "logs") echo "ovn-northd - LOGS"
+	 echo "============ ovsdb-server-nb.log ======================"
+	 cat /var/log/openvswitch/ovsdb-server-nb.log
+	 echo "============ ovsdb-server-sb.log ======================"
+	 cat /var/log/openvswitch/ovsdb-server-sb.log
+	 echo "============ ovs-northd.log ==========================="
+	 cat /var/log/openvswitch/ovn-northd.log
+	 ;;
+  "debug") echo "ovn-northd - DEBUG"
+	 if [ -f /var/run/openvswitch/ovn-northd.pid ] ; then
+	   echo -n "ovnnb_db.pid:   "
+	   cat /var/run/openvswitch/ovnnb_db.pid
+	   echo -n "ovnsb_db.pid:   "
+	   cat /var/run/openvswitch/ovnsb_db.pid
+	   echo -n "ovn-northd.pid: "
+	   cat /var/run/openvswitch/ovn-northd.pid
+	 fi
+	 echo "============ ovn-northd processes ====================="
+	 ps ax | grep -e ovnnb_db -e ovnsb_db -e ovn-northd | grep -v color=auto
+	 ;;
+  *) echo "ovn-northd - unknown arg $1" ; return 1 ;;
+  esac
+}
+
+ovn-master () {
+  case $1 in
+  "start") echo "ovn-master - START"
+	 if [ ! -f /var/run/openvswitch/ovnkube-master.pid ] ; then
+	 /usr/bin/ovnkube \
+           --cluster-subnet "${ovn_cidr}" \
+           --init-master ${ovn_host} \
+	   --pidfile /var/run/openvswitch/ovnkube-master.pid \
+	   --logfile /var/log/openvswitch/ovnkube-master.log \
+           --net-controller &
+	 fi
+	 ;;
+  "stop") echo "ovn-master - STOP"
+	 if [ -f /var/run/openvswitch/ovnkube-master.pid ] ; then
+	   echo "STOP ovn-master"
+	   kill `cat /var/run/openvswitch/ovnkube-master.pid`
+	 else
+	   echo "ovn-master already stopped"
+	 fi
+	 ;;
+  "reload") echo "ovn-master - RELOAD"
+	 ;;
+  "check")
+	 if [ -f /var/run/openvswitch/ovnkube-master.pid ] ; then
+	   echo "ovn-master  - running"
+	 else
+	   echo "ovn-master  - stopped"
+	 fi
+	 ;;
+  "logs") echo "ovn-master - LOGS"
+	 echo "============ ovnkube-master.log ======================="
+	 cat /var/log/openvswitch/ovnkube-master.log
+	 ;;
+  "debug") echo "ovn-master - DEBUG"
+	if [ -f /var/run/openvswitch/ovnkube-master.pid ] ; then
+	 echo -n "ovn-master pid: "
+	 cat /var/run/openvswitch/ovnkube-master.pid
+	fi
+	 echo "============ ovn-master processes ====================="
+	 ;;
+  *) echo "ovn-master - unknown arg $1" ; return 1 ;;
+  esac
+}
+
+ovn-controller () {
+  case $1 in
+  "start") echo "ovn-controller - START"
+	 if [ ! -f /var/run/openvswitch/ovn-controller.pid ] ; then
+	 /usr/share/openvswitch/scripts/ovn-ctl --no-monitor \
+          start_controller ${ovn_controller_opts}
+	 else
+	   echo "ovn-controller already running"
+	 fi
+	 ;;
+  "stop") echo "ovn-controller - STOP"
+	 if [ -f /var/run/openvswitch/ovn-controller.pid ] ; then
+	  /usr/share/openvswitch/scripts/ovn-ctl stop_controller
+	 else
+	   echo "ovn-controller already stopped"
+	 fi
+	 ;;
+  "reload") # echo "ovn-controller - RELOAD"
+	 ;;
+  "check")
+	 if [ -f /var/run/openvswitch/ovn-controller.pid ] ; then
+	   echo "ovn-controller  - running"
+	 else
+	   echo "ovn-controller  - stopped"
+	 fi
+	 ;;
+  "logs") echo "ovn-controller - LOGS"
+	 echo "============ ovn-controller.log ======================="
+	 cat /var/log/openvswitch/ovn-controller.log
+	 ;;
+  "debug") echo "ovn-controller - DEBUG"
+	 echo "============ ovn-controller processes ================="
+	 cat /var/run/openvswitch/ovn-controller.pid
+	 ;;
+  *) echo "ovn-controller - unknown arg $1" ; return 1 ;;
+  esac
+}
+
+ovn-node () {
+  case $1 in
+  "start") echo "ovn-node - START"
+	 /usr/bin/ovnkube \
+        --cluster-subnet "${ovn_cidr}" \
+        --init-node "${ovn_host}" &
+	 ;;
+  "stop") echo "ovn-node - STOP"
+	 ;;
+  "reload") echo "ovn-node - RELOAD"
+	 ;;
+  "check") echo "ovn-node - CHECK"
+	 ;;
+  "logs") echo "ovn-node - LOGS"
+	 ;;
+  "debug") echo "ovn-node - DEBUG"
+	 ;;
+  *) echo "ovn-node - unknown arg $1" ; return 1 ;;
+  esac
+}
+
+all () {
+  case $1 in
+  "start") echo "all - START"
+	 ;;
+  "stop") echo "all - STOP"
+	 ;;
+  "reload") echo "all - RELOAD"
+	 ;;
+  "check") echo "all - CHECK"
+	 ovn-northd $1
+	 ovn-master $1
+	 ovn-controller $1
+	 ovn-node $1
+	 ;;
+  "logs") echo "all - LOGS"
+	 ovn-northd $1
+	 ovn-master $1
+	 ovn-controller $1
+	 ovn-node $1
+	 ;;
+  "debug") echo "all - DEBUG"
+	 ovn-northd $1
+	 ovn-master $1
+	 ovn-controller $1
+	 ovn-node $1
+	 ;;
+  *) echo "all - unknown arg $1" ; return 1 ;;
+  esac
+}
+
+echo ================== ovn-debug.sh ================
+
+echo $0: daemon: ${daemon}  command: ${cmd}
+case $1 in
+"ovn-northd") echo "$1 - $2" ; ovn-northd $2 ;;
+"ovn-master") echo "$1 - $2" ; ovn-master $2 ;;
+"ovn-controller") echo "$1 - $2" ; ovn-controller $2 ;;
+"ovn-node") echo "$1 - $2" ; ovn-node $2 ;;
+"all") echo "$1 - $2" ; all $2 ;;
+*) echo "[all|ovn-northd|ovn-master|ovn-controller|ovn-node] [start|stop|reload|check|logs|debug]" ;;
+esac
+
+exit 0

--- a/dist/images/ovn-run.sh
+++ b/dist/images/ovn-run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# run the ovs-vswitchd daemon from a container
+
+#docker run --rm --network host --mount type=bind,src=/var/run/openvswitch,dst=/var/run/openvswitch  phil-ovn &
+#docker run --rm --network host -v /var/run/openvswitch:/var/run/openvswitch:rw  phil-ovn
+#docker run --rm --network host -v /var/run/openvswitch/db.sock:/var/run/openvswitch/db.sock:ro  phil-ovn
+#docker run --rm --network host -v /var/run/openvswitch/db.sock:/var/run/openvswitch/db.sock:ro -v /etc/origin/node/client-ca.crt:/etc/origin/node/client-ca.crt:ro phil-ovn
+docker run --rm --network host \
+	-e OVN_MASTER="true" \
+	-v /var/run/openvswitch/db.sock:/var/run/openvswitch/db.sock:ro \
+	-v /etc/origin/node/client-ca.crt:/etc/origin/node/client-ca.crt:ro \
+	-v /var/run/openvswitch/br-int.mgmt:/var/run/openvswitch/br-int.mgmt:ro \
+	-v /var/run/openvswitch/br-int.snoop:/var/run/openvswitch/br-int.snoop:ro \
+	-v /var/run/openvswitch/br0.mgmt:/var/run/openvswitch/br0.mgmt:ro \
+	-v /var/run/openvswitch/br0.snoop:/var/run/openvswitch/br0.snoop:ro \
+	-v /opt/cni/bin:/host/opt/cni/bin:rw \
+	-v /etc/cni/net.d:/etc/cni/net.d:rw \
+	-v /var/lib/cni/networks/ovn-k8s-cni-overlay:/var/lib/cni/networks/ovn-k8s-cni-overlay:rw \
+	netdev22:5000/phil-ovn &
+
+exit 0

--- a/dist/images/ovn_k8s.conf
+++ b/dist/images/ovn_k8s.conf
@@ -1,0 +1,15 @@
+[Default]
+mtu=1400
+conntrack-zone=64000
+
+[Logging]
+logfile=/var/log/openvswitch/ovn-k8s-cni-overlay.log
+loglevel=5
+
+[CNI]
+conf-dir=/etc/cni/net.d
+plugin=ovn-k8s-cni-overlay
+
+[Kubernetes]
+cacert=/etc/origin/node/client-ca.crt
+

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+#set -x
+set -euo pipefail
+
+# This script is the entrypoint to the image.
+
+# ====================
+# Environment variables are used to customize operation
+
+# There is a single image for both master node and compute node
+# setup. When OVN_MASTER is true, start the master daemons
+# in addition to the node daemons
+ovn_master=${OVN_MASTER:-"false"}
+
+# hostname is the host's hostname when using host networking,
+# otherwise it is the container ID (useful for debugging).
+ovn_host=$(hostname)
+
+# # The ovs user id 
+# ovs_user_id=${OVS_USER_IDi:-root:root}
+
+# # ovs options
+# ovs_options=${OVS_OPTIONS:-""}
+
+# Cluster's internal network cidr
+net_cidr=${OVN_NET_CIDR:-"10.128.0.0/14"}
+# Cluster's service ip subnet
+svc_cidr=${OVN_SVC_CIDR:-"172.30.0.0/16"}
+
+# ovn north and south databases
+ovn_nbdb=${OVN_NORTH:-""}
+ovn_sbdb=${OVN_SOUTH:-""}
+# Used to test for ovn-northd coming up
+ovn_nbdb_test=$(echo ${ovn_nbdb} | sed 's;//;;')
+
+# kubernetes api server configuration
+k8s_api=${K8S_APISERVER:-""}
+k8s_token=${K8S_TOKEN:-""}
+
+# ovn-northd - /etc/sysconfig/ovn-northd
+ovn_northd_opts=${OVN_NORTHD_OPTS:-"--db-nb-sock=/var/run/openvswitch/ovnnb_db.sock --db-sb-sock=/var/run/openvswitch/ovnsb_db.sock"}
+
+# ovn-controller
+#OVN_CONTROLLER_OPTS="--ovn-controller-log=-vconsole:emer --vsyslog:err -vfile:info"
+ovn_controller_opts=${OVN_CONTROLLER_OPTS:-"--ovn-controller-log=-vconsole:emer"}
+
+# =========================================
+
+# Master must be up before the nodes can come up.
+# This waits for northd to come up
+wait_for_northdb () {
+  # Wait for ovn-northd to come up
+  trap 'kill $(jobs -p); exit 0' TERM
+  retries=0
+  while true; do
+    # northd is up when this works
+    ovn-nbctl --db=${ovn_nbdb_test} show > /dev/null
+    if [[ $? != 0 ]] ; then
+      echo "info: Waiting for ovn-northd to come up, waiting 10s ..." 2>&1
+      sleep 10 & wait
+      (( retries += 1 ))
+    else
+      break
+    fi
+    if [[ "${retries}" -gt 40 ]]; then
+      echo "error: ovn-northd did not come up, exiting" 2>&1
+      exit 1
+    else
+      echo "ovn-northd came up in ${retries} 10sec tries"
+    fi
+  done
+}
+
+display () {
+  echo ${ovn_host}
+  date
+  if [[ ${ovn_master} = "true" ]]
+  then
+    echo "==================== ovnkube-master =================== "
+    echo "====================== ovnnb_db.pid"
+    if [[ -f /var/run/openvswitch/ovnnb_db.pid ]]
+    then
+      cat /var/run/openvswitch/ovnnb_db.pid
+    fi
+    echo "====================== ovnsb_db.pid"
+    if [[ -f /var/run/openvswitch/ovnsb_db.pid ]]
+    then
+      cat /var/run/openvswitch/ovnsb_db.pid
+    fi
+    echo "====================== ovs-vswitchd.pid"
+    if [[ -f /var/run/openvswitch/ovs-vswitchd.pid ]]
+    then
+      cat /var/run/openvswitch/ovs-vswitchd.pid
+    fi
+    echo "====================== ovsdb-server.pid"
+    if [[ -f /var/run/openvswitch/ovsdb-server.pid ]]
+    then
+      cat /var/run/openvswitch/ovsdb-server.pid
+    fi
+    echo "====================== ovsdb-server-nb.log"
+    if [[ -f /var/log/openvswitch/ovsdb-server-nb.log ]]
+    then
+      cat /var/log/openvswitch/ovsdb-server-nb.log
+    fi
+    echo "====================== ovsdb-server-sb.log "
+    if [[ -f /var/log/openvswitch/ovsdb-server-sb.log ]]
+    then
+      cat /var/log/openvswitch/ovsdb-server-sb.log
+    fi
+    echo "====================== ovn-northd.pid"
+    if [[ -f /var/run/openvswitch/ovn-northd.pid ]]
+    then
+      cat /var/run/openvswitch/ovn-northd.pid
+    fi
+    echo " "
+    echo "====================== ovn-northd.log"
+    if [[ -f /var/log/openvswitch/ovn-northd.log ]]
+    then
+      cat /var/log/openvswitch/ovn-northd.log
+    fi
+    echo " "
+    echo "====================== ovnkube-master.pid"
+    if [[ -f /var/run/openvswitch/ovnkube-master.pid ]]
+    then
+      cat /var/run/openvswitch/ovnkube-master.pid
+    fi
+    echo " "
+    echo "====================== ovnkube-master.log"
+    if [[ -f /var/log/openvswitch/ovnkube-master.log ]]
+    then
+      cat /var/log/openvswitch/ovnkube-master.log
+    fi
+  fi
+  echo " "
+  echo "==================== ovnkube =================== "
+  echo "====================== ovn-controller.pid"
+  if [[ -f /var/run/openvswitch/ovn-controller.pid ]]
+  then
+    cat /var/run/openvswitch/ovn-controller.pid
+  fi
+  echo " "
+  echo "====================== ovn-controller.log"
+  if [[ -f /var/log/openvswitch/ovn-controller.log ]]
+  then
+    cat /var/log/openvswitch/ovn-controller.log
+  fi
+  echo " "
+  echo "====================== ovnkube.pid"
+  if [[ -f /var/run/openvswitch/ovnkube.pid ]]
+  then
+    cat /var/run/openvswitch/ovnkube.pid
+  fi
+  echo " "
+  echo "====================== ovnkube.log"
+  if [[ -f /var/log/openvswitch/ovnkube.log ]]
+  then
+    cat /var/log/openvswitch/ovnkube.log
+  fi
+  echo " "
+  echo "====================== ovn-k8s-cni-overlay.log"
+  if [[ -f /var/log/openvswitch/ovn-k8s-cni-overlay.log ]]
+  then
+    cat /var/log/openvswitch/ovn-k8s-cni-overlay.log
+  fi
+}
+
+setup_cni () {
+  # Take over network functions on the node
+  # rm -Rf /etc/cni/net.d/*
+  rm -Rf /host/opt/cni/bin/ovn-k8s-cni-overlay
+  cp -Rf /opt/cni/bin/* /host/opt/cni/bin/
+  cp -f  /usr/libexec/cni/loopback /host/opt/cni/bin/
+}
+
+start_ovn () {
+  echo " ==================== hostname: ${ovn_host} "
+
+echo OVN_NORTH $OVN_NORTH
+echo OVN_SOUTH $OVN_SOUTH
+echo OVN_NET_CIDR $OVN_NET_CIDR
+echo OVN_SVC_CIDR $OVN_SVC_CIDR
+echo K8S_APISERVER $K8S_APISERVER
+echo K8S_TOKEN $K8S_TOKEN
+
+  setup_cni
+
+# # start ovsdb-server
+# /usr/share/openvswitch/scripts/ovs-ctl \
+#   --no-ovs-vswitchd --no-monitor --system-id=random \
+#   --ovs-user=${ovs_user_id} \
+#   start ${ovs_options}
+
+# # start ovs-vswitchd
+# /usr/share/openvswitch/scripts/ovs-ctl \
+#   --no-ovsdb-server --no-monitor --system-id=random \
+#   --ovs-user=${ovs_user_id} \
+#   start ${ovs_options}
+
+  if [[ ${ovn_master} = "true" ]]
+  then
+    # ovn-northd - master node only
+    echo "=============== start ovn-northd ========== MASTER ONLY"
+    /usr/share/openvswitch/scripts/ovn-ctl start_northd \
+      --db-nb-addr=${ovn_nbdb} --db-sb-addr=${ovn_sbdb} \
+      --db-nb-sock=/var/run/openvswitch/ovnnb_db.sock \
+      --db-sb-sock=/var/run/openvswitch/ovnsb_db.sock
+
+    # ovn-master - master node only
+#   wait_for_northdb
+
+    echo "=============== start ovn-master ========== MASTER ONLY"
+    /usr/bin/ovnkube \
+      --init-master ${ovn_host} --net-controller \
+      --cluster-subnet ${net_cidr} --service-cluster-ip-range=${svc_cidr} \
+      --k8s-token=${k8s_token} --k8s-apiserver=${k8s_api} \
+      --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
+      --nodeport \
+      --pidfile /var/run/openvswitch/ovnkube-master.pid \
+      --logfile /var/log/openvswitch/ovnkube-master.log &
+
+  fi
+
+  # ovn-controller - all nodes
+  echo "=============== start ovn-controller"
+  /usr/share/openvswitch/scripts/ovn-ctl --no-monitor start_controller \
+    ${ovn_controller_opts}
+
+  # ovn-node - all nodes
+#   wait_for_northdb
+
+  echo  "=============== start ovn-node"
+  /usr/bin/ovnkube --init-node ${ovn_host} \
+      --cluster-subnet ${net_cidr} --service-cluster-ip-range=${svc_cidr} \
+      --k8s-token=${k8s_token} --k8s-apiserver=${k8s_api} \
+      --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
+      --nodeport \
+      --init-gateways \
+      --pidfile /var/run/openvswitch/ovnkube.pid \
+      --logfile /var/log/openvswitch/ovnkube.log &
+
+  echo "=============== done starting daemons ================="
+
+# Let it settle
+  sleep 4
+
+# display results
+  display
+}
+
+echo "================== ovnkube.sh ================"
+
+# Start the ovn daemons
+# daemons come up in order
+# ovs-db-server  - all nodes  - done in another daemonset
+# ovs-vswitchd   - all nodes  - done in another daemonset
+# ovn-northd     - master node only
+# ovn-master     - master node only
+# ovn-controller - all nodes
+# ovn-node       - all nodes
+
+start_ovn
+
+# keep the container alive
+tail -f /dev/null
+
+exit 0

--- a/dist/yaml/ovnkube-master.yaml
+++ b/dist/yaml/ovnkube-master.yaml
@@ -1,0 +1,174 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-master
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This daemonset launches the ovn-kubernetes networking components.
+spec:
+  selector:
+    matchLabels:
+      name: ovnkube-master
+      node-role.kubernetes.io/master: "true"
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: ovnkube-master
+        component: network
+        type: infra
+        openshift.io/component: network
+        node-role.kubernetes.io/master: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovn
+      hostNetwork: true
+      hostPID: true
+      #tolerations:
+      #- key: node-role.kubernetes.io/master
+      # effect: Schedule
+      containers:
+      # firewall rules for ovn - assumed to be setup
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+      # ovs flow for ovn (geneve)
+      # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
+      - name: ovnkube-master
+        image: "netdev22:5000/ovn-kube:latest"
+        imagePullPolicy: "Always"
+
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        # Directory which contains the host configuration.
+        - mountPath: /etc/origin/node/
+          name: host-config
+          readOnly: true
+        - mountPath: /etc/sysconfig/origin-node
+          name: host-sysconfig-node
+          readOnly: true
+        # Mount the entire run directory for socket access for Docker or CRI-o
+        # TODO: remove
+        - mountPath: /var/run
+          name: host-var-run
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+       #  readOnly: false
+        - mountPath: /var/run/kubernetes/
+          name: host-var-run-kubernetes
+          readOnly: true
+        # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /host/opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-ovn-kubernetes
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OPENSHIFT_DNS_DOMAIN
+          value: cluster.local
+        - name: OVN_MASTER
+          value: "true"
+        - name: OVN_NORTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnNorth
+        - name: OVN_SOUTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnSouth
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_TOKEN
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_token
+        ports:
+        - name: healthz
+          containerPort: 10256
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10256
+        #     scheme: HTTP
+        lifecycle:
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
+      volumes:
+      # In bootstrap mode, the host config contains information not easily available
+      # from other locations.
+      - name: host-config
+        hostPath:
+          path: /etc/origin/node
+      - name: host-sysconfig-node
+        hostPath:
+          path: /etc/sysconfig/origin-node
+      - name: host-modules
+        hostPath:
+          path: /lib/modules
+
+      # TODO: access to the docker socket should be replaced by CRI socket
+      - name: host-var-run
+        hostPath:
+          path: /var/run
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-var-run-kubernetes
+        hostPath:
+          path: /var/run/kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-var-lib-cni-networks-ovn-kubernetes
+        hostPath:
+          path: /var/lib/cni/networks/ovn-k8s-cni-overlay

--- a/dist/yaml/ovnkube.yaml
+++ b/dist/yaml/ovnkube.yaml
@@ -1,0 +1,171 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This daemonset launches the ovn-kubernetes networking components.
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube
+      node-role.kubernetes.io/compute: "true"
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube
+        component: network
+        type: infra
+        openshift.io/component: network
+        node-role.kubernetes.io/compute: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovn
+      hostNetwork: true
+      hostPID: true
+      containers:
+      # firewall rules for ovn - assumed to be setup
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+      # ovs flow for ovn (geneve)
+      # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
+      # The network container launches the ovn-k8s-cni-overlay process, the kube-proxy, and the local DNS service.
+      # It relies on an up to date node-config.yaml being present.
+      - name: ovnkube
+        image: "netdev22:5000/ovn-kube:latest"
+        imagePullPolicy: "Always"
+
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        # Directory which contains the host configuration.
+        - mountPath: /etc/origin/node/
+          name: host-config
+          readOnly: true
+        - mountPath: /etc/sysconfig/origin-node
+          name: host-sysconfig-node
+          readOnly: true
+        # Mount the entire run directory for socket access for Docker or CRI-o
+        # TODO: remove
+        - mountPath: /var/run
+          name: host-var-run
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+       #  readOnly: false
+        - mountPath: /var/run/kubernetes/
+          name: host-var-run-kubernetes
+          readOnly: true
+        # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /host/opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-ovn-kubernetes
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OPENSHIFT_DNS_DOMAIN
+          value: cluster.local
+        - name: OVN_NORTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnNorth
+        - name: OVN_SOUTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnSouth
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_TOKEN
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_token
+        ports:
+        - name: healthz
+          containerPort: 10256
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10256
+        #     scheme: HTTP
+        lifecycle:
+      nodeSelector:
+        node-role.kubernetes.io/compute: "true"
+      volumes:
+      # In bootstrap mode, the host config contains information not easily available
+      # from other locations.
+      - name: host-config
+        hostPath:
+          path: /etc/origin/node
+      - name: host-sysconfig-node
+        hostPath:
+          path: /etc/sysconfig/origin-node
+      - name: host-modules
+        hostPath:
+          path: /lib/modules
+
+      # TODO: access to the docker socket should be replaced by CRI socket
+      - name: host-var-run
+        hostPath:
+          path: /var/run
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-var-run-kubernetes
+        hostPath:
+          path: /var/run/kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-var-lib-cni-networks-ovn-kubernetes
+        hostPath:
+          path: /var/lib/cni/networks/ovn-k8s-cni-overlay

--- a/docs/INSTALL.OPENSHIFT.md
+++ b/docs/INSTALL.OPENSHIFT.md
@@ -1,0 +1,217 @@
+# OVN overlay network on Openshift
+
+This section describes how an OVN overlay network is setup on Openshift 3.10 and later.
+It explains the various components and how they come together to establish the OVN overlay network.
+People that are interested in understatnding how the ovn cni plugin is installed will find this useful.
+
+As of OCP-3.10, the Openshift overlay network is managed using daemonsets. The ovs/ovn components are
+built into a Docker image that has all of the needed packages. Daemonsets are deployed on the nodes
+in the cluster to provide the network. The daemonsets use a common Docker image when creating the needed pods.
+
+## Overview
+
+Ovn has a master service that runs on a compute node in the cluster and node controllers
+that run on all nodes in the cluster. The master service runs ovn north and ovn south
+daemons that work with the ovs north and south databases. All of the nodes run the ovn controller
+which accesses the ovn north and south databases.
+
+There are two daemonsets, ovnkube-master.yaml and ovnkube.yaml that mangage the parts of
+the ovn architecture. The ovnkube-master daemonset runs both master and node services, ovnkube
+daemonset just runs the node service. The daemonset uses selector labels in the cluster's
+nodes to specify where the daemonsets run.
+
+Both daemonsets use the same docker image. Configuration is passed from the daemonset to the
+image using environment variables and mounting directories from the host. The environment
+variables at set from a configmap that is created during installation. The image includes
+an control script that is the entrypoint for the container, ovnkube and the openvswitch and
+ovn rpms.
+
+The ovnkube program (in this repository) provides the interface between Openshift and Ovn.
+The arguments used when starting it determine its role in the configuration which are master
+or node.
+
+The ovn cni service is configured and installed after Openshift is installed and running.
+Openshift comes up with no network support. One of many networking choices, including ovn,
+is selected, installed, configured and started to complete Openshift installation.
+
+The installer creates a configmap that contains the configuration information. The two daemonsets
+use the configuration information.
+
+The configmap is mounted in the daemonsets and is used to initialize environment variables that
+are passed to the Docker image running in the pod.
+
+## Daemonset
+
+The daemonsets govern where the components run, what is run, and how they interface with other components.
+The ovnkube-master.yaml and ovnkube.yaml files bring together the needed pieces and set up the context
+for running the pods. Here is some of how it is done.
+
+The nodes are chosen based on labels:
+
+```
+spec:
+  selector:
+    matchLabels:
+      node-role.kubernetes.io/compute: "true"
+             or
+      node-role.kubernetes.io/master: "true"
+  template:
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/compute: "true"
+             or
+        node-role.kubernetes.io/master: "true"
+
+```
+The daemonset will start a pod on every nodes that has the desired labels.
+
+NOTE: The above labels are openshift labels created when openshift is installed.
+As this evolves ovn specific labels will be used.
+
+The docker image is configured as follows:
+```
+spec:
+  template:
+    spec:
+      containers:
+      - name: ovnkube-master
+        image: "netdev22:5000/ovn-kube:latest"
+```
+The image is in a docker repository that all nodes can access.
+
+NOTE: The above uses a local development docker repository, netdev22:5000
+
+The openshift service account is created during installation and configured here:
+```
+spec:
+  template:
+    spec:
+      serviceAccountName: ovn
+```
+
+The daemonsets use host networking and provide the cni plugin when they startup.
+Docker uses the ovn-cni-plugin to access networking. Docker must be able to access the cni
+plugin that is in the image. To do this the host /opt/cni/bin directory
+is mounted in the pod and the pod startup script copies the plugin to the host.
+Since the host operating environment and the pod are different, the installed
+plugin is just a shim that passes requests to the server that is running in the pod.
+
+```
+spec:
+  template:
+    spec:
+      hostNetwork: true
+      hostPID: true
+      containers:
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-openshift-ovn
+      volumes:
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-var-lib-cni-networks-openshift-ovn
+        hostPath:
+          path: /var/lib/cni/networks/ovn-k8s-cni-overlay
+```
+
+## Docker Image
+
+The Dockerfile directs construction of the image. It installs a base OS, rpms,
+and local scripts into the image. It also sets up directories in the image and
+copies files into them.  In particular it copies in the entrypoint script, ovnkube.sh.
+
+```
+# docker build -t ovn-kube .
+# docker tag ovn-kube netdev22:5000/ovn-kube:latest
+# docker push netdev22:5000/ovn-kube:latest
+```
+The image is taged and pushed to a docker repository. This example uses the
+local development docker repo, netdev22:5000
+
+NOTE: At present go_controller is built and the resultant files are copied
+to the docker build directory. In the future, these files will be installed
+from openvswitch-ovn-kubernetes rpm.
+
+
+## Configuration
+
+There are three sources of configuration information in the daemonsets:
+
+1. /etc/origin/node/ files
+These files are installed by the Openshift install and are in the node daemonset
+which mounts them on the host. The ovn deamonsets mount them in the pod.
+
+```
+spec:
+  template:
+    spec:
+      containers:
+        volumeMounts:
+        # Directory which contains the host configuration.
+        - mountPath: /etc/origin/node/
+          name: host-config
+          readOnly: true
+        - mountPath: /etc/sysconfig/origin-node
+          name: host-sysconfig-node
+          readOnly: true
+      volumes:
+      - name: host-config
+        hostPath:
+          path: /etc/origin/node
+      - name: host-sysconfig-node
+        hostPath:
+          path: /etc/sysconfig/origin-node
+```
+
+2. /etc/openvswitch/ovn_k8s.conf
+
+This file is used by ovn daemons and ovnkube to set needed values.
+This file is build into the image. It holds configuration constants.
+
+3. ovn-config configmap
+
+This configmap is created after Openshift is installed and running and before
+the network is installed. It contains information that is specific to the cluster
+that is needed for ovn to access the cluster apiserver.
+
+```
+# oc get configmap ovn-config -o yaml
+apiVersion: v1
+data:
+  OvnNorth: tcp://10.19.188.22:6641
+  OvnSouth: tcp://10.19.188.22:6642
+  k8s_apiserver: https://wsfd-netdev22.ntdv.lab.eng.bos.redhat.com:8443
+  k8s_token: eyJhbGciOiJSUzI1NiIsIm ..... XGwBj4FuMgcOlX9rh5h2X5w
+  net_cidr: 10.128.0.0/14
+  svc_cidr: 172.30.0.0/16
+kind: ConfigMap
+```
+OvnNorth and OvnSouth are used by ovn to access its daemons. They are host IP address of the daemons.
+
+k8s_apiserver and k8s_token allow access to Openshift's api server.
+
+net_cidr and svc_cidr are the configuration configuration cidrs
+
+The configmap keys become environment variable values in the daemonset yaml files.
+
+```
+spec:
+  template:
+    spec:
+      containers:
+        env:
+        - name: OVN_NORTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnNorth
+```
+

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -38,7 +38,10 @@ func NewClientset(conf *config.KubernetesConfig) (*kubernetes.Clientset, error) 
 	} else if strings.HasPrefix(conf.APIServer, "http") {
 		kconfig, err = clientcmd.BuildConfigFromFlags(conf.APIServer, "")
 	} else {
-		err = fmt.Errorf("a kubeconfig file or server/token/tls credentials are required")
+		// Assume we are running from a container managed by kubernetes
+		// and read the apiserver address and tokens from the
+		// container's environment.
+		kconfig, err = rest.InClusterConfig()
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
    Create a container image for ovn, configure and run from openshift
    daemonsets.  As of OCP-3.10 openshift is in containers. The network
    sdn is also in containers.
    
    See dist/READMEcontainer.md, docs/INSTALL.OPENSHIFT.md for details.
    
    Signed-off-by: Phil Cameron <pcameron@redhat.com>
