### PR TITLE
[WIP]factory: Serialize callbacks for k8s events.

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"reflect"
-	"sync"
 )
 
 // Controller structure is the object which holds the controls for starting
@@ -56,9 +55,6 @@ type Controller struct {
 	// to add a egress deny rule.
 	lspEgressDenyCache map[string]int
 
-	// A mutex for lspIngressDenyCache and lspEgressDenyCache
-	lspMutex *sync.Mutex
-
 	// supports port_group?
 	portGroupSupport bool
 }
@@ -84,7 +80,6 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory,
 		namespacePolicies:        make(map[string]map[string]*namespacePolicy),
 		lspIngressDenyCache:      make(map[string]int),
 		lspEgressDenyCache:       make(map[string]int),
-		lspMutex:                 &sync.Mutex{},
 		gatewayCache:             make(map[string]string),
 		loadbalancerClusterCache: make(map[string]string),
 		nodePortEnable:           nodePortEnable,

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -39,9 +39,6 @@ type Controller struct {
 	// address in that namespace
 	namespaceAddressSet map[string]map[string]bool
 
-	// For each namespace, a lock to protect critical regions
-	namespaceMutex map[string]*sync.Mutex
-
 	// For each namespace, a map of policy name to 'namespacePolicy'.
 	namespacePolicies map[string]map[string]*namespacePolicy
 
@@ -85,7 +82,6 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory,
 		logicalPortUUIDCache:     make(map[string]string),
 		namespaceAddressSet:      make(map[string]map[string]bool),
 		namespacePolicies:        make(map[string]map[string]*namespacePolicy),
-		namespaceMutex:           make(map[string]*sync.Mutex),
 		lspIngressDenyCache:      make(map[string]int),
 		lspEgressDenyCache:       make(map[string]int),
 		lspMutex:                 &sync.Mutex{},

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -162,11 +162,9 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 
 	delete(oc.logicalPortCache, logicalPort)
 
-	oc.lspMutex.Lock()
 	delete(oc.lspIngressDenyCache, logicalPort)
 	delete(oc.lspEgressDenyCache, logicalPort)
 	delete(oc.logicalPortUUIDCache, logicalPort)
-	oc.lspMutex.Unlock()
 
 	if !oc.portGroupSupport {
 		oc.deleteACLDenyOld(pod.Namespace, pod.Spec.NodeName, logicalPort,

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -319,9 +319,6 @@ func (oc *Controller) createDefaultDenyPortGroup(policyType knet.PolicyType) {
 func (oc *Controller) localPodAddDefaultDeny(
 	policy *knet.NetworkPolicy, logicalPort string) {
 
-	oc.lspMutex.Lock()
-	defer oc.lspMutex.Unlock()
-
 	oc.createDefaultDenyPortGroup(knet.PolicyTypeIngress)
 	oc.createDefaultDenyPortGroup(knet.PolicyTypeEgress)
 
@@ -356,8 +353,6 @@ func (oc *Controller) localPodAddDefaultDeny(
 
 func (oc *Controller) localPodDelDefaultDeny(
 	policy *knet.NetworkPolicy, logicalPort string) {
-	oc.lspMutex.Lock()
-	defer oc.lspMutex.Unlock()
 
 	if !(len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) {
 		if oc.lspIngressDenyCache[logicalPort] > 0 {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -396,9 +396,6 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(
 		return
 	}
 
-	np.Lock()
-	defer np.Unlock()
-
 	if np.deleted {
 		return
 	}
@@ -437,9 +434,6 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 	// Get the logical port name.
 	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
 	logicalPortUUID := oc.getLogicalPortUUID(logicalPort)
-
-	np.Lock()
-	defer np.Unlock()
 
 	if np.deleted {
 		return
@@ -503,8 +497,6 @@ func (oc *Controller) handlePeerPodSelector(
 					return
 				}
 
-				np.Lock()
-				defer np.Unlock()
 				if np.deleted {
 					return
 				}
@@ -524,8 +516,6 @@ func (oc *Controller) handlePeerPodSelector(
 					return
 				}
 
-				np.Lock()
-				defer np.Unlock()
 				if np.deleted {
 					return
 				}
@@ -549,8 +539,6 @@ func (oc *Controller) handlePeerPodSelector(
 					return
 				}
 
-				np.Lock()
-				defer np.Unlock()
 				if np.deleted {
 					return
 				}
@@ -614,8 +602,6 @@ func (oc *Controller) handlePeerNamespaceSelector(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				namespace := obj.(*kapi.Namespace)
-				np.Lock()
-				defer np.Unlock()
 				if np.deleted {
 					return
 				}
@@ -628,8 +614,6 @@ func (oc *Controller) handlePeerNamespaceSelector(
 			},
 			DeleteFunc: func(obj interface{}) {
 				namespace := obj.(*kapi.Namespace)
-				np.Lock()
-				defer np.Unlock()
 				if np.deleted {
 					return
 				}
@@ -823,9 +807,6 @@ func (oc *Controller) deleteNetworkPolicyPortGroup(
 		return
 	}
 	np := oc.namespacePolicies[policy.Namespace][policy.Name]
-
-	np.Lock()
-	defer np.Unlock()
 
 	// Mark the policy as deleted.
 	np.deleted = true

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -464,7 +464,6 @@ func (oc *Controller) localPodAddDefaultDenyOld(
 	policy *knet.NetworkPolicy,
 	logicalPort, logicalSwitch string) {
 
-	oc.lspMutex.Lock()
 	// Default deny rule.
 	// 1. Any pod that matches a network policy should get a default
 	// ingress deny rule.  This is irrespective of whether there
@@ -494,13 +493,11 @@ func (oc *Controller) localPodAddDefaultDenyOld(
 		}
 		oc.lspEgressDenyCache[logicalPort]++
 	}
-	oc.lspMutex.Unlock()
 }
 
 func (oc *Controller) localPodDelDefaultDenyOld(
 	policy *knet.NetworkPolicy,
 	logicalPort, logicalSwitch string) {
-	oc.lspMutex.Lock()
 
 	if !(len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) {
 		if oc.lspIngressDenyCache[logicalPort] > 0 {
@@ -522,7 +519,6 @@ func (oc *Controller) localPodDelDefaultDenyOld(
 			}
 		}
 	}
-	oc.lspMutex.Unlock()
 }
 
 func (oc *Controller) handleLocalPodSelectorAddFuncOld(

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -539,9 +539,6 @@ func (oc *Controller) handleLocalPodSelectorAddFuncOld(
 	// Get the logical port name.
 	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
 
-	np.Lock()
-	defer np.Unlock()
-
 	if np.deleted {
 		return
 	}
@@ -576,9 +573,6 @@ func (oc *Controller) handleLocalPodSelectorDelFuncOld(
 
 	// Get the logical port name.
 	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
-
-	np.Lock()
-	defer np.Unlock()
 
 	if np.deleted {
 		return
@@ -640,8 +634,6 @@ func (oc *Controller) handlePeerPodSelectorOld(
 					return
 				}
 
-				np.Lock()
-				defer np.Unlock()
 				if np.deleted {
 					return
 				}
@@ -661,8 +653,6 @@ func (oc *Controller) handlePeerPodSelectorOld(
 					return
 				}
 
-				np.Lock()
-				defer np.Unlock()
 				if np.deleted {
 					return
 				}
@@ -686,8 +676,6 @@ func (oc *Controller) handlePeerPodSelectorOld(
 					return
 				}
 
-				np.Lock()
-				defer np.Unlock()
 				if np.deleted {
 					return
 				}
@@ -753,8 +741,6 @@ func (oc *Controller) handlePeerNamespaceSelectorOld(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				namespace := obj.(*kapi.Namespace)
-				np.Lock()
-				defer np.Unlock()
 				if np.deleted {
 					return
 				}
@@ -767,8 +753,6 @@ func (oc *Controller) handlePeerNamespaceSelectorOld(
 			},
 			DeleteFunc: func(obj interface{}) {
 				namespace := obj.(*kapi.Namespace)
-				np.Lock()
-				defer np.Unlock()
 				if np.deleted {
 					return
 				}
@@ -960,9 +944,6 @@ func (oc *Controller) deleteNetworkPolicyOld(
 		return
 	}
 	np := oc.namespacePolicies[policy.Namespace][policy.Name]
-
-	np.Lock()
-	defer np.Unlock()
 
 	// Mark the policy as deleted.
 	np.deleted = true


### PR DESCRIPTION
For integration with OVSDB golang bindings, it
makes sense to not have parallel threads trying
to access the database at the same time.

This is an attempt to serialize all events coming
from kubernetes.  This also lets us get rid of
locks and any other race conditions that we
may have in code.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>