### PR TITLE
tests: Adjust the timeout in utility calls.

### DIFF
--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Node Operations", func() {
 			)
 
 			fakeCmds := ovntest.AddFakeCmd(nil, &ovntest.ExpectedCmd{
-				Cmd: "ovs-vsctl --timeout=5 set Open_vSwitch . external_ids:ovn-encap-type=geneve external_ids:ovn-encap-ip=" + nodeName,
+				Cmd: "ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-encap-type=geneve external_ids:ovn-encap-ip=" + nodeName,
 			})
 
 			fexec := &fakeexec.FakeExec{

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -194,25 +194,25 @@ var _ = Describe("Config Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			// k8s-api-server
 			fakeCmds := ovntest.AddFakeCmd(nil, &ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=5 --if-exists get Open_vSwitch . external_ids:k8s-api-server",
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-api-server",
 				Output: "https://somewhere.com:8081",
 			})
 
 			// k8s-api-token
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=5 --if-exists get Open_vSwitch . external_ids:k8s-api-token",
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-api-token",
 				Output: "asadfasdfasrw3atr3r3rf33fasdaa3233",
 			})
 			// k8s-ca-certificate
 			fname, err := createTempFile("kube-cacert.pem")
 			Expect(err).NotTo(HaveOccurred())
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=5 --if-exists get Open_vSwitch . external_ids:k8s-ca-certificate",
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-ca-certificate",
 				Output: fname,
 			})
 			// ovn-nb address
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=5 --if-exists get Open_vSwitch . external_ids:ovn-nb",
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-nb",
 				Output: "tcp:1.1.1.1:6441",
 			})
 
@@ -279,25 +279,25 @@ var _ = Describe("Config Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			// k8s-api-server
 			fakeCmds := ovntest.AddFakeCmd(nil, &ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=5 --if-exists get Open_vSwitch . external_ids:k8s-api-server",
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-api-server",
 				Output: "https://somewhere.com:8081",
 			})
 
 			// k8s-api-token
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=5 --if-exists get Open_vSwitch . external_ids:k8s-api-token",
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-api-token",
 				Output: "asadfasdfasrw3atr3r3rf33fasdaa3233",
 			})
 			// k8s-ca-certificate
 			fname, err := createTempFile("kube-cacert.pem")
 			Expect(err).NotTo(HaveOccurred())
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=5 --if-exists get Open_vSwitch . external_ids:k8s-ca-certificate",
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-ca-certificate",
 				Output: fname,
 			})
 			// ovn-nb address
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=5 --if-exists get Open_vSwitch . external_ids:ovn-nb",
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-nb",
 				Output: "tcp:1.1.1.1:6441,tcp:1.1.1.2:6641,tcp:1.1.1.3:6641",
 			})
 
@@ -819,7 +819,7 @@ server-cacert=/path/to/sb-ca.crt`), 0644)
 				Cmd: fmt.Sprintf("ovn-nbctl --db=%s --timeout=5 --private-key=%s --certificate=%s --bootstrap-ca-cert=%s list nb_global", nbURLOVN, keyFile, certFile, caFile),
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd: fmt.Sprintf("ovs-vsctl --timeout=5 set Open_vSwitch . external_ids:ovn-nb=\"%s\"", nbURLOVN),
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-nb=\"%s\"", nbURLOVN),
 			})
 
 			fexec := &fakeexec.FakeExec{
@@ -894,13 +894,13 @@ server-cacert=/path/to/sb-ca.crt`), 0644)
 				Cmd: fmt.Sprintf("ovn-nbctl --db=%s --timeout=5 --private-key=%s --certificate=%s --bootstrap-ca-cert=%s list nb_global", sbURLOVN, keyFile, certFile, caFile),
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd: "ovs-vsctl --timeout=5 del-ssl",
+				Cmd: "ovs-vsctl --timeout=15 del-ssl",
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd: fmt.Sprintf("ovs-vsctl --timeout=5 set-ssl %s %s %s", keyFile, certFile, caFile),
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set-ssl %s %s %s", keyFile, certFile, caFile),
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd: fmt.Sprintf("ovs-vsctl --timeout=5 set Open_vSwitch . external_ids:ovn-remote=\"%s\"", sbURLOVN),
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-remote=\"%s\"", sbURLOVN),
 			})
 
 			fexec := &fakeexec.FakeExec{

--- a/go-controller/pkg/ovn/management-port_test.go
+++ b/go-controller/pkg/ovn/management-port_test.go
@@ -75,27 +75,27 @@ var _ = Describe("Management Port Operations", func() {
 			)
 
 			fakeCmds := ovntest.AddFakeCmd(nil, &ovntest.ExpectedCmd{
-				Cmd: "ovn-nbctl --timeout=5 --if-exist get logical_router_port rtos-" + nodeName + " mac",
+				Cmd: "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtos-" + nodeName + " mac",
 				// Return a known MAC; otherwise code autogenerates it
 				Output: lrpMAC,
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=5 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
 				Output: clusterRouterUUID,
 			})
 			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
-				"ovn-nbctl --timeout=5 --may-exist lrp-add " + clusterRouterUUID + " rtos-" + nodeName + " " + lrpMAC + " " + gwCIDR,
-				"ovn-nbctl --timeout=5 -- --may-exist ls-add " + nodeName + " -- set logical_switch " + nodeName + " other-config:subnet=" + nodeSubnet + " external-ids:gateway_ip=" + gwCIDR,
-				"ovn-nbctl --timeout=5 -- --may-exist lsp-add " + nodeName + " stor-" + nodeName + " -- set logical_switch_port stor-" + nodeName + " type=router options:router-port=rtos-" + nodeName + " addresses=\"" + lrpMAC + "\"",
-				"ovs-vsctl --timeout=5 -- --may-exist add-br br-int",
-				"ovs-vsctl --timeout=5 -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mgtPort,
+				"ovn-nbctl --timeout=15 --may-exist lrp-add " + clusterRouterUUID + " rtos-" + nodeName + " " + lrpMAC + " " + gwCIDR,
+				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + nodeName + " -- set logical_switch " + nodeName + " other-config:subnet=" + nodeSubnet + " external-ids:gateway_ip=" + gwCIDR,
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " stor-" + nodeName + " -- set logical_switch_port stor-" + nodeName + " type=router options:router-port=rtos-" + nodeName + " addresses=\"" + lrpMAC + "\"",
+				"ovs-vsctl --timeout=15 -- --may-exist add-br br-int",
+				"ovs-vsctl --timeout=15 -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mgtPort,
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=5 --if-exists get interface " + mgtPort + " mac_in_use",
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface " + mgtPort + " mac_in_use",
 				Output: mgtPortMAC,
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd: "ovn-nbctl --timeout=5 -- --may-exist lsp-add " + nodeName + " " + mgtPort + " -- lsp-set-addresses " + mgtPort + " " + mgtPortMAC + " " + mgtPortIP,
+				Cmd: "ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + mgtPort + " -- lsp-set-addresses " + mgtPort + " " + mgtPortMAC + " " + mgtPortIP,
 			})
 			if runtime.GOOS == windowsOS {
 				const ifindex string = "10"
@@ -130,18 +130,18 @@ var _ = Describe("Management Port Operations", func() {
 				})
 			}
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=5 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 				Output: tcpLBUUID,
 			})
 			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
-				"ovn-nbctl --timeout=5 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
+				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=5 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
 				Output: udpLBUUID,
 			})
 			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
-				"ovn-nbctl --timeout=5 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
+				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 			})
 
 			fexec := &fakeexec.FakeExec{


### PR DESCRIPTION
commit b054c98d (Remove Hyper-V as a hard dependency)
increased timeouts for utility calls. But the tests
remained using the old values. The tests can be run
with 'make check test'

Signed-off-by: Gurucharan Shetty <guru@ovn.org>