### PR TITLE
Add os.kubernetes.io='linux' label to daemonsets

### DIFF
--- a/dist/yaml/ovnkube-master.yaml
+++ b/dist/yaml/ovnkube-master.yaml
@@ -25,6 +25,7 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
+        beta.kubernetes.io/os: "linux"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -143,6 +144,7 @@ spec:
         lifecycle:
       nodeSelector:
         node-role.kubernetes.io/master: "true"
+        beta.kubernetes.io/os: "linux"
       volumes:
       # In bootstrap mode, the host config contains information not easily available
       # from other locations.

--- a/dist/yaml/ovnkube.yaml
+++ b/dist/yaml/ovnkube.yaml
@@ -24,6 +24,7 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
+        beta.kubernetes.io/os: "linux"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -137,6 +138,7 @@ spec:
         lifecycle:
       nodeSelector:
         node-role.kubernetes.io/compute: "true"
+        beta.kubernetes.io/os: "linux"
       volumes:
       # In bootstrap mode, the host config contains information not easily available
       # from other locations.


### PR DESCRIPTION
The windows/linux integration will have daemonsets on
both linux and windows. Label the linux daemonsets to run
only on linux.

Signed-off-by: Phil Cameron <pcameron@redhat.com>