### PR TITLE
windows: Add gateway support

### DIFF
--- a/contrib/ovn-kubernetes-cluster.yml
+++ b/contrib/ovn-kubernetes-cluster.yml
@@ -56,6 +56,9 @@
   gather_facts: true
   become_method: runas
   any_errors_fatal: true
+  vars:
+    # This will init the gateway on the first minion from the hosts
+    init_gateway: true
   tasks:
     - set_fact:
         windows_container_tag: 1709

--- a/contrib/roles/windows/kubernetes/tasks/main.yml
+++ b/contrib/roles/windows/kubernetes/tasks/main.yml
@@ -51,6 +51,9 @@
 - name: Kubernetes | OVS Docker network setup
   include_tasks: ./setup_ovs_docker.yml
 
+- name: Kubernetes | refresh network details
+  include_tasks: set_ip_facts.yml
+
 - name: Kubernetes | Check ping to OVN gateway
   win_shell: ping {{OVN_GATEWAY_IP}} -n 1
   register: ping_ovn_gateway

--- a/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
+++ b/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
@@ -34,10 +34,23 @@
       changed_when: false
   when: ovnkube_service.exists
 
+- name: Kubernetes minion | Set empty gateway args
+  set_fact:
+    GATEWAY_ARGS: ''
+
+- name: set gateway args
+  set_fact:
+    GATEWAY_ARGS: '--nodeport --init-gateways --gateway-interface="{{interface_name}}" --gateway-nexthop="{{interface_default_gateway}}"'
+  when: init_gateway
+
+- name: OVN Gateway | Set init_gateway to false
+  set_fact:
+    init_gateway: false
+
 - name: Kubelet | Create ovn-kubernetes-node service
   win_service:
     name: ovn-kubernetes-node
-    path: '"{{ install_info.install_path }}\\servicewrapper.exe" --log-file "{{ install_info.install_path }}/ovn-kubernetes-node.log" ovn-kubernetes-node {{ install_info.install_path }}\\ovnkube.exe --k8s-kubeconfig={{ install_info.install_path }}\\kubeconfig.yaml --k8s-apiserver http://{{ kubernetes_info.MASTER_IP }}:8080 --init-node {{ ansible_hostname|lower }} --k8s-token {{TOKEN}} --nb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6641" --sb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6642" --cluster-subnet {{ kubernetes_info.CLUSTER_SUBNET }} --service-cluster-ip-range {{ kubernetes_info.SERVICE_CLUSTER_IP_RANGE }} --cni-conf-dir="{{ install_info.install_path }}/cni" --cni-plugin "ovn-k8s-cni-overlay.exe" --encap-ip="{{host_internal_ip}}"'
+    path: '"{{ install_info.install_path }}\\servicewrapper.exe" --log-file "{{ install_info.install_path }}/ovn-kubernetes-node.log" ovn-kubernetes-node {{ install_info.install_path }}\\ovnkube.exe --k8s-kubeconfig={{ install_info.install_path }}\\kubeconfig.yaml --k8s-apiserver http://{{ kubernetes_info.MASTER_IP }}:8080 --init-node {{ ansible_hostname|lower }} --k8s-token {{TOKEN}} --nb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6641" --sb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6642" --cluster-subnet {{ kubernetes_info.CLUSTER_SUBNET }} --service-cluster-ip-range {{ kubernetes_info.SERVICE_CLUSTER_IP_RANGE }} --cni-conf-dir="{{ install_info.install_path }}/cni" --cni-plugin "ovn-k8s-cni-overlay.exe" --encap-ip="{{host_internal_ip}}" {{GATEWAY_ARGS}}'
     display_name: OVN Kubernetes Node
     description: OVN Kubernetes Node CNI Server
     username: LocalSystem

--- a/contrib/roles/windows/kubernetes/tasks/setup_ovs_docker.yml
+++ b/contrib/roles/windows/kubernetes/tasks/setup_ovs_docker.yml
@@ -41,10 +41,8 @@
       sc.exe config ovs-vswitchd start= disabled
       Stop-Service ovs-vswitchd -Force
       Disable-OVSOnHNSNetwork $HNS_ID
-      ovs-vsctl --if-exists --no-wait del-br br-ex
-      ovs-vsctl --no-wait --may-exist add-br br-ex
-      ovs-vsctl --no-wait add-port br-ex "vEthernet ({{phys_interface_name}})" -- set interface  "vEthernet ({{phys_interface_name}})" type=internal
-      ovs-vsctl --no-wait add-port br-ex '{{phys_interface_name}}'
+      ovs-vsctl --no-wait --may-exist add-br "vEthernet ({{phys_interface_name}})"
+      ovs-vsctl --no-wait add-port "vEthernet ({{phys_interface_name}})" '{{phys_interface_name}}'
       Stop-Service ovs-vswitchd
       Enable-OVSOnHNSNetwork $HNS_ID
 

--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -147,25 +147,9 @@ var _ = Describe("Gateway Init Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			fakeClient := &fake.Clientset{}
-			stop := make(chan struct{})
-			wf, err := factory.NewWatchFactory(fakeClient, stop)
-			Expect(err).NotTo(HaveOccurred())
-
-			cluster := OvnClusterController{
-				watchFactory:     wf,
-				GatewayInit:      true,
-				GatewayIntf:      "",
-				GatewayBridge:    "",
-				GatewayNextHop:   "",
-				GatewaySpareIntf: false,
-				NodePortEnable:   false,
-				LocalnetGateway:  true,
-			}
-
 			ipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
 			Expect(err).NotTo(HaveOccurred())
-			err = cluster.initGatewayInternal(nodeName, []string{clusterCIDR}, nodeSubnet, ipt)
+			err = initLocalnetGatewayInternal(nodeName, []string{clusterCIDR}, nodeSubnet, ipt)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CommandCalls).To(Equal(len(fakeCmds)))
@@ -408,7 +392,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 				err = testNS.Do(func(ns.NetNS) error {
 					defer GinkgoRecover()
 
-					err = cluster.initGatewayInternal(nodeName, []string{clusterCIDR}, nodeSubnet, ipt)
+					err = cluster.initGateway(nodeName, []string{clusterCIDR}, nodeSubnet)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Verify the code moved eth0's IP address, MAC, and routes
@@ -540,7 +524,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 				err = testNS.Do(func(ns.NetNS) error {
 					defer GinkgoRecover()
 
-					err = cluster.initGatewayInternal(nodeName, []string{clusterCIDR}, nodeSubnet, ipt)
+					err = cluster.initGateway(nodeName, []string{clusterCIDR}, nodeSubnet)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Verify the code didn't touch eth0's IP and MAC

--- a/go-controller/pkg/cluster/gateway_init_windows.go
+++ b/go-controller/pkg/cluster/gateway_init_windows.go
@@ -1,8 +1,0 @@
-// +build windows
-
-package cluster
-
-func (cluster *OvnClusterController) initGateway(
-	nodeName string, clusterIPSubnet []string, subnet string) error {
-	return nil
-}

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/coreos/go-iptables/iptables"
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -84,6 +85,15 @@ func localnetGatewayNAT(ipt util.IPTablesHelper, ifname, ip string) error {
 }
 
 func initLocalnetGateway(nodeName string, clusterIPSubnet []string,
+	subnet string) error {
+	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+	if err != nil {
+		return fmt.Errorf("failed to initialize iptables: %v", err)
+	}
+	return initLocalnetGatewayInternal(nodeName, clusterIPSubnet, subnet, ipt)
+}
+
+func initLocalnetGatewayInternal(nodeName string, clusterIPSubnet []string,
 	subnet string, ipt util.IPTablesHelper) error {
 	// Create a localnet OVS bridge.
 	localnetBridgeName := "br-localnet"

--- a/go-controller/pkg/cluster/gateway_localnet_windows.go
+++ b/go-controller/pkg/cluster/gateway_localnet_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package cluster
+
+import (
+	"fmt"
+)
+
+func initLocalnetGateway(nodeName string, clusterIPSubnet []string,
+	subnet string) error {
+	// TODO: Implement this
+	return fmt.Errorf("Not implemented yet on Windows")
+}

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package cluster
 
 import (
@@ -265,20 +263,9 @@ func initSharedGateway(
 				gwIntf, err)
 		}
 	} else {
-		// The given (or autodetected) interface is an OVS bridge;
-		// detect if we previously ran NIC/bridge setup
-		if !strings.HasPrefix(gwIntf, "br") {
-			return "", "", fmt.Errorf("gateway interface %s is an OVS bridge not "+
-				"a physical device", gwIntf)
-		}
-
-		// Is intfName a port of cluster.GatewayIntf?
-		intfName := util.GetNicName(gwIntf)
-		_, stderr, err := util.RunOVSVsctl("--if-exists", "get",
-			"interface", intfName, "ofport")
+		intfName, err := getIntfName(gwIntf)
 		if err != nil {
-			return "", "", fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
-				intfName, stderr, err)
+			return "", "", err
 		}
 		bridgeName = gwIntf
 		gwIntf = intfName

--- a/go-controller/pkg/cluster/gateway_spare_intf.go
+++ b/go-controller/pkg/cluster/gateway_spare_intf.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package cluster
 
 import (

--- a/go-controller/pkg/cluster/helper_linux.go
+++ b/go-controller/pkg/cluster/helper_linux.go
@@ -1,0 +1,57 @@
+// +build linux
+
+package cluster
+
+import (
+	"fmt"
+	"strings"
+	"syscall"
+
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+
+	"github.com/vishvananda/netlink"
+)
+
+// getDefaultGatewayInterfaceDetails returns the interface name on
+// which the default gateway (for route to 0.0.0.0) is configured.
+// It also returns the default gateway itself.
+func getDefaultGatewayInterfaceDetails() (string, string, error) {
+	routes, err := netlink.RouteList(nil, syscall.AF_INET)
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to get routing table in node")
+	}
+
+	for i := range routes {
+		route := routes[i]
+		if route.Dst == nil && route.Gw != nil && route.LinkIndex > 0 {
+			intfLink, err := netlink.LinkByIndex(route.LinkIndex)
+			if err != nil {
+				continue
+			}
+			intfName := intfLink.Attrs().Name
+			if intfName != "" {
+				return intfName, route.Gw.String(), nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("Failed to get default gateway interface")
+}
+
+func getIntfName(gatewayIntf string) (string, error) {
+	// The given (or autodetected) interface is an OVS bridge;
+	// detect if we previously ran NIC/bridge setup
+	if !strings.HasPrefix(gatewayIntf, "br") {
+		return "", fmt.Errorf("gateway interface %s is an OVS bridge not "+
+			"a physical device", gatewayIntf)
+	}
+
+	// Is intfName a port of gatewayIntf?
+	intfName := util.GetNicName(gatewayIntf)
+	_, stderr, err := util.RunOVSVsctl("--if-exists", "get",
+		"interface", intfName, "ofport")
+	if err != nil {
+		return "", fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
+			intfName, stderr, err)
+	}
+	return intfName, nil
+}

--- a/go-controller/pkg/cluster/helper_windows.go
+++ b/go-controller/pkg/cluster/helper_windows.go
@@ -1,0 +1,32 @@
+// +build windows
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// getDefaultGatewayInterfaceDetails returns the interface name on
+// which the default gateway (for route to 0.0.0.0) is configured.
+// It also returns the default gateway itself.
+func getDefaultGatewayInterfaceDetails() (string, string, error) {
+	// TODO: Implement this
+	return "", "", fmt.Errorf("Not implemented yet on Windows")
+}
+
+func getIntfName(gatewayIntf string) (string, error) {
+	// Is intfName a port of gatewayIntf?
+	intfName, err := util.GetNicName(gatewayIntf)
+	if err != nil {
+		return "", err
+	}
+	_, stderr, err := util.RunOVSVsctl("--if-exists", "get",
+		"interface", intfName, "ofport")
+	if err != nil {
+		return "", fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
+			intfName, stderr, err)
+	}
+	return intfName, nil
+}

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"net"
-	"runtime"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -13,10 +12,6 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
-)
-
-const (
-	windowsOS = "windows"
 )
 
 // StartClusterNode learns the subnet assigned to it by the master controller
@@ -78,9 +73,6 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	}
 
 	if cluster.GatewayInit {
-		if runtime.GOOS == windowsOS {
-			panic("Windows is not supported as a gateway node")
-		}
 		err = cluster.initGateway(node.Name, clusterSubnets, subnet.String())
 		if err != nil {
 			return err
@@ -134,9 +126,6 @@ func (cluster *OvnClusterController) updateOvnNode(masterIP string,
 
 	// Reinit Gateway for this node if the --init-gateways flag is set
 	if cluster.GatewayInit {
-		if runtime.GOOS == windowsOS {
-			panic("Windows is not supported as a gateway node")
-		}
 		err = cluster.initGateway(node.Name, clusterSubnets, subnet)
 		if err != nil {
 			return err

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -76,7 +76,9 @@ func generateGatewayIP() (string, error) {
 			stdout, stderr, err)
 		return "", err
 	}
-	ips := strings.Split(strings.TrimSpace(stdout), "\n")
+	// Convert \r\n to \n to support Windows line endings
+	stdout = strings.Replace(strings.TrimSpace(stdout), "\r\n", "\n", -1)
+	ips := strings.Split(stdout, "\n")
 
 	ipStart, ipStartNet, _ := net.ParseCIDR("100.64.1.0/24")
 	ipMax, _, _ := net.ParseCIDR("100.64.1.255/24")

--- a/go-controller/pkg/util/nicstobridge_windows.go
+++ b/go-controller/pkg/util/nicstobridge_windows.go
@@ -1,0 +1,22 @@
+// +build windows
+
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+func GetNicName(brName string) (string, error) {
+	// The bridge has format "vEthernet (<nic_name>)" on Windows
+	nameSplitted := strings.SplitAfterN(brName, " ", 2)
+	if len(nameSplitted) != 2 {
+		return "", fmt.Errorf("invalid bridge name")
+	}
+	nicName := fmt.Sprintf("%s", nameSplitted[1][1:len(nameSplitted[1])-1])
+	return nicName, nil
+}
+
+func NicToBridge(iface string) (string, error) {
+	return "", fmt.Errorf("Not implemented yet on Windows")
+}


### PR DESCRIPTION
This patch separates the Linux specific code from the common
code inside gateway-init file. The code is moved in a helper
file.

Gateway init support is now enabled on Windows.

Signed-off-by: Alin-Gheorghe Balutoiu <alinbalutoiu@gmail.com>
Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
Co-authored-by: Alin Gabriel Serdean <aserdean@ovn.org>