### PR TITLE
ansible install of OVN on v3.11 cluster to bring up networking

### DIFF
--- a/dist/ansible/hosts
+++ b/dist/ansible/hosts
@@ -1,0 +1,12 @@
+# ansible hosts file
+
+# This may be a copy of the host file used to install the cluster
+
+[OSEv3:children]
+masters
+
+[masters]
+# result of `hostname` on master node
+#wsfd-netdev22.ntdv.lab.eng.bos.redhat.com
+
+

--- a/dist/ansible/ovn-playbook.yaml
+++ b/dist/ansible/ovn-playbook.yaml
@@ -1,0 +1,94 @@
+# Install ovn onto cluster
+# This is done when the cluster is up with no networking
+
+# On a convienent host, clone ovn-kubernetes cd to dist/ansible 
+# git clone https://github.com/openvswitch/ovn-kubernetes ~/ovn-kubernetes
+# cd ~/ovn-kubernetes/dist/ansible
+
+# edit hosts file for the hostname of the master
+
+# ./run-playbook
+
+- hosts: masters
+  become: yes
+  become_user: root
+  tasks:
+  # OVN data is persistent, so delete the database
+  - name: Remove OVS DB Content
+    file:
+      state: absent
+      name: /var/lib/openvswitch/ovnnb_db.db
+  - name: Remove OVS DB Content
+    file:
+      state: absent
+      name: /var/lib/openvswitch/ovnsb_db.db
+
+  # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
+  - name: iptables allow 6641
+    iptables:
+      chain: OS_FIREWALL_ALLOW
+      ctstate: NEW
+      destination_port: 6641
+      jump: ACCEPT
+      protocol: tcp
+
+  # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+  - name: iptables allow 6642
+    iptables:
+      chain: OS_FIREWALL_ALLOW
+      ctstate: NEW
+      destination_port: 6642
+      jump: ACCEPT
+      protocol: tcp
+
+  # copy yaml files to master
+  - name: Make dirctory /root/ovn/yaml
+    file:
+      state: directory
+      path: /root/ovn/yaml
+  - name: Make directory /root/ovn/scripts
+    file:
+      state: directory
+      path: /root/ovn/scripts
+  - name: Copy ovn-namespace.yaml
+    copy: src=../yaml/ovn-namespace.yaml dest=/root/ovn/yaml/ovn-namespace.yaml
+  - name: Copy ovn-policy.yaml
+    copy: src=../yaml/ovn-policy.yaml dest=/root/ovn/yaml/ovn-policy.yaml
+  - name: Copy ovn-policy.yaml
+    copy:
+      src: scripts/ovn-setup.sh
+      dest: /root/ovn/scripts/ovn-setup.sh
+      mode: 0755
+  - name: Copy sdn-ovs.yaml
+    copy: src=../yaml/sdn-ovs.yaml dest=/root/ovn/yaml/sdn-ovs.yaml
+  - name: Copy ovnkube-master.yaml
+    copy: src=../yaml/ovnkube-master.yaml dest=/root/ovn/yaml/ovnkube-master.yaml
+  - name: Copy ovnkube.yaml
+    copy: src=../yaml/ovnkube.yaml dest=/root/ovn/yaml/ovnkube.yaml
+
+  - name: Provision the OVN Namespace
+    shell: oc create -f /root/ovn/yaml/ovn-namespace.yaml
+    ignore_errors: yes
+  - name: Provision the OVN Policy
+    shell: oc create -f /root/ovn/yaml/ovn-policy.yaml
+    ignore_errors: yes
+  - name: Provision the OVN Project
+    shell: oc project ovn-kubernetes
+    ignore_errors: yes
+  - name: Add adm policy auyuid
+    shell: oc adm policy add-scc-to-user anyuid -z ovn
+    ignore_errors: yes
+
+  - name: Run the ovn-setup
+    shell: /root/ovn/scripts/ovn-setup.sh
+    ignore_errors: yes
+
+  - name: Start the ovn-ovs daemonset
+    shell: oc create -f /root/ovn/yaml/sdn-ovs.yaml
+    ignore_errors: yes
+  - name: Start the master ovn daemonset
+    shell: oc create -f /root/ovn/yaml/ovnkube-master.yaml
+    ignore_errors: yes
+  - name: Start the node ovn daemonset
+    shell: oc create -f /root/ovn/yaml/ovnkube.yaml
+    ignore_errors: yes

--- a/dist/ansible/run-playbook
+++ b/dist/ansible/run-playbook
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# clone ovn-kubernetes on master and cd to dist/ansible
+# git clone https://github.com/openvswitch/ovn-kubernetes ~/ovn-kubernetes
+# cd ~/ovn-kubernetes/dist/ansible
+# edit hosts for hostname of master
+# edit ../dist/*yaml for desired image
+# ./run-playbook
+
+ansible-playbook -i hosts ovn-playbook.yaml
+

--- a/dist/yaml/ovnkube-master.yaml
+++ b/dist/yaml/ovnkube-master.yaml
@@ -46,9 +46,11 @@ spec:
         # This is the community build
         image: "docker.io/ovnkube/ovn-daemonset:latest"
         # This is an official redhat build
-        # image: "registry.access.redhat.com/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
+        # image: "registry.access.redhat.com/openshift3/ose-ovn-kubernetes:v3.11"
         # This is an official (internal) redhat build
-        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
+        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is an official image on aws
+        # image: "registry.reg-aws.openshift.com:443/openshift3/ose-ovn-kubernetes:v3.11"
         # This is development build image
         # image: "quay.io/pecameron/ovn-kube:latest"
         # imagePullPolicy: "Always"

--- a/dist/yaml/ovnkube.yaml
+++ b/dist/yaml/ovnkube.yaml
@@ -44,9 +44,11 @@ spec:
         # This is the community build
         image: "docker.io/ovnkube/ovn-daemonset:latest"
         # This is an official redhat build
-        # image: "registry.access.redhat.com/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
+        # image: "registry.access.redhat.com/openshift3/ose-ovn-kubernetes:v3.11"
         # This is an official (internal) redhat build
-        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
+        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is an official image on aws
+        # image: "registry.reg-aws.openshift.com:443/openshift3/ose-ovn-kubernetes:v3.11"
         # This is development build image
         # image: "quay.io/pecameron/ovn-kube:latest"
         # imagePullPolicy: "Always"

--- a/dist/yaml/sdn-ovs.yaml
+++ b/dist/yaml/sdn-ovs.yaml
@@ -32,7 +32,11 @@ spec:
         # This is the community build
         image: "docker.io/ovnkube/ovn-daemonset:latest"
         # This is an official redhat build
-        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11.0-123483"
+        # image: "registry.access.redhat.com/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is an official (internal) redhat build
+        # image: "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/openshift3/ose-ovn-kubernetes:v3.11"
+        # This is an official image on aws
+        # image: "registry.reg-aws.openshift.com:443/openshift3/ose-ovn-kubernetes:v3.11"
         # This is development build image
         # image: "quay.io/pecameron/ovn-kube:latest"
         # imagePullPolicy: "Always"


### PR DESCRIPTION
Use ansible to install OVN on top of a 3.11 (no cluster network provisioned) install

On any suitable host, clone ovn-kubernetes

cd dist/yaml
edit ovnkube-master.yaml, ovnkube.yaml, sdn-ovs.yaml for the desired
image name.

cd ../ansible
edit hosts for hostname of master

./run-playbook

Signed-off-by: Phil Cameron <pcameron@redhat.com>