### PR TITLE
util: default to host CA bundle for k8s CACert

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -415,9 +415,6 @@ func buildKubernetesConfig(cli, file *config, defaults *Defaults) error {
 		return fmt.Errorf("kubernetes API server URL scheme %q invalid", url.Scheme)
 	}
 
-	if strings.HasPrefix(Kubernetes.APIServer, "https") && Kubernetes.CACert == "" {
-		return fmt.Errorf("kubernetes API server %q scheme requires a CA certificate", Kubernetes.APIServer)
-	}
 	return nil
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -515,10 +515,6 @@ server-cacert=/path/to/sb-ca.crt`), 0644)
 	// Run once without config file, once with
 	Describe("Kubernetes config options", func() {
 		Context("returns an error when the", func() {
-			generateTestsSimple("apiserver scheme is HTTPS but no CACert is provided",
-				"kubernetes API server \"https://localhost:8443\" scheme requires a CA certificate",
-				"-k8s-apiserver=https://localhost:8443")
-
 			generateTestsSimple("CA cert does not exist",
 				"kubernetes CA certificate file \"/foo/bar/baz.cert\" not found",
 				"-k8s-apiserver=https://localhost:8443", "-k8s-cacert=/foo/bar/baz.cert")

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -22,18 +22,18 @@ func NewClientset(conf *config.KubernetesConfig) (*kubernetes.Clientset, error) 
 		// uses the current context in kubeconfig
 		kconfig, err = clientcmd.BuildConfigFromFlags("", conf.Kubeconfig)
 	} else if strings.HasPrefix(conf.APIServer, "https") {
-		if conf.APIServer == "" || conf.Token == "" || conf.CACert == "" {
+		if conf.APIServer == "" || conf.Token == "" {
 			return nil, fmt.Errorf("TLS-secured apiservers require token and CA certificate")
 		}
-
-		if _, err := cert.NewPool(conf.CACert); err != nil {
-			return nil, err
-		}
-
 		kconfig = &rest.Config{
-			Host:            conf.APIServer,
-			BearerToken:     conf.Token,
-			TLSClientConfig: rest.TLSClientConfig{CAFile: conf.CACert},
+			Host:        conf.APIServer,
+			BearerToken: conf.Token,
+		}
+		if conf.CACert != "" {
+			if _, err := cert.NewPool(conf.CACert); err != nil {
+				return nil, err
+			}
+			kconfig.TLSClientConfig = rest.TLSClientConfig{CAFile: conf.CACert}
 		}
 	} else if strings.HasPrefix(conf.APIServer, "http") {
 		kconfig, err = clientcmd.BuildConfigFromFlags(conf.APIServer, "")


### PR DESCRIPTION
…sn't exist

k8s apiserver's CACert might not need to be specified explicitly.
In some k8s cluster, apiserver's CACert is trusted automatically on the host,
e.g., part of /etc/pki/tls/certs/ca-bundle.crt.

Signed-off-by: Bo Gan <ganb@vmware.com>