### PR TITLE
add parameter -t for host cmd to get the correct host_ip

### DIFF
--- a/dist/ansible/scripts/ovn-setup.sh
+++ b/dist/ansible/scripts/ovn-setup.sh
@@ -29,7 +29,7 @@ net_cidr=10.128.0.0/14
 svc_cidr=172.30.0.0/16
 
 # get the ovn master's ip address
-host_ip=$(host $(hostname) | gawk '{ print $4 }' )
+host_ip=$(host -t A $(hostname) | gawk '{ print $4 }' )
 
 # Currently using tcp, may move to ssl
 OvnNorth="tcp://${host_ip}:6641"


### PR DESCRIPTION
By default, the `host` cmd will search for the A, AAAA, and MX records in order.

This may result problem sometimes. 

Like below:
```
+++ hostname
++ host networking-master.cluster.local
+ host_ip='10.66.144.161
out;
out;'
+ OvnNorth='tcp://10.66.144.161
out;
out;:6641'
+ OvnSouth='tcp://10.66.144.161
out;
out;:6642'
--snip---
+ echo OvnNorth tcp://10.66.144.161 'out;' 'out;:6641'
OvnNorth tcp://10.66.144.161 out; out;:6641
+ echo OvnSouth tcp://10.66.144.161 'out;' 'out;:6642'
OvnSouth tcp://10.66.144.161 out; out;:6642

```

The full output of the `host` cmd is:
```
# host $(hostname)
networking-master.cluster.local has address 10.66.144.161
;; connection timed out; no servers could be reached
;; connection timed out; no servers could be reached
```

So, add `-t A` parameter can fix the issue, and grab the ipv4 address which we want.

Signed-off-by: Bo Meng bmeng@redhat.com