### PR TITLE
ovn: unit test management port creation and clean up Windows bits

### DIFF
--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
@@ -19,28 +20,18 @@ const (
 func configureManagementPortWindows(clusterSubnet, clusterServicesSubnet,
 	routerIP, interfaceName, interfaceIP string) error {
 	// Up the interface.
-	args := []string{"Enable-NetAdapter", fmt.Sprintf("%s", interfaceName)}
-	logrus.Debugf("Executing 'powershell %s'", strings.Join(args, " "))
-
-	_, err := exec.Command("powershell", args...).CombinedOutput()
+	_, _, err := util.RunPowershell("Enable-NetAdapter", interfaceName)
 	if err != nil {
 		return err
 	}
 
 	//check if interface already exists
-	args = []string{"Get-NetIPAddress", fmt.Sprintf("-InterfaceAlias %s", interfaceName)}
-	logrus.Debugf("Executing 'powershell %s'", strings.Join(args, " "))
-
-	_, err = exec.Command("powershell", args...).CombinedOutput()
+	ifAlias := fmt.Sprintf("-InterfaceAlias %s", interfaceName)
+	_, _, err = util.RunPowershell("Get-NetIPAddress", ifAlias)
 	if err == nil {
 		//The interface already exists, we should delete the routes and IP
 		logrus.Debugf("Interface %s exists, removing.", interfaceName)
-		args = []string{"Remove-NetIPAddress",
-			fmt.Sprintf("-InterfaceAlias %s", interfaceName),
-			"-Confirm:$false"}
-		logrus.Debugf("Executing 'powershell %s'", strings.Join(args, " "))
-
-		_, err = exec.Command("powershell", args...).CombinedOutput()
+		_, _, err = util.RunPowershell("Remove-NetIPAddress", ifAlias, "-Confirm:$false")
 		if err != nil {
 			return err
 		}
@@ -52,62 +43,56 @@ func configureManagementPortWindows(clusterSubnet, clusterServicesSubnet,
 		return fmt.Errorf("Failed to parse interfaceIP %v : %v", interfaceIP, err)
 	}
 	portPrefix, _ := interfaceIPNet.Mask.Size()
-	args = []string{"New-NetIPAddress",
+	_, _, err = util.RunPowershell("New-NetIPAddress",
 		fmt.Sprintf("-IPAddress %s", portIP),
 		fmt.Sprintf("-PrefixLength %d", portPrefix),
-		fmt.Sprintf("-InterfaceAlias %s", interfaceName)}
-	logrus.Debugf("Executing 'powershell %s'", strings.Join(args, " "))
-
-	_, err = exec.Command("powershell", args...).CombinedOutput()
+		ifAlias)
 	if err != nil {
 		return err
 	}
 
 	// Set MTU for the interface
-	args = []string{"interface", "ipv4", "set", "subinterface",
-		fmt.Sprintf("%s", interfaceName), fmt.Sprintf("mtu=%d", config.Default.MTU), "store=persistent"}
-	logrus.Debugf("Executing 'netsh %s'", strings.Join(args, " "))
-
-	_, err = exec.Command("netsh", args...).CombinedOutput()
+	_, _, err = util.RunNetsh("interface", "ipv4", "set", "subinterface",
+		interfaceName, fmt.Sprintf("mtu=%d", config.Default.MTU),
+		"store=persistent")
 	if err != nil {
 		return err
 	}
+
+	// Retrieve the interface index
+	stdout, stderr, err := util.RunPowershell("$(Get-NetAdapter", "|", "Where",
+		"{", "$_.Name", "-Match", fmt.Sprintf("\"%s\"", interfaceName), "}).ifIndex")
+	if err != nil {
+		logrus.Errorf("Failed to fetch interface index, stderr: %q, error: %v", stderr, err)
+		return err
+	}
+	if _, err := strconv.Atoi(stdout); err != nil {
+		logrus.Errorf("Failed to parse interface index %q: %v", stdout, err)
+		return err
+	}
+	interfaceIndex := stdout
 
 	clusterIP, clusterIPNet, err := net.ParseCIDR(clusterSubnet)
 	if err != nil {
 		return fmt.Errorf("Failed to parse clusterSubnet %v : %v", clusterSubnet, err)
 	}
 	// Checking if the route already exists, in which case it will not be created again
-	stdoutStderr, err := exec.Command("route", "print", "-4", fmt.Sprintf("%s", clusterIP)).CombinedOutput()
+	stdout, stderr, err = util.RunRoute("print", "-4", clusterIP.String())
 	if err != nil {
-		logrus.Debugf("Failed to run route print, stderr: %q, error: %v", stdoutStderr, err)
+		logrus.Debugf("Failed to run route print, stderr: %q, error: %v", stderr, err)
 	}
 
-	var interfaceIndex string
-	if strings.Contains(fmt.Sprintf("%s", stdoutStderr), fmt.Sprintf("%s", clusterIP)) {
+	if strings.Contains(stdout, clusterIP.String()) {
 		logrus.Debugf("Route was found, skipping route add")
 	} else {
-		args = []string{"$(Get-NetAdapter", "|", "Where",
-			"{", "$_.Name", "-Match", fmt.Sprintf("\"%s\"", interfaceName), "}).ifIndex"}
-		logrus.Debugf("Executing 'powershell %s'", strings.Join(args, " "))
-
-		stdoutStderr, err := exec.Command("powershell", args...).CombinedOutput()
-		if err != nil {
-			logrus.Errorf("Failed to fetch interface index, stderr: %q, error: %v", stdoutStderr, err)
-			return err
-		}
-		interfaceIndex = strings.TrimSpace(fmt.Sprintf("%s", stdoutStderr))
 		// Windows route command requires the mask to be specified in the IP format
-		clusterMask := fmt.Sprintf("%s", net.IP(clusterIPNet.Mask))
+		clusterMask := net.IP(clusterIPNet.Mask).String()
 		// Create a route for the entire subnet.
-		args = []string{"route", "-p", "add",
-			fmt.Sprintf("%s", clusterIP), "mask", fmt.Sprintf("%s", clusterMask),
-			fmt.Sprintf("%s", routerIP), "METRIC", "2", "IF", fmt.Sprintf("%s", interfaceIndex)}
-		logrus.Debugf("Executing 'powershell %s'", strings.Join(args, " "))
-
-		stdoutStderr, err = exec.Command("powershell", args...).CombinedOutput()
+		_, stderr, err = util.RunRoute("-p", "add",
+			clusterIP.String(), "mask", clusterMask,
+			routerIP, "METRIC", "2", "IF", interfaceIndex)
 		if err != nil {
-			logrus.Errorf("failed to run route add, stderr: %q, error: %v", fmt.Sprintf("%s", stdoutStderr), err)
+			logrus.Errorf("failed to run route add, stderr: %q, error: %v", stderr, err)
 			return err
 		}
 	}
@@ -118,25 +103,22 @@ func configureManagementPortWindows(clusterSubnet, clusterServicesSubnet,
 			return fmt.Errorf("Failed to parse clusterServicesSubnet %v : %v", clusterServicesSubnet, err)
 		}
 		// Checking if the route already exists, in which case it will not be created again
-		stdoutStderr, err := exec.Command("route", "print", "-4", fmt.Sprintf("%s", clusterServiceIP)).CombinedOutput()
+		stdout, stderr, err = util.RunRoute("print", "-4", clusterServiceIP.String())
 		if err != nil {
-			logrus.Debugf("Failed to run route print, stderr: %q, error: %v", stdoutStderr, err)
+			logrus.Debugf("Failed to run route print, stderr: %q, error: %v", stderr, err)
 		}
 
-		if strings.Contains(fmt.Sprintf("%s", stdoutStderr), fmt.Sprintf("%s", clusterServiceIP)) {
+		if strings.Contains(stdout, clusterServiceIP.String()) {
 			logrus.Debugf("Route was found, skipping route add")
 		} else {
 			// Windows route command requires the mask to be specified in the IP format
-			clusterServiceMask := fmt.Sprintf("%s", net.IP(clusterServiceIPNet.Mask))
+			clusterServiceMask := net.IP(clusterServiceIPNet.Mask).String()
 			// Create a route for the entire subnet.
-			args = []string{"route", "-p", "add",
-				fmt.Sprintf("%s", clusterServiceIP), "mask", fmt.Sprintf("%s", clusterServiceMask),
-				fmt.Sprintf("%s", routerIP), "METRIC", "2", "IF", fmt.Sprintf("%s", interfaceIndex)}
-			logrus.Debugf("Executing 'powershell %s'", strings.Join(args, " "))
-
-			stdoutStderr, err = exec.Command("powershell", args...).CombinedOutput()
+			_, stderr, err = util.RunRoute("-p", "add",
+				clusterServiceIP.String(), "mask", clusterServiceMask,
+				routerIP, "METRIC", "2", "IF", interfaceIndex)
 			if err != nil {
-				logrus.Errorf("failed to run route add, stderr: %q, error: %v", fmt.Sprintf("%s", stdoutStderr), err)
+				logrus.Errorf("failed to run route add, stderr: %q, error: %v", stderr, err)
 				return err
 			}
 		}

--- a/go-controller/pkg/ovn/management-port_test.go
+++ b/go-controller/pkg/ovn/management-port_test.go
@@ -1,0 +1,170 @@
+package ovn
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/urfave/cli"
+	fakeexec "k8s.io/utils/exec/testing"
+
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var tmpDir string
+
+var _ = AfterSuite(func() {
+	err := os.RemoveAll(tmpDir)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func createTempFile(name string) (string, error) {
+	fname := filepath.Join(tmpDir, name)
+	if err := ioutil.WriteFile(fname, []byte{0x20}, 0644); err != nil {
+		return "", err
+	}
+	return fname, nil
+}
+
+var _ = Describe("Management Port Operations", func() {
+	var tmpErr error
+	var app *cli.App
+
+	tmpDir, tmpErr = ioutil.TempDir("", "clusternodetest_certdir")
+	if tmpErr != nil {
+		GinkgoT().Errorf("failed to create tempdir: %v", tmpErr)
+	}
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.RestoreDefaultConfig()
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+	})
+
+	It("sets up the management port", func() {
+		app.Action = func(ctx *cli.Context) error {
+			const (
+				nodeName          string = "node1"
+				lrpMAC            string = "00:00:00:05:46:C3"
+				clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
+				tcpLBUUID         string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
+				udpLBUUID         string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
+				nodeSubnet        string = "10.1.1.0/24"
+				mgtPortMAC        string = "00:00:00:55:66:77"
+				mgtPort           string = "k8s-" + nodeName
+				mgtPortIP         string = "10.1.1.2"
+				mgtPortPrefix     string = "24"
+				mgtPortCIDR       string = mgtPortIP + "/" + mgtPortPrefix
+				clusterIPNet      string = "10.1.0.0"
+				clusterCIDR       string = clusterIPNet + "/16"
+				serviceIPNet      string = "172.16.0.0"
+				serviceCIDR       string = serviceIPNet + "/16"
+				mtu               string = "1400"
+				gwIP              string = "10.1.1.1"
+				gwCIDR            string = gwIP + "/24"
+			)
+
+			fakeCmds := ovntest.AddFakeCmd(nil, &ovntest.ExpectedCmd{
+				Cmd: "ovn-nbctl --timeout=5 --if-exist get logical_router_port rtos-" + nodeName + " mac",
+				// Return a known MAC; otherwise code autogenerates it
+				Output: lrpMAC,
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=5 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
+				Output: clusterRouterUUID,
+			})
+			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+				"ovn-nbctl --timeout=5 --may-exist lrp-add " + clusterRouterUUID + " rtos-" + nodeName + " " + lrpMAC + " " + gwCIDR,
+				"ovn-nbctl --timeout=5 -- --may-exist ls-add " + nodeName + " -- set logical_switch " + nodeName + " other-config:subnet=" + nodeSubnet + " external-ids:gateway_ip=" + gwCIDR,
+				"ovn-nbctl --timeout=5 -- --may-exist lsp-add " + nodeName + " stor-" + nodeName + " -- set logical_switch_port stor-" + nodeName + " type=router options:router-port=rtos-" + nodeName + " addresses=\"" + lrpMAC + "\"",
+				"ovs-vsctl --timeout=5 -- --may-exist add-br br-int",
+				"ovs-vsctl --timeout=5 -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mgtPort,
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovs-vsctl --timeout=5 --if-exists get interface " + mgtPort + " mac_in_use",
+				Output: mgtPortMAC,
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd: "ovn-nbctl --timeout=5 -- --may-exist lsp-add " + nodeName + " " + mgtPort + " -- lsp-set-addresses " + mgtPort + " " + mgtPortMAC + " " + mgtPortIP,
+			})
+			if runtime.GOOS == windowsOS {
+				const ifindex string = "10"
+				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+					"powershell Enable-NetAdapter " + mgtPort,
+					"powershell Get-NetIPAddress -InterfaceAlias " + mgtPort,
+					"powershell Remove-NetIPAddress -InterfaceAlias " + mgtPort + " -Confirm:$false",
+					"powershell New-NetIPAddress -IPAddress " + mgtPortIP + " -PrefixLength " + mgtPortPrefix + " -InterfaceAlias " + mgtPort,
+					"netsh interface ipv4 set subinterface " + mgtPort + " mtu=" + mtu + " store=persistent",
+				})
+				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+					Cmd:    "powershell $(Get-NetAdapter | Where { $_.Name -Match \"" + mgtPort + "\" }).ifIndex",
+					Output: ifindex,
+				})
+				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+					// Don't print route output; test that network is not yet found
+					"route print -4 " + clusterIPNet,
+					"route -p add " + clusterIPNet + " mask 255.255.0.0 " + gwIP + " METRIC 2 IF " + ifindex,
+					// Don't print route output; test that network is not yet found
+					"route print -4 " + serviceIPNet,
+					"route -p add " + serviceIPNet + " mask 255.255.0.0 " + gwIP + " METRIC 2 IF " + ifindex,
+				})
+			} else {
+				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+					"ip link set " + mgtPort + " up",
+					"ip addr flush dev " + mgtPort,
+					"ip addr add " + mgtPortCIDR + " dev " + mgtPort,
+					"ip route flush " + clusterCIDR,
+					"ip route add " + clusterCIDR + " via " + gwIP,
+					"ip route flush " + serviceCIDR,
+					"ip route add " + serviceCIDR + " via " + gwIP,
+				})
+			}
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=5 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+				Output: tcpLBUUID,
+			})
+			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+				"ovn-nbctl --timeout=5 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=5 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+				Output: udpLBUUID,
+			})
+			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+				"ovn-nbctl --timeout=5 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
+			})
+
+			fexec := &fakeexec.FakeExec{
+				CommandScript: fakeCmds,
+				LookPathFunc: func(file string) (string, error) {
+					return fmt.Sprintf("/fake-bin/%s", file), nil
+				},
+			}
+
+			err := util.SetExec(fexec)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = CreateManagementPort(nodeName, nodeSubnet, clusterCIDR, serviceCIDR)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fexec.CommandCalls).To(Equal(len(fakeCmds)))
+			return nil
+		}
+
+		err := app.Run([]string{app.Name})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/go-controller/pkg/ovn/ovn_suite_test.go
+++ b/go-controller/pkg/ovn/ovn_suite_test.go
@@ -1,0 +1,13 @@
+package ovn
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClusterNode(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OVN Operations Suite")
+}

--- a/go-controller/pkg/testing/testing.go
+++ b/go-controller/pkg/testing/testing.go
@@ -44,3 +44,12 @@ func AddFakeCmd(fakeCmds []fakeexec.FakeCommandAction, expected *ExpectedCmd) []
 		}
 	})
 }
+
+// AddFakeCmdsNoOutputNoError takes a list of commands and appends those commands
+// to the expected command set. The command cannot return any output or error.
+func AddFakeCmdsNoOutputNoError(fakeCmds []fakeexec.FakeCommandAction, commands []string) []fakeexec.FakeCommandAction {
+	for _, cmd := range commands {
+		fakeCmds = AddFakeCmd(fakeCmds, &ExpectedCmd{Cmd: cmd})
+	}
+	return fakeCmds
+}


### PR DESCRIPTION
Unit tests were developed against pre-cleaned-up Windows management
port commands to ensure cleanups didn't change the command sequence.

Signed-off-by: Dan Williams <dcbw@redhat.com>

@shettyg @rajatchopra @alinbalutoiu 