### PR TITLE
Ovn-kube community container image

### DIFF
--- a/README.daemonset.md
+++ b/README.daemonset.md
@@ -1,0 +1,38 @@
+# Community Container Image
+
+From time to time the maintainers build and push an image to
+```
+docker.io/ovnkube/ovn-daemonset
+```
+The image may be a release version, or latest which is a stable
+usable image reflecting work in progress. The daemonsets in dist/yaml
+default to this image:
+```
+docker.io/ovnkube/ovn-daemonset:latest
+```
+
+When the imgage is started in the daemonset the log displays the
+git commit number of the build.
+
+```
+# kubectl logs ovnkube-master-klpnm -c ovn-northd
+==================== compatible with version 1  and version 2 daemonsets
+Image built from ovn-kubernetes ref: refs/heads/ovn-containers  commit: 8468bacb56f2ca213d044dcb2b27ddee4851cdaa
+```
+
+## Building the Container Image
+
+The community ovn container image is built as follows
+
+```
+# cd ovn-kubernetes
+
+# docker login -u ovnkube docker.io
+Password:
+Login Succeeded
+
+# docker build -f Dockerfile.centos -t ovn-daemonset .
+# docker tag  ovn-daemonset docker.io/ovnkube/ovn-daemonset:latest
+# docker push docker.io/ovnkube/ovn-daemonset:latest
+```
+

--- a/dist/READMEopenshiftdevpreview.md
+++ b/dist/READMEopenshiftdevpreview.md
@@ -107,8 +107,8 @@ At this point ovn is providing networking for the cluster.
 
 There is a single docker image that is used in all of the ovn daemonsets.
 All daemonset yaml files must be edited to reference the same desired image.
-The images can be found in the official OKD repositories or they can be
-built in the openvswitch/ovn-kubernetes git repo.
+The images can be found in docker.io, the official OKD repositories or
+they can be built in the openvswitch/ovn-kubernetes git repo.
 
 The OKD image is built in the openshift/ose-ovn-kubernetes repo from rhel:7
 with openvswitch from the fastdatapath repo.
@@ -126,10 +126,12 @@ The OKD 3.11 image name includes the build tag:
 openshift3/ose-ovn-kubernetes:v3.11.0-123483
 ```
 
-NOTE:
-- A prebuilt community version of the image is not currently available.  The
-daemonset yaml files point to the OKD image above. You may have to change the
-image name.
+The community image based on current development is:
+```
+docker.io/ovnkube/ovn-daemonset:latest
+```
+The daemonset yaml files reference the community image.
+
 
 Alternatively, the image can be built from the ovn-kubernetes repo.
 When doing this edit the Makefile to itag and push the image to your existing
@@ -159,7 +161,3 @@ can be deleted and recreated.
 # oc create -f ovnkube-master.yaml
 # oc create -f ovnkube.yaml
 ```
-
-NOTE:
-- Never delete the ovs-ovn daemonset.
-

--- a/dist/yaml/ovnkube-master.yaml
+++ b/dist/yaml/ovnkube-master.yaml
@@ -43,8 +43,10 @@ spec:
       # ovs flow for ovn (geneve)
       # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
       - name: ovnkube-master
-        # This is an official build
-        image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
+        # This is the community build
+        image: "docker.io/ovnkube/ovn-daemonset:latest"
+        # This is an official redhat build
+        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
         # This is development build image
         # image: "quay.io/pecameron/ovn-kube:latest"
         # imagePullPolicy: "Always"

--- a/dist/yaml/ovnkube.yaml
+++ b/dist/yaml/ovnkube.yaml
@@ -41,8 +41,10 @@ spec:
       # The network container launches the ovn-k8s-cni-overlay process, the kube-proxy, and the local DNS service.
       # It relies on an up to date node-config.yaml being present.
       - name: ovnkube
-        # This is an official build
-        image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
+        # This is the community build
+        image: "docker.io/ovnkube/ovn-daemonset:latest"
+        # This is an official redhat build
+        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
         # This is development build image
         # image: "quay.io/pecameron/ovn-kube:latest"
         # imagePullPolicy: "Always"

--- a/dist/yaml/sdn-ovs.yaml
+++ b/dist/yaml/sdn-ovs.yaml
@@ -29,8 +29,14 @@ spec:
       hostPID: true
       containers:
       - name: openvswitch
-        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.12.0"
-        image: "netdev31:5000/ovn-kube:latest"
+        # This is the community build
+        image: "docker.io/ovnkube/ovn-daemonset:latest"
+        # This is an official redhat build
+        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
+        # This is development build image
+        # image: "quay.io/pecameron/ovn-kube:latest"
+        # imagePullPolicy: "Always"
+
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
There is a useable build of the ovn image in
docker.io/ovnkube/ovn-daemonset:latest
The image is updated as described in README.docker.md

The daemonset yaml files are updated to reference this image.

Signed-off-by: Phil Cameron <pcameron@redhat.com>