### PR TITLE
cluster: Add a error message.

### DIFF
--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -240,6 +240,7 @@ func (cluster *OvnClusterController) StartClusterMaster(masterNodeName string) e
 	}
 
 	if err := cluster.SetupMaster(masterNodeName); err != nil {
+		logrus.Errorf("Failed to setup master (%v)", err)
 		return err
 	}
 

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -107,6 +107,7 @@ func (cluster *OvnClusterController) updateOvnNode(masterIP string,
 	err = setupOVNNode(node.Name, config.Kubernetes.APIServer,
 		config.Kubernetes.Token, config.Kubernetes.CACert)
 	if err != nil {
+		logrus.Errorf("Failed to setup OVN node (%v)", err)
 		return err
 	}
 


### PR DESCRIPTION
Without this, it is hard to figure out where in the code
the error came from.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>