### PR TITLE
[4.0]Refactor ovnkube.sh and daemonset files

### DIFF
--- a/dist/yaml/ovnkube-master.yaml
+++ b/dist/yaml/ovnkube-master.yaml
@@ -1,8 +1,7 @@
 # ovnkube-master
-# daemonset version 1
-# This daemonset starts, in a single container,  all on the daemons
-# that need to run on the master node.
-# This supports a single master node.
+# daemonset version 2
+# starts master daemons, each in a separate container
+# it is run on the master node(s)
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -25,6 +24,7 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
+        beta.kubernetes.io/os: "linux"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -42,6 +42,109 @@ spec:
       # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
       # ovs flow for ovn (geneve)
       # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
+      - name: ovn-northd
+        # This is the community build
+        image: "docker.io/ovnkube/ovn-daemonset:latest"
+        # This is an official redhat build
+        # image: "registry.access.redhat.com/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is an official (internal) redhat build
+        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is development build image
+        # image: "quay.io/pecameron/ovn-kube:latest"
+        # imagePullPolicy: "Always"
+
+        command: ["/root/ovnkube.sh", "ovn-northd"]
+
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        - mountPath: /etc/sysconfig/origin-node
+          name: host-sysconfig-node
+          readOnly: true
+        # Mount the entire run directory for socket access for Docker or CRI-o
+        # TODO: remove
+        - mountPath: /var/run
+          name: host-var-run
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        # ovn db is stored in the pod in /etc/openvswitch
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+       #  readOnly: false
+        - mountPath: /var/run/kubernetes/
+          name: host-var-run-kubernetes
+          readOnly: true
+        # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /host/opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-ovn-kubernetes
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_MASTER
+          value: "true"
+        - name: OVN_NORTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnNorth
+        - name: OVN_SOUTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnSouth
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - name: healthz
+          containerPort: 10257
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10257
+        #     scheme: HTTP
+        lifecycle:
+      # end of container
+
       - name: ovnkube-master
         # This is the community build
         image: "docker.io/ovnkube/ovn-daemonset:latest"
@@ -54,6 +157,8 @@ spec:
         # This is development build image
         # image: "quay.io/pecameron/ovn-kube:latest"
         # imagePullPolicy: "Always"
+
+        command: ["/root/ovnkube.sh", "ovn-master"]
 
         securityContext:
           runAsUser: 0
@@ -145,6 +250,8 @@ spec:
         #     port: 10256
         #     scheme: HTTP
         lifecycle:
+      # end of container
+
       nodeSelector:
         node-role.kubernetes.io/master: "true"
         beta.kubernetes.io/os: "linux"

--- a/dist/yaml/ovnkube.yaml
+++ b/dist/yaml/ovnkube.yaml
@@ -1,7 +1,7 @@
 # ovnkube
-# daemonset version 1
-# This daemonset starts, in a single container, all on the daemons that
-# need to run on a compute node.
+# daemonset version 2
+# starts node daemons for ovs and ovn, each in a separate container
+# it is run on all nodes
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -24,6 +24,7 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
+        beta.kubernetes.io/os: "linux"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -33,6 +34,50 @@ spec:
       hostNetwork: true
       hostPID: true
       containers:
+
+      # ovsdb-server and ovs-switchd daemons
+      - name: ovs-daemons
+        # This is the community image:
+        image: "docker.io/ovnkube/ovn-daemonset:latest"
+        # This is an official build
+        # image: "registry.access.redhat.com/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is an official (internal) redhat build
+        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is an official image on aws
+        # image: "registry.reg-aws.openshift.com:443/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is development build image
+        # image: "quay.io/pecameron/ovn-kube:latest"
+        # imagePullPolicy: "Always"
+
+        command: ["/root/ovnkube.sh", "ovs-server"]
+
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: host-modules
+          readOnly: true
+        - mountPath: /run/openvswitch
+          name: host-run-ovs
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-ovs
+        - mountPath: /sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /etc/openvswitch
+          name: host-config-openvswitch
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 200m
+            memory: 400Mi
+
+
       # firewall rules for ovn - assumed to be setup
       # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
       # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
@@ -40,8 +85,8 @@ spec:
       # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
       # The network container launches the ovn-k8s-cni-overlay process, the kube-proxy, and the local DNS service.
       # It relies on an up to date node-config.yaml being present.
-      - name: ovnkube
-        # This is the community build
+      - name: ovn-controller
+        # This is the community image:
         image: "docker.io/ovnkube/ovn-daemonset:latest"
         # This is an official redhat build
         # image: "registry.access.redhat.com/openshift3/ose-ovn-kubernetes:v3.11"
@@ -52,6 +97,8 @@ spec:
         # This is development build image
         # image: "quay.io/pecameron/ovn-kube:latest"
         # imagePullPolicy: "Always"
+
+        command: ["/root/ovnkube.sh", "ovn-controller"]
 
         securityContext:
           runAsUser: 0
@@ -129,7 +176,7 @@ spec:
 
         ports:
         - name: healthz
-          containerPort: 10256
+          containerPort: 10258
         # TODO: Temporarily disabled until we determine how to wait for clean default
         # config
         # livenessProbe:
@@ -139,8 +186,110 @@ spec:
         #     port: 10256
         #     scheme: HTTP
         lifecycle:
+
+      - name: ovn-node
+        # This is the community image:
+        image: "docker.io/ovnkube/ovn-daemonset:latest"
+        # This is an official build
+        # image: "registry.access.redhat.com/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is an official (internal) redhat build
+        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is an official image on aws
+        # image: "registry.reg-aws.openshift.com:443/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is development build image
+        # image: "quay.io/pecameron/ovn-kube:latest"
+        # imagePullPolicy: "Always"
+
+        command: ["/root/ovnkube.sh", "ovn-node"]
+
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        # Directory which contains the host configuration.
+        - mountPath: /etc/sysconfig/origin-node
+          name: host-sysconfig-node
+          readOnly: true
+        # Mount the entire run directory for socket access for Docker or CRI-o
+        # TODO: remove
+        - mountPath: /var/run
+          name: host-var-run
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+       #  readOnly: false
+        - mountPath: /var/run/kubernetes/
+          name: host-var-run-kubernetes
+          readOnly: true
+        # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /host/opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-ovn-kubernetes
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVNKUBE_LOGLEVEL
+          value: "5"
+        - name: OVN_NORTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnNorth
+        - name: OVN_SOUTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnSouth
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+
+        ports:
+        - name: healthz
+          containerPort: 10259
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10256
+        #     scheme: HTTP
+        lifecycle:
+
       nodeSelector:
-        node-role.kubernetes.io/compute: "true"
         beta.kubernetes.io/os: "linux"
       volumes:
       # In bootstrap mode, the host config contains information not easily available
@@ -162,6 +311,9 @@ spec:
       - name: host-var-lib-ovs
         hostPath:
           path: /var/lib/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
       - name: host-var-run-ovs
         hostPath:
           path: /var/run/openvswitch
@@ -171,6 +323,9 @@ spec:
       - name: host-var-run-ovn-kubernetes
         hostPath:
           path: /var/run/ovn-kubernetes
+      - name: host-sys
+        hostPath:
+          path: /sys
 
       - name: host-opt-cni-bin
         hostPath:
@@ -178,6 +333,9 @@ spec:
       - name: host-etc-cni-netd
         hostPath:
           path: /etc/cni/net.d
+      - name: host-config-openvswitch
+        hostPath:
+          path: /etc/origin/openvswitch
       - name: host-var-lib-cni-networks-ovn-kubernetes
         hostPath:
           path: /var/lib/cni/networks/ovn-k8s-cni-overlay

--- a/dist/yaml/sdn-ovs.yaml
+++ b/dist/yaml/sdn-ovs.yaml
@@ -1,3 +1,8 @@
+# ovs-ovn
+# daemonset version 1
+# This daemonset starts, in a single container, all of the needed
+# ovs daemons. It does not use the ovnkube.sh startup script in the image.
+# It is run on every node in the cluster.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:


### PR DESCRIPTION
Daemonset version 1 runs all daemons in a single container.
Further there is a daemonset for master and a separate daemonset
that runs on all nodes except master.

Version 2 daemonsets run each daemon in its own container.
The master daemonset runs only master daemons. The node daemonset
runs only node daemons. Both master and node daemonsets run on the
master and only node daemonsets run on the other nodes.

The ovnkube.sh script now supports both version 1 daemonsets
and version 2 daemonsets. The script has additional commands
that display the container logs, container environment variables
and ovn/ovs debug information.

SDN-110 - [ovn] split master and node-level daemonsets
https://jira.coreos.com/browse/SDN-110

Signed-off-by: Phil Cameron <pcameron@redhat.com>