### PR TITLE
ovn-policy: Get rid of ClusterRoleBinding "ovn-cluster-reader".

### DIFF
--- a/dist/yaml/ovn-policy.yaml
+++ b/dist/yaml/ovn-policy.yaml
@@ -57,20 +57,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ovn-cluster-reader
-roleRef:
-  name: cluster-reader
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: ovn
-  namespace: ovn-kubernetes
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
   name: ovn-reader
 roleRef:
   name: system:ovn-reader


### PR DESCRIPTION
I checked in kubernetes installed manually and also via kubeadm
and did not see a ClusterRole named "cluster-reader". I am not
sure what its intentions are here. May be it only comes from
openshift?

Signed-off-by: Gurucharan Shetty <guru@ovn.org>