### PR TITLE
Dockerfile.ubuntu: Use debian packages from 18.191.116.101.

### DIFF
--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -12,14 +12,20 @@ FROM ubuntu:18.04
 
 USER root
 
-
-# get a reasonable version of openvswitch
 RUN apt-get update
-RUN apt-get install -y iptables iproute2
+RUN apt-get install -y iptables iproute2 curl software-properties-common
+
+# We do not have much control over the exact version of OVS/OVN that can be
+# obtained from upstream Ubuntu. guru@ovn.org maintains more latest versions of
+# OVS/OVN packages at 18.191.116.101. Please comment out the next 3 lines if
+# you prefer to use upstream Ubuntu packages instead.
+RUN echo "deb http://18.191.116.101/openvswitch/stable /" |  tee /etc/apt/sources.list.d/openvswitch.list
+RUN curl http://18.191.116.101/openvswitch/keyFile |  apt-key add -
+RUN apt-get update
+
+# Install OVS and OVN packages.
 RUN apt-get install -y openvswitch-switch openvswitch-common
 RUN apt-get install -y ovn-central ovn-common ovn-host
-
-
 
 RUN mkdir -p /var/run/openvswitch
 RUN mkdir -p /etc/cni/net.d


### PR DESCRIPTION
We use 18.191.116.101 for installing OVS/OVN for vagrant
in setup-master.sh and setup-minion.sh.

This gives us more control over the exact OVS/OVN version
that we need installed. For e.g., currently upstream Ubuntu
provides OVS 2.9.0. We know that it is buggy and is a old release.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>