### PR TITLE
WORKAROUND for network loss problem

### DIFF
--- a/dist/yaml/ovnkube-master.yaml
+++ b/dist/yaml/ovnkube-master.yaml
@@ -67,13 +67,15 @@ spec:
         - mountPath: /var/run/dbus/
           name: host-var-run-dbus
           readOnly: true
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
        #  readOnly: false
         - mountPath: /var/run/kubernetes/
           name: host-var-run-kubernetes
           readOnly: true
-        # We mount our socket here   ---- is this needed PHIL
+        # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
         # CNI related mounts which we take over
@@ -150,6 +152,9 @@ spec:
       - name: host-var-run-dbus
         hostPath:
           path: /var/run/dbus
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
       - name: host-var-run-ovs
         hostPath:
           path: /var/run/openvswitch

--- a/dist/yaml/ovnkube.yaml
+++ b/dist/yaml/ovnkube.yaml
@@ -65,6 +65,8 @@ spec:
         - mountPath: /var/run/dbus/
           name: host-var-run-dbus
           readOnly: true
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
        #  readOnly: false
@@ -146,6 +148,9 @@ spec:
       - name: host-var-run-dbus
         hostPath:
           path: /var/run/dbus
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
       - name: host-var-run-ovs
         hostPath:
           path: /var/run/openvswitch


### PR DESCRIPTION
Ovn adds the HW nic to the ovn bridge. This works as long as
ovn is running.  When docker is restarted or the ovs daemonset
is deleted the traffic continues to go to the bridge which
results in the loss of all network access. The console can
be used to repair the configuration and restore networking.
    
This change is a workaround that avoids placing the nic in the
bridge.  A side effect is that iptables are used.
    
Also, a bind mount can't be deleted in a container.
Changed the go_controller to not try. Deleted files in the
daemonset yaml files.
    
/var/run needs to be mounted.
    
ovnkube.sh now displays the git branch and commit number
when available.


Signed-off-by: Phil Cameron <pcameron@redhat.com>