### PR TITLE
gateway-router: Flag to enable nodeport load-balancers.

### DIFF
--- a/docs/ovn-kube-util.1
+++ b/docs/ovn-kube-util.1
@@ -39,6 +39,9 @@ A unique node name.
 \fB\--default-gw\fR  value
 The next hop IP address for your physical interface.
 .TP
+\fB\--enable-load-balancers\fR
+Enable load-balancers on Gateway router for nodeports.
+.TP
 \fB\--rampout-ip-subnets\fR  value
 Uses this gateway to rampout traffic originating from the specified comma separated ip subnets.  Used to distribute outgoing traffic via multiple gateways.
 .TP

--- a/go-controller/cmd/ovn-kube-util/app/gateway_init.go
+++ b/go-controller/cmd/ovn-kube-util/app/gateway_init.go
@@ -41,6 +41,10 @@ var InitGatewayCmd = cli.Command{
 			Name:  "rampout-ip-subnets",
 			Usage: "Uses this gateway to rampout traffic originating from the specified comma separated ip subnets.  Used to distribute outgoing traffic via multiple gateways.",
 		},
+		cli.BoolFlag{
+			Name:  "enable-load-balancers",
+			Usage: "Enable load-balancers on Gateway router for nodeports.",
+		},
 	}, config.Flags...),
 	Action: func(context *cli.Context) error {
 		if err := initGateway(context); err != nil {
@@ -74,6 +78,7 @@ func initGateway(context *cli.Context) error {
 	bridgeInterface := context.String("bridge-interface")
 	defaultGW := context.String("default-gw")
 	rampoutIPSubnet := context.String("rampout-ip-subnet")
+	enableLB := context.Bool("enable-load-balancers")
 
 	// We want either of args.physical_interface or args.bridge_interface provided. But not both. (XOR)
 	if (len(physicalInterface) == 0 && len(bridgeInterface) == 0) || (len(physicalInterface) != 0 && len(bridgeInterface) != 0) {
@@ -81,5 +86,6 @@ func initGateway(context *cli.Context) error {
 	}
 
 	return util.GatewayInit(clusterIPSubnet, nodeName, physicalIP,
-		physicalInterface, bridgeInterface, defaultGW, rampoutIPSubnet)
+		physicalInterface, bridgeInterface, defaultGW, rampoutIPSubnet,
+		enableLB)
 }

--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -363,7 +363,8 @@ func (cluster *OvnClusterController) initGateway(
 				cluster.GatewayBridge)
 		}
 		err = util.GatewayInit(clusterIPSubnet, nodeName, ipAddress, "",
-			cluster.GatewayBridge, cluster.GatewayNextHop, subnet)
+			cluster.GatewayBridge, cluster.GatewayNextHop, subnet,
+			cluster.NodePortEnable)
 		if err != nil {
 			return err
 		}
@@ -381,7 +382,8 @@ func (cluster *OvnClusterController) initGateway(
 				cluster.GatewayIntf)
 		}
 		err = util.GatewayInit(clusterIPSubnet, nodeName, ipAddress,
-			cluster.GatewayIntf, "", cluster.GatewayNextHop, subnet)
+			cluster.GatewayIntf, "", cluster.GatewayNextHop, subnet,
+			cluster.NodePortEnable)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We currently, always create 2 LBs (one for TCP and one for UDP)
when a gateway router is created, irrespective of whether
nodeport is needed. When the cluster size increases, we are
increasing the number of objects that OVN daemons need to
process unnecessarily.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>