### PR TITLE
support for external IPs

### DIFF
--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -116,12 +116,17 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 }
 
 func (ovn *Controller) handleExternalIPs(svc *kapi.Service, svcPort kapi.ServicePort, ips []string, targetPort int32) {
-	logrus.Infof("handling external IPs for svc %v", svc.Name)
+	logrus.Debugf("handling external IPs for svc %v", svc.Name)
 	if len(svc.Spec.ExternalIPs) == 0 {
 		return
 	}
 	for _, extIP := range svc.Spec.ExternalIPs {
-		err := ovn.createLoadBalancerVIP(ovn.getDefaultGatewayLoadBalancer(svcPort.Protocol), extIP, svcPort.Port, ips, targetPort)
+		lb := ovn.getDefaultGatewayLoadBalancer(svcPort.Protocol)
+		if lb == "" {
+			logrus.Warningf("No default gateway found for protocol %s\n\tNote: 'nodeport' flag needs to be enabled for default gateway", svcPort.Protocol)
+			continue
+		}
+		err := ovn.createLoadBalancerVIP(lb, extIP, svcPort.Port, ips, targetPort)
 		if err != nil {
 			logrus.Errorf("Error in creating external IP for service: %s, externalIP: %s", svc.Name, extIP)
 		}

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -51,10 +51,10 @@ func (ovn *Controller) getDefaultGatewayLoadBalancer(protocol kapi.Protocol) str
 		return ""
 	}
 
-	externalIdKey := string(protocol) + "_lb_gateway_router"
+	externalIDKey := string(protocol) + "_lb_gateway_router"
 	lb, _, _ := util.RunOVNNbctlUnix("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "load_balancer",
-		"external_ids:"+externalIdKey+"="+gw)
+		"external_ids:"+externalIDKey+"="+gw)
 	if len(lb) != 0 {
 		ovn.loadbalancerGWCache[string(protocol)] = lb
 	}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -25,6 +25,10 @@ type Controller struct {
 	// cluster's east-west traffic.
 	loadbalancerClusterCache map[string]string
 
+	// For TCP and UDP type traffice, cache OVN load balancer that exists on the
+	// default gateway
+	loadbalancerGWCache map[string]string
+
 	// A cache of all logical switches seen by the watcher
 	logicalSwitchCache map[string]bool
 
@@ -91,6 +95,7 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory,
 		lspMutex:                 &sync.Mutex{},
 		gatewayCache:             make(map[string]string),
 		loadbalancerClusterCache: make(map[string]string),
+		loadbalancerGWCache:      make(map[string]string),
 		nodePortEnable:           nodePortEnable,
 	}
 }


### PR DESCRIPTION
ExternalIPs are put as load balancer keys on the default gateway. The default gateway is the one which has the port 100.64.1.2 (we used to slap an external id earlier, but not anymore).
ovnkube on the default gateway must be invoked with --nodeport to let the load balancers be installed on the default gateway, or external IPs will be ignored.

To create a service with external IP, see [this](https://github.com/rajatchopra/openshift-examples/blob/master/hello-lb.json) example.

Tested it to the point where load balancer entries are made properly. 
TODO: Test with a configured environment where a packet is sent to the default gw node with the external IP as destination.

@shettyg PTAL. Thanks.

Signed-off-by: Rajat Chopra <rchopra@redhat.com>