### PR TITLE
cluster: Remove OVN objects for a node deletion.

### DIFF
--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -396,6 +396,10 @@ func (cluster *OvnClusterController) watchNodes() error {
 			if err != nil {
 				logrus.Errorf("Error deleting node %s: %v", node.Name, err)
 			}
+			err = util.RemoveNode(node.Name)
+			if err != nil {
+				logrus.Errorf("Failed to remove node %s (%v)", node.Name, err)
+			}
 		},
 	}, nil)
 	return err


### PR DESCRIPTION
When a k8s node is deleted, we can remove OVN
objects in the central DB associated with that node.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>