### PR TITLE
gateway: Add a localnet gateway.

### DIFF
--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -54,6 +54,11 @@ If true, assumes that "gateway-interface" provided can be exclusively
 used for the OVN gateway.  When true, only OVNrelated traffic can flow
 through this interface.
 .TP
+\fB\--gateway-localnet\fR
+If true, creates a localnet gateway to let traffic reach host network
+and also exit host with iptables NAT. A localnet gateway will have
+a IP address of 169.254.33.2.
+.TP
 \fB\--nodeport\fR
 Setup nodeport based entries in OVN gateways for ingress into the k8s cluster.
 By default, it is disabled.

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -90,7 +90,11 @@ func main() {
 				"exclusively used for the OVN gateway.  When true, only OVN" +
 				"related traffic can flow through this interface",
 		},
-
+		cli.BoolFlag{
+			Name: "gateway-localnet",
+			Usage: "If true, creates a localnet gateway to let traffic reach " +
+				"host network and also exit host with iptables NAT",
+		},
 		cli.BoolFlag{
 			Name:  "nodeport",
 			Usage: "Setup nodeport based ingress on gateways.",
@@ -199,6 +203,7 @@ func runOvnKube(ctx *cli.Context) error {
 		clusterController.GatewayIntf = ctx.String("gateway-interface")
 		clusterController.GatewayNextHop = ctx.String("gateway-nexthop")
 		clusterController.GatewaySpareIntf = ctx.Bool("gateway-spare-interface")
+		clusterController.LocalnetGateway = ctx.Bool("gateway-localnet")
 		clusterController.OvnHA = ctx.Bool("ha")
 		_, clusterController.ClusterIPNet, err = net.ParseCIDR(ctx.String("cluster-subnet"))
 		if err != nil {

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -30,6 +30,7 @@ type OvnClusterController struct {
 	GatewaySpareIntf bool
 	NodePortEnable   bool
 	OvnHA            bool
+	LocalnetGateway  bool
 }
 
 const (

--- a/vagrant/provisioning/setup-k8s-master.sh
+++ b/vagrant/provisioning/setup-k8s-master.sh
@@ -139,6 +139,7 @@ nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -net-controller -loglev
  -k8s-token="test" \
  -nb-address="$PROTOCOL://$OVERLAY_IP:6641" \
  -sb-address="$PROTOCOL://$OVERLAY_IP:6642" \
+ -init-gateways -gateway-localnet \
  ${SSL_ARGS} 2>&1 &
 
 


### PR DESCRIPTION
gateway: Add a localnet gateway.

There are k8s deployments with only master node (as a starting
point). And sometimes they just deploy a DNS pod or some other
pods in the master node. The DNS pod in pod network will go into a
crash loop because it cannot access the k8s daemons' IP in host
network.  Even if we deploy a OVN gateway on master, this won't
help because OVN gateway will have the same IP as the host IP. 

Currently in OVN we create gateways in minions only. We can also
create a gateway in master, but we do need 2 NICs there.

This commit lets OVN handle master-only deployment. This is done
by creating a "localnet OVN gateway" on master. A localnet OVN gateway
is just a regular OVN gateway, but with a local physical interface
connected to it. When ovnkube is run with '-init-gateways -gateway-localnet',
the code will create a OVS bridge called "br-localnet" and create a internal
port called "br-nexthop". It will assign a local ip "169.254.33.2"
to OVN gateway in logical space and "169.254.33.1" to "br-nexthop"
in physical space. Now, if /proc/sys/net/ipv4/ip_forward is set to 1,
we can access the host IP. In addition, for the pods to be able to
access outside internet, a iptables NAT rule is added.

[Some of the code is copied from:
https://github.com/openvswitch/ovn-kubernetes/pull/184]
Signed-off-by: Gurucharan Shetty <guru@ovn.org>