### PR TITLE
remove unnecessary go-routines around policy watches

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -9,7 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"strings"
-	"sync"
 )
 
 func (oc *Controller) syncNetworkPoliciesPortGroup(
@@ -472,8 +471,6 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 func (oc *Controller) handleLocalPodSelector(
 	policy *knet.NetworkPolicy, np *namespacePolicy) {
 
-	np.stopWg.Add(1)
-
 	id, err := oc.watchFactory.AddFilteredPodHandler(policy.Namespace,
 		&policy.Spec.PodSelector,
 		cache.ResourceEventHandlerFuncs{
@@ -493,16 +490,14 @@ func (oc *Controller) handleLocalPodSelector(
 		return
 	}
 
-	<-np.stop
-	_ = oc.watchFactory.RemovePodHandler(id)
-	np.stopWg.Done()
+	np.podHandlerIDList = append(np.podHandlerIDList, id)
+
 }
 
 func (oc *Controller) handlePeerPodSelector(
 	policy *knet.NetworkPolicy, podSelector *metav1.LabelSelector,
 	addressSet string, addressMap map[string]bool, np *namespacePolicy) {
 
-	np.stopWg.Add(1)
 	id, err := oc.watchFactory.AddFilteredPodHandler(policy.Namespace,
 		podSelector,
 		cache.ResourceEventHandlerFuncs{
@@ -579,9 +574,8 @@ func (oc *Controller) handlePeerPodSelector(
 		return
 	}
 
-	<-np.stop
-	_ = oc.watchFactory.RemovePodHandler(id)
-	np.stopWg.Done()
+	np.podHandlerIDList = append(np.podHandlerIDList, id)
+
 }
 
 func (oc *Controller) handlePeerNamespaceSelectorModify(
@@ -620,7 +614,6 @@ func (oc *Controller) handlePeerNamespaceSelector(
 	namespaceSelector *metav1.LabelSelector,
 	gress *gressPolicy, np *namespacePolicy) {
 
-	np.stopWg.Add(1)
 	id, err := oc.watchFactory.AddFilteredNamespaceHandler("",
 		namespaceSelector,
 		cache.ResourceEventHandlerFuncs{
@@ -662,9 +655,8 @@ func (oc *Controller) handlePeerNamespaceSelector(
 		return
 	}
 
-	<-np.stop
-	_ = oc.watchFactory.RemoveNamespaceHandler(id)
-	np.stopWg.Done()
+	np.nsHandlerIDList = append(np.nsHandlerIDList, id)
+
 }
 
 // AddNetworkPolicy adds network policy and create corresponding acl rules
@@ -689,8 +681,8 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 	np.namespace = policy.Namespace
 	np.ingressPolicies = make([]*gressPolicy, 0)
 	np.egressPolicies = make([]*gressPolicy, 0)
-	np.stop = make(chan bool, 1)
-	np.stopWg = &sync.WaitGroup{}
+	np.podHandlerIDList = make([]uint64, 0)
+	np.nsHandlerIDList = make([]uint64, 0)
 	np.localPods = make(map[string]bool)
 
 	// Create a port group for the policy. All the pods that this policy
@@ -746,14 +738,14 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 			if fromJSON.NamespaceSelector != nil {
 				// For each peer namespace selector, we create a watcher that
 				// populates ingress.peerAddressSets
-				go oc.handlePeerNamespaceSelector(policy,
+				oc.handlePeerNamespaceSelector(policy,
 					fromJSON.NamespaceSelector, ingress, np)
 			}
 
 			if fromJSON.PodSelector != nil {
 				// For each peer pod selector, we create a watcher that
 				// populates the addressSet
-				go oc.handlePeerPodSelector(policy, fromJSON.PodSelector,
+				oc.handlePeerPodSelector(policy, fromJSON.PodSelector,
 					hashedLocalAddressSet, peerPodAddressMap, np)
 			}
 		}
@@ -807,7 +799,7 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 			if toJSON.PodSelector != nil {
 				// For each peer pod selector, we create a watcher that
 				// populates the addressSet
-				go oc.handlePeerPodSelector(policy, toJSON.PodSelector,
+				oc.handlePeerPodSelector(policy, toJSON.PodSelector,
 					hashedLocalAddressSet, peerPodAddressMap, np)
 			}
 		}
@@ -818,7 +810,7 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 
 	// For all the pods in the local namespace that this policy
 	// effects, add them to the port group.
-	go oc.handleLocalPodSelector(policy, np)
+	oc.handleLocalPodSelector(policy, np)
 
 	return
 }
@@ -838,6 +830,7 @@ func (oc *Controller) deleteNetworkPolicyPortGroup(
 	np := oc.namespacePolicies[policy.Namespace][policy.Name]
 
 	np.Lock()
+	defer np.Unlock()
 
 	// Mark the policy as deleted.
 	np.deleted = true
@@ -859,15 +852,8 @@ func (oc *Controller) deleteNetworkPolicyPortGroup(
 		oc.deleteAddressSet(hashedAddressSet)
 	}
 
-	// We should now stop all the go routines.
-	// But, we got to give up on np Lock, so that any pending pod events
-	// can proceed further, and release their own informer lock
-	np.Unlock()
-	close(np.stop)
-	np.stopWg.Wait()
-
-	np.Lock()
-	defer np.Unlock()
+	// We should now stop all the handlers go routines.
+	oc.shutdownHandlers(np)
 
 	for logicalPort := range np.localPods {
 		oc.localPodDelDefaultDeny(policy, logicalPort)

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -12,16 +12,16 @@ import (
 
 type namespacePolicy struct {
 	sync.Mutex
-	name            string
-	namespace       string
-	ingressPolicies []*gressPolicy
-	egressPolicies  []*gressPolicy
-	stop            chan bool
-	stopWg          *sync.WaitGroup
-	localPods       map[string]bool //pods effected by this policy
-	portGroupUUID   string          //uuid for OVN port_group
-	portGroupName   string
-	deleted         bool //deleted policy
+	name             string
+	namespace        string
+	ingressPolicies  []*gressPolicy
+	egressPolicies   []*gressPolicy
+	podHandlerIDList []uint64
+	nsHandlerIDList  []uint64
+	localPods        map[string]bool //pods effected by this policy
+	portGroupUUID    string          //uuid for OVN port_group
+	portGroupName    string
+	deleted          bool //deleted policy
 }
 
 type gressPolicy struct {
@@ -252,4 +252,13 @@ func (oc *Controller) deleteNetworkPolicy(
 		oc.deleteNetworkPolicyOld(policy)
 	}
 
+}
+
+func (oc *Controller) shutdownHandlers(np *namespacePolicy) {
+	for _, id := range np.podHandlerIDList {
+		_ = oc.watchFactory.RemovePodHandler(id)
+	}
+	for _, id := range np.nsHandlerIDList {
+		_ = oc.watchFactory.RemoveNamespaceHandler(id)
+	}
 }


### PR DESCRIPTION
With the addition of federated watch handlers, there are unnecessary go routines in the policy flow.
All we do with spinning a new go-routine for watching local peer pods for policy is 'add' the handlers and then wait for network policy to be removed so that we can 'remove' the handlers. We don't need go-routines for that.
This will be immensely helpful when we have 20k namespaces isolated from each other by at least as many NetworkPolicy objects.

This is a rebased version of https://github.com/openvswitch/ovn-kubernetes/pull/311