### PR TITLE
config: Modify inactivity-probe for DB server and client.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -48,6 +48,20 @@ for the conntrack flow rules.
 conntrack-zone=64000
 ```
 
+The following option only affects ovn-controller. This is the maximum number
+of milliseconds of idle time on connection to the server before sending an
+inactivity probe message.  As a client connects to the server over TCP, it
+may take a while for the kernel to figure out if the connection is
+broken.  But the client can overcome this by periodically sending probes over
+the TCP connection to make sure that the connection is up.  On the flip side,
+when there are hundreds of nodes, the server can get bogged down by client
+probe messages.
+
+The default value is set as 100000ms. But can be changed with this config
+option
+
+inactivity-probe=600000
+
 ### [logging] section
 
 The following config values control what verbosity level logging is written at

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -71,6 +71,8 @@ func setOVSExternalIDs(nodeName string, ids ...string) error {
 		".",
 		fmt.Sprintf("external_ids:ovn-encap-type=%s", config.Default.EncapType),
 		fmt.Sprintf("external_ids:ovn-encap-ip=%s", nodeIP),
+		fmt.Sprintf("external_ids:ovn-remote-probe-interval=%d",
+			config.Default.InactivityProbe),
 	}
 	for _, str := range ids {
 		args = append(args, "external_ids:"+str)

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -65,10 +65,15 @@ var _ = Describe("Node Operations", func() {
 				nodeName  string = "1.2.5.6"
 				apiserver string = "https://1.2.3.4:8080"
 				token     string = "adsfadsfasdfasdfasfaf"
+				interval  int    = 100000
 			)
 
 			fakeCmds := ovntest.AddFakeCmd(nil, &ovntest.ExpectedCmd{
-				Cmd: "ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-encap-type=geneve external_ids:ovn-encap-ip=" + nodeName,
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+					"external_ids:ovn-encap-type=geneve "+
+					"external_ids:ovn-encap-ip=%s "+
+					"external_ids:ovn-remote-probe-interval=%d",
+					nodeName, interval),
 			})
 
 			fexec := &fakeexec.FakeExec{

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -774,7 +774,7 @@ server-cacert=/path/to/sb-ca.crt`), 0644)
 
 		It("configures server northbound SSL correctly", func() {
 			fakeCmds := ovntest.AddFakeCmd(nil, &ovntest.ExpectedCmd{
-				Cmd: "ovn-nbctl set-connection pssl:6641",
+				Cmd: "ovn-nbctl set-connection pssl:6641 -- set connection . inactivity_probe=0",
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 				Cmd: "ovn-nbctl del-ssl",
@@ -849,7 +849,7 @@ server-cacert=/path/to/sb-ca.crt`), 0644)
 
 		It("configures server southbound SSL correctly", func() {
 			fakeCmds := ovntest.AddFakeCmd(nil, &ovntest.ExpectedCmd{
-				Cmd: "ovn-sbctl set-connection pssl:6642",
+				Cmd: "ovn-sbctl set-connection pssl:6642 -- set connection . inactivity_probe=0",
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 				Cmd: "ovn-sbctl del-ssl",


### PR DESCRIPTION
OVN DB has a connection table where we currently define the
port number to listen on for the OVN DB servers.  By default,
every 5 seconds or so, OVN DB server sends a inactivity probe
to test whether the client is still connected.  When there
are hundreds of clients, the server may spend a lot of time
maintaining these inactivity probes and as a result consume
a lot of CPU. It does not make sense for the server to do
this job. It should be the client that tries to maintain
the connection. And if the connection is down, the client
should restart it.

So this commit disables the inactivity_probe for the server
by setting it as zero.

For the clients (ovn-controller in our case), we provide the
option for the user to set it. Shorter time would mean that
a lot of inactivity probes could be sent by al the clients
to the server. A very long time means that events may
not get propogated to the clients soon enough.  This commit
sets the default value as 1 minute. And a user can change it
if he prefers.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>