### PR TITLE
dist/*: small daemonset cleanup

### DIFF
--- a/dist/images/ovn_k8s.conf
+++ b/dist/images/ovn_k8s.conf
@@ -11,5 +11,5 @@ conf-dir=/etc/cni/net.d
 plugin=ovn-k8s-cni-overlay
 
 [Kubernetes]
-cacert=/etc/origin/node/client-ca.crt
+cacert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 

--- a/dist/yaml/ovnkube-master.yaml
+++ b/dist/yaml/ovnkube-master.yaml
@@ -11,9 +11,6 @@ spec:
   selector:
     matchLabels:
       name: ovnkube-master
-      # use master nodes - Will likley change
-      # Supports one master at present
-      node-role.kubernetes.io/master: "true"
   updateStrategy:
     type: RollingUpdate
   template:
@@ -23,7 +20,6 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
-        node-role.kubernetes.io/master: "true"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -52,10 +48,6 @@ spec:
           privileged: true
 
         volumeMounts:
-        # Directory which contains the host configuration.
-        - mountPath: /etc/origin/node/
-          name: host-config
-          readOnly: true
         - mountPath: /etc/sysconfig/origin-node
           name: host-sysconfig-node
           readOnly: true
@@ -118,6 +110,10 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         ports:
         - name: healthz
           containerPort: 10256
@@ -135,16 +131,12 @@ spec:
       volumes:
       # In bootstrap mode, the host config contains information not easily available
       # from other locations.
-      - name: host-config
-        hostPath:
-          path: /etc/origin/node
       - name: host-sysconfig-node
         hostPath:
           path: /etc/sysconfig/origin-node
       - name: host-modules
         hostPath:
           path: /lib/modules
-
       # TODO: access to the docker socket should be replaced by CRI socket
       - name: host-var-run
         hostPath:
@@ -164,7 +156,6 @@ spec:
       - name: host-var-run-ovn-kubernetes
         hostPath:
           path: /var/run/ovn-kubernetes
-
       - name: host-opt-cni-bin
         hostPath:
           path: /opt/cni/bin

--- a/dist/yaml/ovnkube.yaml
+++ b/dist/yaml/ovnkube.yaml
@@ -11,8 +11,6 @@ spec:
   selector:
     matchLabels:
       app: ovnkube
-      # use compute nodes - Will likley change
-      node-role.kubernetes.io/compute: "true"
   updateStrategy:
     type: RollingUpdate
   template:
@@ -22,7 +20,6 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
-        node-role.kubernetes.io/compute: "true"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -51,9 +48,6 @@ spec:
 
         volumeMounts:
         # Directory which contains the host configuration.
-        - mountPath: /etc/origin/node/
-          name: host-config
-          readOnly: true
         - mountPath: /etc/sysconfig/origin-node
           name: host-sysconfig-node
           readOnly: true
@@ -114,6 +108,11 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+
         ports:
         - name: healthz
           containerPort: 10256
@@ -126,14 +125,9 @@ spec:
         #     port: 10256
         #     scheme: HTTP
         lifecycle:
-      nodeSelector:
-        node-role.kubernetes.io/compute: "true"
       volumes:
       # In bootstrap mode, the host config contains information not easily available
       # from other locations.
-      - name: host-config
-        hostPath:
-          path: /etc/origin/node
       - name: host-sysconfig-node
         hostPath:
           path: /etc/sysconfig/origin-node

--- a/docs/INSTALL.OPENSHIFT.md
+++ b/docs/INSTALL.OPENSHIFT.md
@@ -189,14 +189,13 @@ data:
   OvnNorth: tcp://10.19.188.22:6641
   OvnSouth: tcp://10.19.188.22:6642
   k8s_apiserver: https://wsfd-netdev22.ntdv.lab.eng.bos.redhat.com:8443
-  k8s_token: eyJhbGciOiJSUzI1NiIsIm ..... XGwBj4FuMgcOlX9rh5h2X5w
   net_cidr: 10.128.0.0/14
   svc_cidr: 172.30.0.0/16
 kind: ConfigMap
 ```
 OvnNorth and OvnSouth are used by ovn to access its daemons. They are host IP address of the daemons.
 
-k8s_apiserver and k8s_token allow access to Openshift's api server.
+k8s_apiserver allows access to Openshift's api server.
 
 net_cidr and svc_cidr are the configuration configuration cidrs
 


### PR DESCRIPTION
- Don't mount /etc/origin (use the k8s-provided secret)
- Fail on missing variables
- Get the nodename from the k8s downward API