### PR TITLE
bind mount problem /var/run/ovn-kubernetes

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -251,7 +251,7 @@ start_ovn () {
 
   # ovn-controller - all nodes
   echo "=============== start ovn-controller"
-  rm -f /var/run/ovn-kubernetes/*
+  rm -f /var/run/ovn-kubernetes/cni/*
   /usr/share/openvswitch/scripts/ovn-ctl --no-monitor start_controller \
     ${ovn_controller_opts}
 #   wait_for_northdb

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -7,7 +7,7 @@ import (
 )
 
 // serverRunDir is the default directory for CNIServer runtime files
-const serverRunDir string = "/var/run/ovn-kubernetes/"
+const serverRunDir string = "/var/run/ovn-kubernetes/cni/"
 
 const serverSocketName string = "ovn-cni-server.sock"
 const serverSocketPath string = serverRunDir + "/" + serverSocketName


### PR DESCRIPTION
In a container /var/run/ovn-kubernetes is created with
permission 0755 (from kubelet). Because of the bind mount
permissions can't be changed. The fix is to create directory
/var/run/ovn-kubernetes with permission 0700 as needed.

Signed-off-by: Phil Cameron <pcameron@redhat.com>