### PR TITLE
cni result should be versioned according to the one asked for

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -151,8 +151,8 @@ func (pr *PodRequest) cmdAdd() *PodResult {
 	}
 
 	podResult := &PodResult{}
-	versionedResult, _ := result.GetAsVersion(pr.CNIConf.CNIVersion)
-	podResult.Response, _ = json.Marshal(versionedResult)
+	//versionedResult, _ := result.GetAsVersion(pr.CNIConf.CNIVersion)
+	podResult.Response, _ = json.Marshal(result)
 	return podResult
 }
 


### PR DESCRIPTION
Signed-off-by: Rajat Chopra <rchopra@redhat.com>

Or, supposedly if cniserver responds accurately to a 0.2.0 request with a 0.2.0 response, the cnishim will still return a current version result.

@dcbw Can you urgently take a look at this? I somehow get an error on Windows with an older kubelet where the response is expected to be 0.2.0 and the one given by ovn fails to translate properly (no IP addresses).