### PR TITLE
add k8s_token to configmap

### DIFF
--- a/dist/ansible/scripts/ovn-setup.sh
+++ b/dist/ansible/scripts/ovn-setup.sh
@@ -63,6 +63,7 @@ metadata:
   namespace: ovn-kubernetes
 data:
   k8s_apiserver: $apiserver
+  k8s_token:     $token
   net_cidr:      $net_cidr
   svc_cidr:      $svc_cidr
   OvnNorth:      $OvnNorth


### PR DESCRIPTION
I'm trying to create the the ovnkube-master pod, found the pod cannot be running due to 
`  Warning  Failed   11s (x4 over 39s)  kubelet, ip-172-18-14-203.ec2.internal  Error: Couldn't find key k8s_token in ConfigMap ovn-kubernetes/ovn-config`, I added the k8s_token to the configmap, it becomes running.

So here I update the script to add the `k8s_token` to configmap
