### PR TITLE
docs/vagrant: Use default ports that startup scripts use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ uses the hostname.  kubelet allows this name to be overridden with
  -service-cluster-ip-range=$SERVICE_IP_SUBNET \
  -nodeport \
  -k8s-token="$TOKEN" \
- -nb-address="tcp://$CENTRAL_IP:6631" \
- -sb-address="tcp://$CENTRAL_IP:6632" 2>&1 &
+ -nb-address="tcp://$CENTRAL_IP:6641" \
+ -sb-address="tcp://$CENTRAL_IP:6642" 2>&1 &
 ```
 
 Note: Make sure to read /var/log/openvswitch/ovnkube.log to see that there were
@@ -145,8 +145,8 @@ nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -loglevel=4 \
     -k8s-apiserver="http://$CENTRAL_IP:8080" \
     -init-node="$NODE_NAME"  \
     -nodeport \
-    -nb-address="tcp://$CENTRAL_IP:6631" \
-    -sb-address="tcp://$CENTRAL_IP:6632" -k8s-token="$TOKEN" \
+    -nb-address="tcp://$CENTRAL_IP:6641" \
+    -sb-address="tcp://$CENTRAL_IP:6642" -k8s-token="$TOKEN" \
     -init-gateways \
     -service-cluster-ip-range=$SERVICE_IP_SUBNET \
     -cluster-subnet=$CLUSTER_IP_SUBNET 2>&1 &

--- a/docs/INSTALL.SSL.md
+++ b/docs/INSTALL.SSL.md
@@ -132,11 +132,11 @@ sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -net-controller -loglevel=4 \
  -init-master="$NODE_NAME" -cluster-subnet=$CLUSTER_IP_SUBNET \
  -service-cluster-ip-range=$SERVICE_IP_SUBNET \
  -nodeport \
- -nb-address="ssl://$CENTRAL_IP:6631" \
+ -nb-address="ssl://$CENTRAL_IP:6641" \
  -nb-server-privkey /etc/openvswitch/ovnnb-privkey.pem \
  -nb-server-cert /etc/openvswitch/ovnnb-cert.pem \
  -nb-server-cacert /vagrant/pki/switchca/cacert.pem \
- -sb-address="ssl://$CENTRAL_IP:6632" \
+ -sb-address="ssl://$CENTRAL_IP:6642" \
  -sb-server-privkey /etc/openvswitch/ovnsb-privkey.pem \
  -sb-server-cert /etc/openvswitch/ovnsb-cert.pem \
  -sb-server-cacert /vagrant/pki/switchca/cacert.pem  \
@@ -156,8 +156,8 @@ sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -k8s-apiserver="http://$CENTRAL_IP:8080" \
     -init-node="$MINION_NAME"  \
     -nodeport \
-    -nb-address="ssl://$CENTRAL_IP:6631" \
-    -sb-address="ssl://$CENTRAL_IP:6632" -k8s-token=$TOKEN \
+    -nb-address="ssl://$CENTRAL_IP:6641" \
+    -sb-address="ssl://$CENTRAL_IP:6642" -k8s-token=$TOKEN \
     -nb-client-privkey /etc/openvswitch/ovncontroller-privkey.pem \
     -nb-client-cert /etc/openvswitch/ovncontroller-cert.pem \
     -nb-client-cacert /etc/openvswitch/ovnnb-ca.cert \

--- a/vagrant/provisioning/setup-k8s-master.sh
+++ b/vagrant/provisioning/setup-k8s-master.sh
@@ -137,8 +137,8 @@ nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -net-controller -loglev
  -service-cluster-ip-range=172.16.1.0/24 \
  -nodeport \
  -k8s-token="test" \
- -nb-address="$PROTOCOL://$OVERLAY_IP:6631" \
- -sb-address="$PROTOCOL://$OVERLAY_IP:6632" \
+ -nb-address="$PROTOCOL://$OVERLAY_IP:6641" \
+ -sb-address="$PROTOCOL://$OVERLAY_IP:6642" \
  ${SSL_ARGS} 2>&1 &
 
 

--- a/vagrant/provisioning/setup-k8s-minion.sh
+++ b/vagrant/provisioning/setup-k8s-minion.sh
@@ -77,8 +77,8 @@ nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -k8s-apiserver="http://$MASTER_OVERLAY_IP:8080" \
     -init-node="$MINION_NAME"  \
     -nodeport \
-    -nb-address="$PROTOCOL://$MASTER_OVERLAY_IP:6631" \
-    -sb-address="$PROTOCOL://$MASTER_OVERLAY_IP:6632" \
+    -nb-address="$PROTOCOL://$MASTER_OVERLAY_IP:6641" \
+    -sb-address="$PROTOCOL://$MASTER_OVERLAY_IP:6642" \
     ${SSL_ARGS} \
     -k8s-token="test" \
     -init-gateways -gateway-interface=enp0s9 -gateway-nexthop="$GW_IP" \


### PR DESCRIPTION
6641 and 6642 is what OVN uses by default. Stick to it.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>