### PR TITLE
cniserver: fail if cniserver socket cannot be removed

### DIFF
--- a/go-controller/pkg/cni/cniserver_linux.go
+++ b/go-controller/pkg/cni/cniserver_linux.go
@@ -24,7 +24,7 @@ func (s *Server) Start(requestFunc cniRequestFunc) error {
 
 	// Remove and re-create the socket directory with root-only permissions
 	if err := os.RemoveAll(s.rundir); err != nil && !os.IsNotExist(err) {
-		utilruntime.HandleError(fmt.Errorf("failed to remove old pod info socket: %v", err))
+		return fmt.Errorf("failed to remove old pod info socket directory: %v", err)
 	}
 	if err := os.MkdirAll(s.rundir, 0700); err != nil {
 		return fmt.Errorf("failed to create pod info socket directory: %v", err)


### PR DESCRIPTION
If for some reason another ovnkube is running and already
bound to the socket, this instance should quit. We need to
remove it and recreate it to (a) ensure this instance
owns it, and (b) that it has the right (root-only) permissions.

Signed-off-by: Dan Williams <dcbw@redhat.com>

@rajatchopra @shettyg @pecameron 