### PR TITLE
[WIP] North South load balancer for localnet type gateway

### DIFF
--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -432,7 +432,7 @@ func (cluster *OvnClusterController) initGateway(
 		err = util.GatewayInit(clusterIPSubnet, nodeName,
 			localnetGatewayIP, "",
 			localnetBridgeName, localnetGatewayNextHop, subnet,
-			false)
+			cluster.NodePortEnable)
 		if err != nil {
 			logrus.Errorf("failed to GatewayInit for localnet (%v)", err)
 			return err


### PR DESCRIPTION
Let the default gateway still create load balancer for nodeport/external-ip even if the type is of localnet.

TODO:
 - [ ] Routing rules on the host to enable external-ip traffic to localnet device
 - [ ] iptables/firewall/dnat rules to enable nodeport on host translated to localnet device 