### PR TITLE
Bump OVS version used by ansible:

### DIFF
--- a/contrib/roles/linux/openvswitch/vars/ubuntu.yml
+++ b/contrib/roles/linux/openvswitch/vars/ubuntu.yml
@@ -27,13 +27,13 @@ ovs_info:
   git_url: https://github.com/openvswitch/ovs.git
   build_path: /tmp
   modules_file_path: /etc/modules-load.d/modules.conf
-  branch: branch-2.8
+  branch: branch-2.9
   service_path: /etc/systemd/system/openvswitch.service
-  release_link: http://openvswitch.org/releases/openvswitch-2.8.2.tar.gz
-  release_name: openvswitch-2.8.2
-  pkg_build_version: 2.8.2-1
+  release_link: http://openvswitch.org/releases/openvswitch-2.9.2.tar.gz
+  release_name: openvswitch-2.9.2
+  pkg_build_version: 2.9.2-1
   # Prebuilt packages info and download link
   install_prebuilt_packages: "{{ovs_install_prebuilt_packages | default(false)}}"
   prebuilt_packages_download_path: /tmp
-  prebuilt_version: "2.8.2-1"
+  prebuilt_version: "2.9.2-1"
   debs_targz_link: "replace_me"


### PR DESCRIPTION
Until now version 2.8 of OVS was used since there was a bug when using
'nodeport'. For more information see:
https://github.com/openvswitch/ovn-kubernetes/issues/272

The issue is now fixed, and this patch bump the version used by the playbooks.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>