### PR TITLE
add namespace selector and pod selector functionality to network policy 

### DIFF
--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -967,14 +967,20 @@ func (oc *Controller) addNetworkPolicyOld(policy *knet.NetworkPolicy) {
 			if toJSON.IPBlock != nil {
 				egress.addIPBlock(toJSON.IPBlock)
 			}
-			if toJSON.NamespaceSelector != nil {
+
+			if toJSON.NamespaceSelector != nil && toJSON.PodSelector != nil {
+				// For each rule that contains both peer namespace selector and
+				// peer pod selector, we create a watcher for each matching namespace
+				// that populates the addressSet
+				oc.handlePeerNamespaceAndPodSelectorOld(policy,
+					toJSON.NamespaceSelector, toJSON.PodSelector,
+					hashedLocalAddressSet, peerPodAddressMap, egress, np)
+			} else if toJSON.NamespaceSelector != nil {
 				// For each peer namespace selector, we create a watcher that
 				// populates egress.peerAddressSets
 				oc.handlePeerNamespaceSelectorOld(policy,
 					toJSON.NamespaceSelector, egress, np)
-			}
-
-			if toJSON.PodSelector != nil {
+			} else if toJSON.PodSelector != nil {
 				// For each peer pod selector, we create a watcher that
 				// populates the addressSet
 				oc.handlePeerPodSelectorOld(policy, toJSON.PodSelector,


### PR DESCRIPTION
This PR adds the ability to use both podSelector and NamespaceSelector in a network policy as conforms to kubernetes documentation.

 > namespaceSelector and podSelector: A single to/from entry that specifies both namespaceSelector and podSelector selects particular Pods within particular namespaces.

Makes the change in both egress and ingress 

