### PR TITLE
Add logging to kubelet on Windows

### DIFF
--- a/contrib/roles/windows/kubernetes/tasks/start_kubelet.yml
+++ b/contrib/roles/windows/kubernetes/tasks/start_kubelet.yml
@@ -50,7 +50,7 @@
 - name: Kubelet | Create Kubelet service
   win_service:
     name: kubelet
-    path: '"{{ install_info.install_path }}\\servicewrapper.exe" kubelet "{{ install_info.install_path }}\\kubelet.exe" --hostname-override="{{ ansible_hostname }}" --cluster-dns="{{ kubernetes_info.K8S_DNS_SERVICE_IP }}" --cluster-domain="{{ kubernetes_info.K8S_DNS_DOMAIN }}" --pod-infra-container-image="{{kubernetes_info.infracontainername_1709}}" --resolv-conf="" --kubeconfig="{{ install_info.install_path }}\\kubeconfig.yaml" --network-plugin=cni --cni-bin-dir="{{ install_info.install_path }}\\cni" --cni-conf-dir="{{ install_info.install_path }}\\cni" --log-dir="{{ install_info.install_path }}" --cgroups-per-qos=false --enforce-node-allocatable=""'
+    path: '"{{ install_info.install_path }}\\servicewrapper.exe" kubelet "{{ install_info.install_path }}\\kubelet.exe" --hostname-override="{{ ansible_hostname }}" --cluster-dns="{{ kubernetes_info.K8S_DNS_SERVICE_IP }}" --cluster-domain="{{ kubernetes_info.K8S_DNS_DOMAIN }}" --pod-infra-container-image="{{kubernetes_info.infracontainername_1709}}" --resolv-conf="" --kubeconfig="{{ install_info.install_path }}\\kubeconfig.yaml" --network-plugin=cni --cni-bin-dir="{{ install_info.install_path }}\\cni" --cni-conf-dir="{{ install_info.install_path }}\\cni" --log-dir="{{ install_info.install_path }}" --logtostderr=false --cgroups-per-qos=false --enforce-node-allocatable=""'
     display_name: Kubernetes Kubelet
     description: Kubernetes Kubelet service
     username: LocalSystem


### PR DESCRIPTION
By default kubelet logs on STD_ERR and not to the files.

This commit adds a command line argument to instruct kubelet to log
in files rather than STD_ERR.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>