### PR TITLE
contrib: Generate automatically test yamls for Windows

### DIFF
--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -315,32 +315,3 @@
           image: nginx
         nodeSelector:
           beta.kubernetes.io/os: linux
-- name: Create test yamls
-  blockinfile:
-    path: /root/nano-pod-{{item}}.yaml
-    create: yes
-    marker: "# {mark} Ansible automatic example generation"
-    block: |
-      apiVersion: v1
-      kind: Pod
-      metadata:
-        name: nano-{{item}}
-        labels:
-          name: webserver
-      spec:
-        containers:
-        - name: nano
-          image: ovnkubernetes/pause
-          imagePullPolicy: IfNotPresent
-        # This test yaml uses a custom nanoserver container that starts a simple
-        # http server that can be used for tests. It's much faster compared to the
-        # IIS container.
-        - name: nano2
-          image: alinbalutoiu/nanoserver-web:{{item}}
-          imagePullPolicy: IfNotPresent
-        nodeSelector:
-          beta.kubernetes.io/os: windows
-          # kubernetes.io/hostname: windows_{{item}}_hostname
-  with_items:
-    - 1709
-    - 1803

--- a/contrib/roles/windows/kubernetes/tasks/main.yml
+++ b/contrib/roles/windows/kubernetes/tasks/main.yml
@@ -68,3 +68,34 @@
 
 - include_tasks: ./create_infracontainer.yml
   when: infra_inspect.rc != 0 and ansible_kernel in supported_versions_by_the_playbook
+
+- name: Create test yaml for this host
+  become: true
+  become_method: sudo
+  blockinfile:
+    path: /root/nano-pod-{{windows_container_tag}}-{{ansible_hostname|lower}}.yaml
+    create: yes
+    marker: "# {mark} Ansible automatic example generation"
+    block: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: nano-{{windows_container_tag}}-{{ansible_hostname|lower}}
+        labels:
+          name: webserver
+      spec:
+        containers:
+        - name: nano
+          image: ovnkubernetes/pause
+          imagePullPolicy: IfNotPresent
+        # This test yaml uses a custom nanoserver container that starts a simple
+        # http server that can be used for tests. It's much faster compared to the
+        # IIS container.
+        - name: nano2
+          image: alinbalutoiu/nanoserver-web:{{windows_container_tag}}
+          imagePullPolicy: IfNotPresent
+        nodeSelector:
+          beta.kubernetes.io/os: windows
+          kubernetes.io/hostname: {{ansible_hostname|lower}}
+  delegate_to: "{{ item }}"
+  with_items: "{{groups['kube-master']}}"


### PR DESCRIPTION
The ansible playbook generates a template yaml which has to
be edited before it can be used to create windows containers.

This patch will generate automatically an yaml file for each
Windows minion existing in the cluster which can be used for
testing.

Signed-off-by: Alin-Gheorghe Balutoiu <alinbalutoiu@gmail.com>