### PR TITLE
Minor cleanups

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -4,6 +4,10 @@
 
 # This script is the entrypoint to the image.
 
+# NOTE: The script/image must be compatible with the daemonset.
+# This script supports version 1 daemonsets
+#      When called, it starts all needed daemons.
+
 # ====================
 # Environment variables are used to customize operation
 #
@@ -20,9 +24,14 @@
 # K8S_CACERT - the apiserver CA. Automatically detected when running in a pod
 # OVN_CONTROLLER_OPTS - the options for ovn-ctl
 # OVN_NORTHD_OPTS - the options for the ovn northbound db
+# OVNKUBE_LOGLEVEL - log level for ovnkube (0..5, default 4)
+
+# The argument to the command is the operation to be performed
+# start_ovn is default, display_env, display, ovn_debug
+cmd=${1:-"start_ovn"}
 
 
-# There is a single image for both master node and compute node
+# There is a single image for both master nodes and compute nodes
 # setup. When OVN_MASTER is true, start the master daemons
 # in addition to the node daemons
 ovn_master=${OVN_MASTER:-"false"}
@@ -53,7 +62,35 @@ ovn_northd_opts=${OVN_NORTHD_OPTS:-"--db-nb-sock=/var/run/openvswitch/ovnnb_db.s
 #OVN_CONTROLLER_OPTS="--ovn-controller-log=-vconsole:emer --vsyslog:err -vfile:info"
 ovn_controller_opts=${OVN_CONTROLLER_OPTS:-"--ovn-controller-log=-vconsole:emer"}
 
+# set the log level for ovnkube
+ovnkube_loglevel=${OVNKUBE_LOGLEVEL:-4}
+
 # =========================================
+
+# ovs must be up before ovn comes up
+# This waits for ovs to come up
+wait_for_ovs () {
+
+  trap 'kill $(jobs -p); exit 0' TERM
+  retries=0
+  while true; do
+    /usr/share/openvswitch/scripts/ovs-ctl status &>/dev/null
+    if [[ $? != 0 ]] ; then
+      (( retries += 1 ))
+      if [[ "${retries}" -gt 40 ]]; then
+        echo "error: ovs did not come up, exiting"
+        exit 1
+      fi
+      echo "info: Waiting for ovs to come up, waiting 10s ..."
+      sleep 10
+    else
+      if [[ "${retries}" != 0 ]]; then
+        echo "ovs came up in ${retries} 10sec tries"
+      fi
+      break
+    fi
+  done
+}
 
 # Master must be up before the nodes can come up.
 # This waits for northd to come up
@@ -67,17 +104,26 @@ wait_for_northdb () {
     # northd is up when this works
     ovn-nbctl --db=${ovn_nbdb_test} show > /dev/null 2>&1
     if [[ $? != 0 ]] ; then
-      echo "info: Waiting for ovn-northd to come up, waiting 10s ..." 2>&1
-      sleep 10
-      (( retries += 1 ))
+      ovn-nbctl show > /dev/null 2>&1
+      if [[ $? != 0 ]] ; then
+        (( retries += 1 ))
+        if [[ "${retries}" -gt 40 ]]; then
+          echo "error: ovn-northd did not come up, exiting"
+          exit 1
+        fi
+        echo "info: Waiting for ovn-northd to come up, waiting 10s ..."
+        sleep 10
+      else
+        if [[ "${retries}" != 0 ]]; then
+          echo "ovn-northd came up in ${retries} 10sec tries"
+        fi
+        break
+      fi
     else
+      if [[ "${retries}" != 0 ]]; then
+        echo "ovn-northd came up in ${retries} 10sec tries"
+      fi
       break
-    fi
-    if [[ "${retries}" -gt 40 ]]; then
-      echo "error: ovn-northd did not come up, exiting" 2>&1
-      exit 1
-    else
-      echo "ovn-northd came up in ${retries} 10sec tries"
     fi
   done
 }
@@ -93,31 +139,37 @@ display () {
     then
       cat /var/run/openvswitch/ovnnb_db.pid
     fi
+    echo " "
     echo "====================== ovnsb_db.pid"
     if [[ -f /var/run/openvswitch/ovnsb_db.pid ]]
     then
       cat /var/run/openvswitch/ovnsb_db.pid
     fi
+    echo " "
     echo "====================== ovs-vswitchd.pid"
     if [[ -f /var/run/openvswitch/ovs-vswitchd.pid ]]
     then
       cat /var/run/openvswitch/ovs-vswitchd.pid
     fi
+    echo " "
     echo "====================== ovsdb-server.pid"
     if [[ -f /var/run/openvswitch/ovsdb-server.pid ]]
     then
       cat /var/run/openvswitch/ovsdb-server.pid
     fi
+    echo " "
     echo "====================== ovsdb-server-nb.log"
     if [[ -f /var/log/openvswitch/ovsdb-server-nb.log ]]
     then
       cat /var/log/openvswitch/ovsdb-server-nb.log
     fi
+    echo " "
     echo "====================== ovsdb-server-sb.log "
     if [[ -f /var/log/openvswitch/ovsdb-server-sb.log ]]
     then
       cat /var/log/openvswitch/ovsdb-server-sb.log
     fi
+    echo " "
     echo "====================== ovn-northd.pid"
     if [[ -f /var/run/openvswitch/ovn-northd.pid ]]
     then
@@ -178,23 +230,16 @@ display () {
 setup_cni () {
   # Take over network functions on the node
   # rm -Rf /etc/cni/net.d/*
-  rm -f /host/opt/cni/bin/ovn-k8s-cni-overlay
   cp -f /usr/libexec/cni/ovn-k8s-cni-overlay /host/opt/cni/bin/ovn-k8s-cni-overlay
-  cp -f /usr/libexec/cni/loopback /host/opt/cni/bin/loopback
+  if [[ ! -f /host/opt/cni/bin/loopback ]]
+  then
+    cp -f /usr/libexec/cni/loopback /host/opt/cni/bin/loopback
+  fi
 }
 
-display_env () {
-# echo OVS_USER_ID ${ovs_user_id}  OVS_OPTIONS ${ovs_options}
-echo OVN_NORTH ${OVN_NORTH}       OVN_NORTHD_OPTS ${ovn_northd_opts}
-echo OVN_SOUTH ${OVN_SOUTH}
-echo OVN_CONTROLLER_OPTS ${ovn_controller_opts}
-echo OVN_NET_CIDR ${OVN_NET_CIDR}
-echo OVN_SVC_CIDR ${OVN_SVC_CIDR}
-echo K8S_APISERVER ${K8S_APISERVER}
-}
-
-start_ovn () {
-  echo " ==================== hostname: ${ovn_host} "
+display_version () {
+  echo "==================== hostname: ${ovn_host} "
+  echo "==================== compatible with version 1 daemonsets"
   if [[ -f /root/.git/HEAD ]]
   then
     commit=$(gawk '{ print $1 }' /root/.git/HEAD )
@@ -208,7 +253,71 @@ start_ovn () {
     fi
     echo "Image built from ovn-kubernetes ref: ${head}  commit: ${commit}"
   fi
+}
 
+display_env () {
+# echo OVS_USER_ID ${ovs_user_id}  OVS_OPTIONS ${ovs_options}
+echo OVN_NORTH ${OVN_NORTH}       OVN_NORTHD_OPTS ${ovn_northd_opts}
+echo OVN_SOUTH ${OVN_SOUTH}
+echo OVN_CONTROLLER_OPTS ${ovn_controller_opts}
+echo OVN_NET_CIDR ${OVN_NET_CIDR}
+echo OVN_SVC_CIDR ${OVN_SVC_CIDR}
+echo K8S_APISERVER ${K8S_APISERVER}
+echo OVNKUBE_LOGLEVEL ${ovnkube_loglevel}
+}
+
+ovn_debug () {
+  # get ovs/ovn info from the node for debug purposes
+  echo "=========== ovn_debug ============="
+  if [[ ${ovn_master} = "true" ]]
+  then
+    echo "=========== MASTER NODE ==========="
+  fi
+  display_version
+  echo " "
+  echo "=========== ovn-nbctl show ============="
+  ovn-nbctl show
+  echo " "
+  ovn_nbdb_test=$(echo ${OVN_NORTH} | sed 's;//;;')
+  echo "=========== ovn-nbctl --db=${ovn_nbdb_test} show ============="
+  ovn-nbctl --db=${ovn_nbdb_test} show
+  echo " "
+  echo "=========== ovn-nbctl list ACL ============="
+  ovn-nbctl list ACL
+  echo " "
+  echo "=========== ovn-nbctl list address_set ============="
+  ovn-nbctl list address_set
+  echo " "
+  echo "=========== ovs-vsctl show ============="
+  ovs-vsctl show
+  echo " "
+  echo "=========== ovs-ofctl -O OpenFlow13 dump-ports br-int ============="
+  ovs-ofctl -O OpenFlow13 dump-ports br-int
+  echo " "
+  echo "=========== ovs-ofctl -O OpenFlow13 dump-ports-desc br-int ============="
+  ovs-ofctl -O OpenFlow13 dump-ports-desc br-int
+  echo " "
+  echo "=========== ovs-ofctl dump-flows br-int ============="
+  ovs-ofctl dump-flows br-int
+  if [[ ${ovn_master} = "true" ]]
+  then
+    echo " "
+    echo "=========== MASTER NODE ==========="
+    echo " "
+    echo "=========== ovn-sbctl lflow-list ============="
+    ovn-sbctl lflow-list
+    echo " "
+    echo "=========== ovn-sbctl list datapath ============="
+    ovn-sbctl list datapath
+    echo " "
+    echo "=========== ovn-sbctl list port ============="
+    ovn-sbctl list port
+  fi
+}
+
+# daemonset version 1 compatibility
+start_ovn () {
+  display_version
   display_env
   setup_cni
 
@@ -225,6 +334,9 @@ start_ovn () {
 #   --ovs-user=${ovs_user_id} \
 #   start ${ovs_options}
 
+  echo "=============== wait for ovs"
+  wait_for_ovs
+
   # on the master only
   if [[ ${ovn_master} = "true" ]]
   then
@@ -232,12 +344,14 @@ start_ovn () {
     mkdir -p /var/lib/openvswitch
     # ovn-northd - master node only
     echo "=============== start ovn-northd ========== MASTER ONLY"
+    echo OVN_NORTH=${OVN_NORTH}  OVN_SOUTH==${OVN_SOUTH} ovn_northd_opts=${ovn_northd_opts}
     /usr/share/openvswitch/scripts/ovn-ctl start_northd \
       --db-nb-addr=${OVN_NORTH} --db-sb-addr=${OVN_SOUTH} \
       ${ovn_northd_opts}
-#   wait_for_northdb
 
     # ovn-master - master node only
+    echo "=============== start ovn-master (wait for northbd) ========== MASTER ONLY"
+    wait_for_northdb
     echo "=============== start ovn-master ========== MASTER ONLY"
     /usr/bin/ovnkube \
       --init-master ${ovn_host} --net-controller \
@@ -245,16 +359,18 @@ start_ovn () {
       --k8s-token=${k8s_token} --k8s-apiserver=${K8S_APISERVER} --k8s-cacert=${K8S_CACERT} \
       --nb-address=${OVN_NORTH} --sb-address=${OVN_SOUTH} \
       --nodeport \
+      --loglevel=${ovnkube_loglevel} \
       --pidfile /var/run/openvswitch/ovnkube-master.pid \
       --logfile /var/log/openvswitch/ovnkube-master.log &
   fi
 
   # ovn-controller - all nodes
+  echo "=============== start ovn-controller (wait for northdb)"
+  wait_for_northdb
   echo "=============== start ovn-controller"
   rm -f /var/run/ovn-kubernetes/cni/*
   /usr/share/openvswitch/scripts/ovn-ctl --no-monitor start_controller \
     ${ovn_controller_opts}
-#   wait_for_northdb
 
   # ovn-node - all nodes
   echo  "=============== start ovn-node"
@@ -268,6 +384,7 @@ start_ovn () {
       --k8s-token=${k8s_token} --k8s-apiserver=${K8S_APISERVER} --k8s-cacert=${K8S_CACERT} \
       --nb-address=${OVN_NORTH} --sb-address=${OVN_SOUTH} \
       --nodeport \
+      --loglevel=${ovnkube_loglevel} \
       --init-gateways --gateway-localnet \
       --pidfile /var/run/openvswitch/ovnkube.pid \
       --logfile /var/log/openvswitch/ovnkube.log &
@@ -275,7 +392,7 @@ start_ovn () {
   echo "=============== done starting daemons ================="
 
 # Let it settle
-  sleep 4
+  sleep 6
 
 # display results
   display
@@ -285,16 +402,39 @@ echo "================== ovnkube.sh ================"
 
 # Start the ovn daemons
 # daemons come up in order
-# ovs-db-server  - all nodes
-# ovs-vswitchd   - all nodes
+# ovs-db-server  - all nodes  -- not done by this script
+# ovs-vswitchd   - all nodes  -- not done by this script
 # ovn-northd     - master node only
 # ovn-master     - master node only
 # ovn-controller - all nodes
 # ovn-node       - all nodes
 
-start_ovn
+  case ${cmd} in
+    "start_ovn")
+	start_ovn
+    ;;
+    "display_env")
+	display_version
+	display_env
+	exit 0
+    ;;
+    "display")
+	display_version
+	display
+	exit 0
+    ;;
+    "ovn_debug")
+	display_version
+	ovn_debug
+	exit 0
+    ;;
+    *)
+	echo "invalid command ${cmd}"
+	exit 0
+    ;;
+  esac
 
 # keep the container alive
-tail -f /dev/null
+while true; do sleep 10; done
 
 exit 0

--- a/dist/yaml/ovnkube-master.yaml
+++ b/dist/yaml/ovnkube-master.yaml
@@ -1,3 +1,8 @@
+# ovnkube-master
+# daemonset version 1
+# This daemonset starts, in a single container,  all on the daemons
+# that need to run on the master node.
+# This supports a single master node.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -38,8 +43,10 @@ spec:
       # ovs flow for ovn (geneve)
       # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
       - name: ovnkube-master
-        # this is development build image
-        image: "netdev31:5000/ovn-kube:latest"
+        # This is an official build
+        image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
+        # This is development build image
+        # image: "quay.io/pecameron/ovn-kube:latest"
         # imagePullPolicy: "Always"
 
         securityContext:
@@ -85,6 +92,8 @@ spec:
         env:
         - name: OVN_MASTER
           value: "true"
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
         - name: OVN_NORTH
           valueFrom:
             configMapKeyRef:

--- a/dist/yaml/ovnkube-master.yaml
+++ b/dist/yaml/ovnkube-master.yaml
@@ -66,6 +66,10 @@ spec:
         - mountPath: /var/run/dbus/
           name: host-var-run-dbus
           readOnly: true
+        # ovn db is stored in the pod in /etc/openvswitch
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
         - mountPath: /var/lib/openvswitch/
           name: host-var-lib-ovs
         - mountPath: /var/run/openvswitch/

--- a/dist/yaml/ovnkube.yaml
+++ b/dist/yaml/ovnkube.yaml
@@ -1,3 +1,7 @@
+# ovnkube
+# daemonset version 1
+# This daemonset starts, in a single container, all on the daemons that
+# need to run on a compute node.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -37,8 +41,10 @@ spec:
       # The network container launches the ovn-k8s-cni-overlay process, the kube-proxy, and the local DNS service.
       # It relies on an up to date node-config.yaml being present.
       - name: ovnkube
-        # this is development build image
-        image: "netdev31:5000/ovn-kube:latest"
+        # This is an official build
+        image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
+        # This is development build image
+        # image: "quay.io/pecameron/ovn-kube:latest"
         # imagePullPolicy: "Always"
 
         securityContext:
@@ -83,6 +89,8 @@ spec:
             cpu: 100m
             memory: 300Mi
         env:
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
         - name: OVN_NORTH
           valueFrom:
             configMapKeyRef:
@@ -125,6 +133,8 @@ spec:
         #     port: 10256
         #     scheme: HTTP
         lifecycle:
+      nodeSelector:
+        node-role.kubernetes.io/compute: "true"
       volumes:
       # In bootstrap mode, the host config contains information not easily available
       # from other locations.


### PR DESCRIPTION
ovn-kubernetes/dist cleanups
- make ovndb persistent
- include official image name
- note requred compatibility between daemonset and image
- wait for deamons to come up before starting additiona daemons
- ovnkube.sh - add display command to dump logs
-                     add display_env to dump environment variables
-                     add ovn_debug comamnd to gather ovn debug information

Signed-off-by: Phil Cameron <pcameron@redhat.com>