### PR TITLE
ovnkube.yaml: Remove unrecognized keyword.

### DIFF
--- a/dist/yaml/ovnkube-master.yaml
+++ b/dist/yaml/ovnkube-master.yaml
@@ -57,8 +57,6 @@ spec:
 
         securityContext:
           runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
 
         volumeMounts:
         - mountPath: /etc/sysconfig/origin-node

--- a/dist/yaml/ovnkube.yaml
+++ b/dist/yaml/ovnkube.yaml
@@ -55,8 +55,6 @@ spec:
 
         securityContext:
           runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
 
         volumeMounts:
         # Directory which contains the host configuration.


### PR DESCRIPTION
'privileged' in securityContext is not recognized
by stock kubernetes.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>