### PR TITLE
ovnkube: Support gateway name different than node name.

### DIFF
--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -37,6 +37,9 @@ Initialize a gateway in the minion. Only useful with \fB--init-node\fR.
 The interface in minions that will be the gateway interface.  If none
 specified, then the node's interface on which the default gateway is
 configured will be used as the gateway interface. Only useful with
+\fB\--gateway-name\fR string
+The name for the gateway. Should be unique in the cluster. By default,
+uses the node name provided to \fB\--init-node\f.
 \fB\--gateway-spare-interface\fR
 If set, assumes that \fB\--gateway-interface\fR provided can be
 exclusively used for  the OVN gateway.  When specified, only OVN

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -24,6 +24,7 @@ type OvnClusterController struct {
 
 	GatewayInit      bool
 	GatewayIntf      string
+	GatewayName      string
 	GatewayBridge    string
 	GatewayNextHop   string
 	GatewaySpareIntf bool

--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -375,8 +375,14 @@ func (cluster *OvnClusterController) nodePortWatcher() error {
 	return err
 }
 
-func (cluster *OvnClusterController) initGateway(
+// InitGateway setsup OVS bridge for the gateway, initialize the gateway in
+// OVN NB and listen for nodeport events if needed.
+func (cluster *OvnClusterController) InitGateway(
 	nodeName, clusterIPSubnet, subnet string) error {
+	if cluster.GatewayName != "" {
+		nodeName = cluster.GatewayName
+	}
+
 	if cluster.LocalnetGateway {
 		// Create a localnet OVS bridge.
 		localnetBridgeName := "br-localnet"

--- a/go-controller/pkg/cluster/gateway_init_windows.go
+++ b/go-controller/pkg/cluster/gateway_init_windows.go
@@ -2,7 +2,8 @@
 
 package cluster
 
-func (cluster *OvnClusterController) initGateway(
+// InitGateway does nothing for Windows.
+func (cluster *OvnClusterController) InitGateway(
 	nodeName, clusterIPSubnet, subnet string) error {
 	return nil
 }

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -77,7 +77,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		if runtime.GOOS == windowsOS {
 			panic("Windows is not supported as a gateway node")
 		}
-		err = cluster.initGateway(node.Name, cluster.ClusterIPNet.String(),
+		err = cluster.InitGateway(node.Name, cluster.ClusterIPNet.String(),
 			subnet.String())
 		if err != nil {
 			return err
@@ -129,7 +129,7 @@ func (cluster *OvnClusterController) updateOvnNode(masterIP string,
 		if runtime.GOOS == windowsOS {
 			panic("Windows is not supported as a gateway node")
 		}
-		err = cluster.initGateway(node.Name, cluster.ClusterIPNet.String(),
+		err = cluster.InitGateway(node.Name, cluster.ClusterIPNet.String(),
 			subnet)
 		if err != nil {
 			return err


### PR DESCRIPTION
This lets us support multiple gateways on the same node.
(e.g: 2 separate interfaces letting you do 2 gateways).

Signed-off-by: Gurucharan Shetty <guru@ovn.org>