### PR TITLE
ansible: Add minion hostnames in master hosts file

### DIFF
--- a/contrib/ovn-kubernetes-cluster.yml
+++ b/contrib/ovn-kubernetes-cluster.yml
@@ -43,6 +43,13 @@
         name: linux/ovn-kubernetes
     - import_role:
         name: linux/kubernetes
+    - name: Ensure /etc/hosts is updated on kube-master
+      lineinfile:
+        path: /etc/hosts
+        regexp: '{{ansible_hostname}}$'
+        line: '{{host_public_ip}} {{ansible_hostname}}'
+      delegate_to: "{{ item }}"
+      with_items: "{{groups['kube-master']}}"
 
 - hosts: kube-minions-windows
   remote_user: Administrator
@@ -76,3 +83,12 @@
         name: windows/ovn-kubernetes
     - import_role:
         name: windows/kubernetes
+    - name: Ensure /etc/hosts is updated on kube-master
+      become: true
+      become_method: sudo
+      lineinfile:
+        path: /etc/hosts
+        regexp: '{{ansible_hostname}}$'
+        line: '{{host_public_ip}} {{ansible_hostname}}'
+      delegate_to: "{{ item }}"
+      with_items: "{{groups['kube-master']}}"


### PR DESCRIPTION
The ansible playbook does not add minion hostnames inside
the /etc/hosts file on the master. As a result, the kubectl exec
command does not work since the master node cannot resolve the
minion hostname to connect to the pod.

This patch fixes this by adding the hostnames of the minion
in the master /etc/hosts file.

Example of kubectl commands working afterwards:
```
root@k8s-master:~# kubectl exec nano-1803 cmd /c dir
Defaulting container name to nano.
Use 'kubectl describe pod/nano-1803 -n default' to see all of the containers in this pod.
 Volume in drive C has no label.
 Volume Serial Number is 0C99-B7C6

 Directory of C:\

04/11/2018  04:53 PM             1,894 License.txt
07/07/2018  03:36 PM    <DIR>          Users
08/21/2018  09:42 AM    <DIR>          var
08/21/2018  09:42 AM    <DIR>          Windows
               1 File(s)          1,894 bytes
               3 Dir(s)  21,296,275,456 bytes free
root@k8s-master:~# kubectl exec alpine date
Tue Aug 21 17:00:32 UTC 2018
root@k8s-master:~# kubectl logs nano-1803 nano2
Web Server started. Listening on 0.0.0.0:80
```

Partially fixes issue: #410 

Signed-off-by: Alin Balutoiu <alinbalutoiu@gmail.com>