### PR TITLE
multiple CIDR and configurable hostsubnetlength support 

### DIFF
--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -10,7 +10,11 @@ The ovn utility used to confiugre ovn-kubernetes
 .SH GLOBAL OPTIONS
 .TP
 \fB\--cluster-subnet\fR string
-Cluster wide IP subnet to use (default "11.11.0.0/16")
+A comma separated set of IP subnets and the associated hostsubnetlengths to use for
+the cluster (eg, "10.128.0.0/14/23,10.0.0.0/14/23").  Each entry is given in the form
+IP address/subnet mask/hostsubnetlength, the hostsubnetlength is optional and if
+unspecified defaults to 24. The hostsubnetlength defines how many IP addresses are
+dedicated to each node. (default "11.11.0.0/16")
 .TP
 \fB\--service-cluster-ip-range\fR value
 A CIDR notation IP range from which k8s assigns service cluster IPs.

--- a/go-controller/cmd/ovn-kube-util/app/gateway_init.go
+++ b/go-controller/cmd/ovn-kube-util/app/gateway_init.go
@@ -92,7 +92,7 @@ func initGateway(context *cli.Context) error {
 		return fmt.Errorf("One of physical-interface or bridge-interface has to be specified")
 	}
 
-	return util.GatewayInit(clusterIPSubnet, nodeName, physicalIP,
+	return util.GatewayInit([]string{clusterIPSubnet}, nodeName, physicalIP,
 		physicalInterface, bridgeInterface, defaultGW, rampoutIPSubnet,
 		enableLB)
 }

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/sirupsen/logrus"
@@ -206,14 +208,14 @@ func runOvnKube(ctx *cli.Context) error {
 	clusterController := ovncluster.NewClusterController(clientset, factory)
 
 	if master != "" || node != "" {
-		clusterController.HostSubnetLength = 8
 		clusterController.GatewayInit = ctx.Bool("init-gateways")
 		clusterController.GatewayIntf = ctx.String("gateway-interface")
 		clusterController.GatewayNextHop = ctx.String("gateway-nexthop")
 		clusterController.GatewaySpareIntf = ctx.Bool("gateway-spare-interface")
 		clusterController.LocalnetGateway = ctx.Bool("gateway-localnet")
 		clusterController.OvnHA = ctx.Bool("ha")
-		_, clusterController.ClusterIPNet, err = net.ParseCIDR(ctx.String("cluster-subnet"))
+
+		clusterController.ClusterIPNet, err = parseClusterSubnetEntries(ctx.String("cluster-subnet"))
 		if err != nil {
 			panic(err.Error)
 		}
@@ -278,4 +280,58 @@ func runOvnKube(ctx *cli.Context) error {
 	}
 
 	return nil
+}
+
+// parseClusterSubnetEntries returns the parsed set of CIDRNetworkEntries passed by the user on the command line
+// These entries define the clusters network space by specifying a set of CIDR and netmaskas the SDN can allocate
+// addresses from.
+func parseClusterSubnetEntries(clusterSubnetCmd string) ([]ovncluster.CIDRNetworkEntry, error) {
+	var parsedClusterList []ovncluster.CIDRNetworkEntry
+
+	clusterEntriesList := strings.Split(clusterSubnetCmd, ",")
+
+	for _, clusterEntry := range clusterEntriesList {
+		var parsedClusterEntry ovncluster.CIDRNetworkEntry
+
+		splitClusterEntry := strings.Split(clusterEntry, "/")
+		if len(splitClusterEntry) == 3 {
+			tmp, err := strconv.ParseUint(splitClusterEntry[2], 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			parsedClusterEntry.HostSubnetLength = uint32(tmp)
+		} else if len(splitClusterEntry) == 2 {
+			// the old hardcoded value for backwards compatability
+			parsedClusterEntry.HostSubnetLength = 24
+		} else {
+			return nil, fmt.Errorf("cluster-cidr not formatted properly")
+		}
+
+		var err error
+		_, parsedClusterEntry.CIDR, err = net.ParseCIDR(fmt.Sprintf("%s/%s", splitClusterEntry[0], splitClusterEntry[1]))
+		if err != nil {
+			return nil, err
+		}
+
+		//check to make sure that no cidrs overlap
+		if cidrsOverlap(parsedClusterEntry.CIDR, parsedClusterList) {
+			return nil, fmt.Errorf("CIDR %s overlaps with another cluster network CIDR", parsedClusterEntry.CIDR.String())
+		}
+
+		parsedClusterList = append(parsedClusterList, parsedClusterEntry)
+
+	}
+
+	return parsedClusterList, nil
+}
+
+//cidrsOverlap returns a true if the cidr range overlaps any in the list of cidr ranges
+func cidrsOverlap(cidr *net.IPNet, cidrList []ovncluster.CIDRNetworkEntry) bool {
+
+	for _, clusterEntry := range cidrList {
+		if cidr.Contains(clusterEntry.CIDR.IP) || clusterEntry.CIDR.Contains(cidr.IP) {
+			return true
+		}
+	}
+	return false
 }

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -33,7 +33,11 @@ func main() {
 		cli.StringFlag{
 			Name:  "cluster-subnet",
 			Value: "11.11.0.0/16",
-			Usage: "Cluster wide IP subnet to use",
+			Usage: "A comma separated set of IP subnets and the associated" +
+				"hostsubnetlengths to use for the cluster (eg, \"10.128.0.0/14/23,10.0.0.0/14/23\"). " +
+				"Each entry is given in the form IP address/subnet mask/hostsubnetlength, " +
+				"the hostsubnetlength is optional and if unspecified defaults to 24. The " +
+				"hostsubnetlength defines how many IP addresses are dedicated to each node.",
 		},
 		cli.StringFlag{
 			Name: "service-cluster-ip-range",

--- a/go-controller/cmd/ovnkube/ovnkube_test.go
+++ b/go-controller/cmd/ovnkube/ovnkube_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	ovncluster "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/cluster"
+	"net"
+	"testing"
+)
+
+func returnIPNetPointers(input string) *net.IPNet {
+	_, ipNet, _ := net.ParseCIDR(input)
+	return ipNet
+}
+
+func TestParseClusterSubnetEntries(t *testing.T) {
+	tests := []struct {
+		name            string
+		cmdLineArg      string
+		clusterNetworks []ovncluster.CIDRNetworkEntry
+		expectedErr     bool
+	}{
+		{
+			name:            "Single CIDR correctly formatted",
+			cmdLineArg:      "10.132.0.0/26/28",
+			clusterNetworks: []ovncluster.CIDRNetworkEntry{{CIDR: returnIPNetPointers("10.132.0.0/26"), HostSubnetLength: 28}},
+			expectedErr:     false,
+		},
+		{
+			name:       "Two CIDRs correctly formatted",
+			cmdLineArg: "10.132.0.0/26/28,10.133.0.0/26/28",
+			clusterNetworks: []ovncluster.CIDRNetworkEntry{
+				{CIDR: returnIPNetPointers("10.132.0.0/26"), HostSubnetLength: 28},
+				{CIDR: returnIPNetPointers("10.133.0.0/26"), HostSubnetLength: 28},
+			},
+			expectedErr: false,
+		},
+		{
+			name:            "Test that defaulting to hostsubnetlength 8 still works",
+			cmdLineArg:      "10.128.0.0/14",
+			clusterNetworks: []ovncluster.CIDRNetworkEntry{{CIDR: returnIPNetPointers("10.128.0.0/14"), HostSubnetLength: 24}},
+			expectedErr:     false,
+		},
+		{
+			name:            "empty cmdLineArg",
+			cmdLineArg:      "",
+			clusterNetworks: nil,
+			expectedErr:     true,
+		},
+		{
+			name:            "improperly formated CIDR",
+			cmdLineArg:      "10.132.0.-/26/28",
+			clusterNetworks: nil,
+			expectedErr:     true,
+		},
+		{
+			name:            "negative HostsubnetLength",
+			cmdLineArg:      "10.132.0.0/26/-22",
+			clusterNetworks: nil,
+			expectedErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+
+		parsedList, err := parseClusterSubnetEntries(tc.cmdLineArg)
+		if err != nil && !tc.expectedErr {
+			t.Errorf("Test case \"%s\" expected no errors, got %v", tc.name, err)
+		}
+		if len(tc.clusterNetworks) != len(parsedList) {
+			t.Errorf("Test case \"%s\" expected to output the same number of entries as parseClusterSubnetEntries", tc.name)
+		} else {
+			for index, entry := range parsedList {
+				if entry.CIDR.String() != tc.clusterNetworks[index].CIDR.String() {
+					t.Errorf("Test case \"%s\" expected entry[%d].CIDR: %s to equal tc.clusterNetworks[%d].CIDR: %s", tc.name, index, entry.CIDR.String(), index, tc.clusterNetworks[index].CIDR.String())
+				}
+				if entry.HostSubnetLength != tc.clusterNetworks[index].HostSubnetLength {
+					t.Errorf("Test case \"%s\" expected entry[%d].HostSubnetLength: %d to equal tc.clusterNetworks[%d].HostSubnetLength: %d", tc.name, index, entry.HostSubnetLength, index, tc.clusterNetworks[index].HostSubnetLength)
+				}
+			}
+		}
+	}
+}
+
+func TestCidrsOverlap(t *testing.T) {
+	tests := []struct {
+		name           string
+		cidr           *net.IPNet
+		cidrList       []ovncluster.CIDRNetworkEntry
+		expectedOutput bool
+	}{
+		{
+			name:           "empty cidrList",
+			cidr:           returnIPNetPointers("10.132.0.0/26"),
+			cidrList:       nil,
+			expectedOutput: false,
+		},
+		{
+			name: "non-overlapping",
+			cidr: returnIPNetPointers("10.132.0.0/26"),
+			cidrList: []ovncluster.CIDRNetworkEntry{
+				{CIDR: returnIPNetPointers("10.133.0.0/26")},
+			},
+			expectedOutput: false,
+		},
+		{
+			name: "cidr equal to an entry in the list",
+			cidr: returnIPNetPointers("10.132.0.0/26"),
+			cidrList: []ovncluster.CIDRNetworkEntry{
+				{CIDR: returnIPNetPointers("10.132.0.0/26")},
+			},
+			expectedOutput: true,
+		},
+		{
+			name: "proposed cidr is a proper subset of a list entry",
+			cidr: returnIPNetPointers("10.132.0.0/26"),
+			cidrList: []ovncluster.CIDRNetworkEntry{
+				{CIDR: returnIPNetPointers("10.0.0.0/8")},
+			},
+			expectedOutput: true,
+		},
+		{
+			name: "proposed cidr is a proper superset of a list entry",
+			cidr: returnIPNetPointers("10.0.0.0/8"),
+			cidrList: []ovncluster.CIDRNetworkEntry{
+				{CIDR: returnIPNetPointers("10.133.0.0/26")},
+			},
+			expectedOutput: true,
+		},
+		{
+			name: "proposed cidr overlaps a list entry",
+			cidr: returnIPNetPointers("10.1.0.0/14"),
+			cidrList: []ovncluster.CIDRNetworkEntry{
+				{CIDR: returnIPNetPointers("10.0.0.0/15")},
+			},
+			expectedOutput: true,
+		},
+	}
+
+	for _, tc := range tests {
+
+		if result := cidrsOverlap(tc.cidr, tc.cidrList); result != tc.expectedOutput {
+			t.Errorf("testcase \"%s\" expected output %t cidrsOverlap returns %t", tc.name, tc.expectedOutput, result)
+		}
+	}
+}

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -14,13 +14,12 @@ import (
 
 // OvnClusterController is the object holder for utilities meant for cluster management
 type OvnClusterController struct {
-	Kube                  kube.Interface
-	watchFactory          *factory.WatchFactory
-	masterSubnetAllocator *netutils.SubnetAllocator
+	Kube                      kube.Interface
+	watchFactory              *factory.WatchFactory
+	masterSubnetAllocatorList []*netutils.SubnetAllocator
 
-	ClusterIPNet          *net.IPNet
 	ClusterServicesSubnet string
-	HostSubnetLength      uint32
+	ClusterIPNet          []CIDRNetworkEntry
 
 	GatewayInit      bool
 	GatewayIntf      string
@@ -30,6 +29,12 @@ type OvnClusterController struct {
 	NodePortEnable   bool
 	OvnHA            bool
 	LocalnetGateway  bool
+}
+
+// CIDRNetworkEntry is the object that holds the definition for a single network CIDR range
+type CIDRNetworkEntry struct {
+	CIDR             *net.IPNet
+	HostSubnetLength uint32
 }
 
 const (

--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -376,7 +376,7 @@ func (cluster *OvnClusterController) nodePortWatcher() error {
 }
 
 func (cluster *OvnClusterController) initGateway(
-	nodeName, clusterIPSubnet, subnet string) error {
+	nodeName string, clusterIPSubnet []string, subnet string) error {
 	if cluster.LocalnetGateway {
 		// Create a localnet OVS bridge.
 		localnetBridgeName := "br-localnet"

--- a/go-controller/pkg/cluster/gateway_init_windows.go
+++ b/go-controller/pkg/cluster/gateway_init_windows.go
@@ -3,6 +3,6 @@
 package cluster
 
 func (cluster *OvnClusterController) initGateway(
-	nodeName, clusterIPSubnet, subnet string) error {
+	nodeName string, clusterIPSubnet []string, subnet string) error {
 	return nil
 }

--- a/go-controller/pkg/ovn/management-port_test.go
+++ b/go-controller/pkg/ovn/management-port_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Management Port Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = CreateManagementPort(nodeName, nodeSubnet, clusterCIDR, serviceCIDR)
+			err = CreateManagementPort(nodeName, nodeSubnet, serviceCIDR, []string{clusterCIDR})
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CommandCalls).To(Equal(len(fakeCmds)))


### PR DESCRIPTION
First draft of adding multiple CIDR and configurable hostsubnetlengh in ovn-kubernetes networkwork plugin.

multiple cidrs are passed on the command line with  --cluster-subnet flag in the form

`--cluster-subnet [cidr]-[hostsubnetlength],...`
for example I used the below for testing
 
`-cluster-subnet "10.132.0.0/26-4,10.133.0.0/26-4"`

the hostsubnetlength refers to the number of ip addresses each node has for the allocation of pods in the above the nodes allocated in the above ranges would have /28 addresses to allocate pods in (I made it small for testing purposes) without this PR the hostsubnetlength was hard-coded to 8 so nodes had /24