### PR TITLE
Added top level Dockerfile

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -6,9 +6,9 @@
 
 # Notes:
 # This is for a development build where the ovn-kubernetes utilities
-# are built locally and included in the image (instead of the rpm)
+# are built in this Dockerfile and included in the image (instead of the rpm)
 #
-# At present this uses centos:7
+# This is based on centos:7
 # openvswitch rpms are from
 # http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.0/4.el7/x86_64/
 #
@@ -20,6 +20,29 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
+# install golang and build tools
+RUN yum install -y  \
+	make which golang  && \
+	yum clean all
+
+# copy git commit number into image
+RUN mkdir -p go-controller /root/.git/ /root/.git/refs/heads/
+COPY .git/HEAD /root/.git/HEAD
+COPY .git/refs/heads/ /root/.git/refs/heads/
+
+# build the binaries
+COPY go-controller/ go-controller/
+RUN cd go-controller && make
+
+# remove build tools
+RUN yum remove -y  \
+	gmake which golang \
+	cpp gcc glibc-devel glibc-headers golang-bin \
+	golang-src.noarch kernel-headers.x86_64 \
+	libgomp.x86_64 libmpc.x86_64 mpfr.x86_64 && \
+	yum clean all
+
+# install needed rpms
 RUN yum install -y  \
 	PyYAML bind-utils \
 	libnuma.so \
@@ -30,37 +53,31 @@ RUN yum install -y  \
 	iproute strace socat && \
 	yum clean all
 
-# get a reasonable version of openvswitch
+# get a reasonable version of openvswitch (2.9.0 or higher)
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.0/4.el7/x86_64/openvswitch-2.9.0-4.el7.x86_64.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.0/4.el7/x86_64/openvswitch-ovn-common-2.9.0-4.el7.x86_64.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.0/4.el7/x86_64/openvswitch-ovn-central-2.9.0-4.el7.x86_64.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.0/4.el7/x86_64/openvswitch-ovn-host-2.9.0-4.el7.x86_64.rpm
-#RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.0/4.el7/x86_64/openvswitch-ovn-docker-2.9.0-4.el7.x86_64.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.0/4.el7/x86_64/openvswitch-ovn-vtep-2.9.0-4.el7.x86_64.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.0/4.el7/x86_64/openvswitch-devel-2.9.0-4.el7.x86_64.rpm
 RUN rpm -i http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/containernetworking-cni-0.5.1-1.el7.x86_64.rpm
+RUN rm -rf /var/cache/yum
 
-RUN mkdir -p /var/run/openvswitch
-RUN mkdir -p /etc/cni/net.d
-RUN mkdir -p /opt/cni/bin
-
-# Built in ../../go_controller, then the binaries are copied here.
-# put things where they are in the rpm
-RUN mkdir -p /usr/libexec/cni/
-COPY ovn-k8s-overlay ovnkube ovn-kube-util /usr/bin/
-COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
+RUN mkdir -p /var/run/openvswitch && \
+    mkdir -p /etc/cni/net.d && \
+    mkdir -p /opt/cni/bin && \
+    mkdir -p /usr/libexec/cni/ && \
+    cp go-controller/_output/go/bin/ovnkube /usr/bin/ && \
+    cp go-controller/_output/go/bin/ovn-kube-util /usr/bin/ && \
+    cp go-controller/_output/go/bin/ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay && \
+    rm -rf go-controller
 
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
-COPY ovnkube.sh /root/
-COPY ovn-debug.sh /root/
+COPY dist/images/ovnkube.sh /root/
+COPY dist/images/ovn-debug.sh /root/
 # override the rpm's ovn_k8s.conf with this local copy
-COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
-
-# copy git commit number into image
-RUN mkdir -p /root/.git/ /root/.git/refs/heads/
-COPY .git/HEAD /root/.git/HEAD
-COPY .git/refs/heads/ /root/.git/refs/heads/
+COPY dist/images/ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 
 
 LABEL io.k8s.display-name="ovn kubernetes" \

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -44,5 +44,16 @@ COPY ovn-debug.sh /root/
 # override the rpm's ovn_k8s.conf with this local copy
 COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 
+# copy git commit number into image
+RUN mkdir -p /root/.git/ /root/.git/refs/heads/
+COPY .git/HEAD /root/.git/HEAD
+COPY .git/refs/heads/ /root/.git/refs/heads/
+
+
+LABEL io.k8s.display-name="ovn kubernetes" \
+      io.k8s.description="This is a component of OpenShift Container Platform that provides an overlay network using ovn." \
+      io.openshift.tags="openshift" \
+      maintainer="Phil Cameron <pcameron@redhat.com>"
+
 WORKDIR /root
 ENTRYPOINT /root/ovnkube.sh

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -12,13 +12,13 @@
 
 all: bld
 	docker build -t ovn-kube .
-	docker tag ovn-kube netdev31:5000/ovn-kube:latest
-	docker push netdev31:5000/ovn-kube:latest
+	#docker tag ovn-kube my-registry:5000/ovn-kube:latest
+	#docker push my-registry:5000/ovn-kube:latest
 
 fedora: bld
 	docker build -t ovn-kube-f -f Dockerfile.fedora .
-	docker tag ovn-kube-f netdev31:5000/ovn-kube:latest
-	docker push netdev31:5000/ovn-kube:latest
+	#docker tag ovn-kube-f my-registry:5000/ovn-kube:latest
+	#docker push my-registry:5000/ovn-kube:latest
 
 .PHONY: ../../go-controller/_output/go/bin/ovnkube
 
@@ -27,4 +27,7 @@ fedora: bld
 
 bld: ../../go-controller/_output/go/bin/ovnkube
 	cp ../../go-controller/_output/go/bin/* .
+	mkdir -p .git/ .git/refs/heads/
+	cp ../../.git/HEAD .git/HEAD
+	cp ../../.git/refs/heads/* .git/refs/heads/
 

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -35,7 +35,12 @@ ovn_nbdb_test=$(echo ${ovn_nbdb} | sed 's;//;;')
 
 # kubernetes api server configuration
 k8s_api=${K8S_APISERVER:-""}
-k8s_token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+if [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]
+then
+  k8s_token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+else
+  k8s_token=""
+fi
 
 # ovn-northd - /etc/sysconfig/ovn-northd
 ovn_northd_opts=${OVN_NORTHD_OPTS:-"--db-nb-sock=/var/run/openvswitch/ovnnb_db.sock --db-sb-sock=/var/run/openvswitch/ovnsb_db.sock"}
@@ -185,6 +190,12 @@ echo K8S_TOKEN ${k8s_token}
 
 start_ovn () {
   echo " ==================== hostname: ${ovn_host} "
+  if [ -f /root/.git/HEAD ]
+  then
+    head=$(gawk '{ print $2 }' /root/.git/HEAD )
+    commit=$(cat /root/.git/${head})
+    echo "Image built from ovn-kubernetes ref: ${head}  commit: ${commit}"
+  fi
 
   display_env
   setup_cni


### PR DESCRIPTION
ovn-kubernetes/Dockerfile.centos
build the binaries in the Dockerfile

docker build -t ovn-kube .
to build the binaries and the image.

dist/images/Makefile builds the binaries and then the
docker build just includes them in the image.

Copy .git/HEAD and .git/refs/heads into image
Display ref and commit in log

Signed-off-by: Phil Cameron <pcameron@redhat.com>