### PR TITLE
vagrant: p80.pool.sks-keyservers.net appears to be down

### DIFF
--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -33,7 +33,7 @@ sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates
 echo "deb http://18.191.116.101/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
 wget -O - http://18.191.116.101/openvswitch/keyFile |  sudo apt-key add -
-sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 sudo su -c "echo \"deb https://apt.dockerproject.org/repo ubuntu-xenial main\" >> /etc/apt/sources.list.d/docker.list"
 sudo apt-get update
 

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -48,7 +48,7 @@ sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates
 echo "deb http://18.191.116.101/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
 wget -O - http://18.191.116.101/openvswitch/keyFile |  sudo apt-key add -
-sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 sudo su -c "echo \"deb https://apt.dockerproject.org/repo ubuntu-xenial main\" >> /etc/apt/sources.list.d/docker.list"
 sudo apt-get update
 


### PR DESCRIPTION
Which means that docker can't be installed, which means that
kubelet can't start, which means not much works.
Replace with keyserver.ubuntu.com which is probably more reliable.

    k8s-master: + sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
    k8s-master: Executing: /tmp/tmp.fIFMpo6bEb/gpg.1.sh --keyserver
    k8s-master: hkp://p80.pool.sks-keyservers.net:80
    k8s-master: --recv-keys
    k8s-master: 58118E89F3A912897C070ADBF76221572C52609D
    k8s-master: gpg: requesting key 2C52609D from hkp server p80.pool.sks-keyservers.net
    k8s-master: gpgkeys: key 58118E89F3A912897C070ADBF76221572C52609D can't be retrieved
    k8s-master: gpg: no valid OpenPGP data found.
    k8s-master: gpg: Total number processed: 0
    k8s-master: gpg: keyserver communications error: keyserver helper general error
    k8s-master: gpg: keyserver communications error: unknown pubkey algorithm
    k8s-master: gpg: keyserver receive failed: unknown pubkey algorithm
    k8s-master: + sudo su -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-xenial main" >> /etc/apt/sources.list.d/docker.list'
    k8s-master: + sudo apt-get update
    k8s-master: Get:1 http://18.191.116.101/openvswitch/stable  InRelease [1,724 B]
    k8s-master: Get:2 http://18.191.116.101/openvswitch/stable  Packages [9,274 B]
    k8s-master: Get:3 https://apt.dockerproject.org/repo ubuntu-xenial InRelease [48.7 kB]
    k8s-master: Hit:4 http://security.ubuntu.com/ubuntu xenial-security InRelease
    k8s-master: Hit:5 http://archive.ubuntu.com/ubuntu xenial InRelease
    k8s-master: Ign:3 https://apt.dockerproject.org/repo ubuntu-xenial InRelease
    k8s-master: Get:6 https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages [4,177 B]
    k8s-master: Hit:7 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
    k8s-master: Hit:8 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
    k8s-master: Fetched 63.9 kB in 0s (120 kB/s)
    k8s-master: Reading package lists...
    k8s-master: W
    k8s-master: :
    k8s-master: GPG error: https://apt.dockerproject.org/repo ubuntu-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY F76221572C52609D
    k8s-master: W
    k8s-master: :

Signed-off-by: Dan Williams <dcbw@redhat.com>