### PR TITLE
contrib: Install OVS Cloudbase beta MSI by default

### DIFF
--- a/contrib/ovn-kubernetes-cluster.yml
+++ b/contrib/ovn-kubernetes-cluster.yml
@@ -75,10 +75,10 @@
         # to install the MSI in unattended mode
         # Setting install_beta_ovs to false will install the latest stable OVS
         install_custom_ovs: true
-        custom_ovs_link: "https://balutoiu.com/ionut/OpenvSwitch.msi"
-        ovs_certs_link: "https://docs.google.com/uc?export=download&id=1tGbGalZ6gDQOgjQuWAfIqGCNy-9RTpAF"
+        custom_ovs_link: "https://cloudbase.it/downloads/openvswitch-hyperv-installer-beta.msi"
         # This is useful for dev purposes and when using custom MSI which is not signed
-        bcdedit_needed: true
+        bcdedit_needed: false
+        # ovs_certs_link: ""  # link to certificates for OVS if required
     - import_role:
         name: windows/ovn-kubernetes
     - import_role:

--- a/contrib/roles/windows/openvswitch/tasks/install_custom_ovs.yml
+++ b/contrib/roles/windows/openvswitch/tasks/install_custom_ovs.yml
@@ -21,6 +21,16 @@
     dest: "{{ovs_info.tmp_dir}}\\certificate.cer"
     timeout: 60
   retries: 3
+  when: ovs_certs_link is defined
+
+- name: OVS | Extract certificate from msi
+  win_shell: |
+    $driverFile = "{{ovs_info.tmp_dir}}\\ovs.msi"
+    $outputFile = "{{ovs_info.tmp_dir}}\\certificate.cer"
+    $exportType = [System.Security.Cryptography.X509Certificates.X509ContentType]::Cert
+    $cert = (Get-AuthenticodeSignature $driverFile).SignerCertificate
+    [System.IO.File]::WriteAllBytes($outputFile, $cert.Export($exportType))
+  when: ovs_certs_link is not defined
 
 - name: OVS | Install certificate
   win_shell: |
@@ -39,7 +49,7 @@
     path: "{{ovs_info.tmp_dir}}\\ovs.msi"
     wait: yes
     state: present
-    arguments: ADDLOCAL="OpenvSwitchServices,OpenvSwitchCLI,OpenvSwitchDriver,OVNHost"
+    arguments: ADDLOCAL="OpenvSwitchCLI,OpenvSwitchDriver,OVNHost"
 
 - name: OVS | Restarting after OVS install
   win_reboot:


### PR DESCRIPTION
Currently, a custom version of OVS is being installed by default
by the ansible playbooks.

This commit changes the default OVS installer to the Cloudbase beta
MSI instead of using the custom one.

Signed-off-by: Alin-Gheorghe Balutoiu <alinbalutoiu@gmail.com>
Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
Co-authored-by: Alin Gabriel Serdean <aserdean@ovn.org>