### PR TITLE
contrib: Remove unnecessary Windows restarts

### DIFF
--- a/contrib/roles/windows/docker/tasks/install_docker.yml
+++ b/contrib/roles/windows/docker/tasks/install_docker.yml
@@ -32,6 +32,3 @@
   win_service:
     name: docker
     state: started
-
-- name: Docker | Reboot computer to update Path with docker
-  win_reboot:

--- a/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
+++ b/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
@@ -50,35 +50,15 @@
   changed_when: false
 
 # TODO: add firewall rules instead of disabling it
-- name: Kubernetes minion | Create startup-script
-  win_lineinfile:
-    path: C:\startup.ps1
-    create: yes
-    line: |
-      $RegROPath = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
-      Remove-ItemProperty $RegROPath "OVN_Init_Node" -ErrorAction SilentlyContinue
-      Start-Service ovn-kubernetes-node
-      netsh firewall set opmode disable
-    newline: unix
+- name: Kubernetes minion | Disable firewall
+  win_shell: netsh firewall set opmode disable
 
-- name: Kubernetes minion | Make minion-init startup script Run
-  win_shell: |
-    $RegPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"
-    # HKCU to run after the user logs in
-    $RegROPath = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+- name: Kubernetes minion | Start ovn-kubernetes-node service
+  win_service:
+    name: ovn-kubernetes-node
+    state: started
 
-    $script = "C:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -noexit C:\startup.ps1"
-
-    Set-ItemProperty $RegPath "AutoAdminLogon" -Value "1" -type String  
-    Set-ItemProperty $RegPath "DefaultUsername" -Value "{{ host_info.username }}" -type String  
-    Set-ItemProperty $RegPath "DefaultPassword" -Value "{{ host_info.password }}" -type String
-    Set-ItemProperty $RegPath "AutoLogonCount" -Value "1" -type DWord
-    Set-ItemProperty $RegROPath "OVN_Init_Node" -Value "$script" -type String
-
-- name: Kubernetes minion | Reboot
-  win_reboot:
-
-- name: Kubernetes minion | Wait for minion-init script to finish
+- name: Kubernetes minion | Wait for ovn-kubernetes-node service to finish init
   win_shell: ping {{OVN_GATEWAY_IP}} -n 1
   changed_when: false
   register: ovngateway_ping


### PR DESCRIPTION
During minion init, a script is created which will run at startup
and Windows gets rebooted.
Since ovnkube runs as a service, this is not required anymore.

This commit removes the Windows reboot and starts directly the
ovn-kubernetes-node service which will run minion init. The restart
after docker installation is also removed since the path is
already updated.

Signed-off-by: Alin-Gheorghe Balutoiu <alinbalutoiu@gmail.com>
Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
Co-authored-by: Alin Gabriel Serdean <aserdean@ovn.org>