### PR TITLE
ovn: tolerate all taints

### DIFF
--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -280,3 +280,5 @@ spec:
       - name: host-var-lib-cni-networks-ovn-kubernetes
         hostPath:
           path: /var/lib/cni/networks/ovn-k8s-cni-overlay
+      tolerations:
+      - operator: "Exists"

--- a/dist/templates/ovnkube.yaml.j2
+++ b/dist/templates/ovnkube.yaml.j2
@@ -316,3 +316,5 @@ spec:
       - name: host-var-lib-cni-networks-ovn-kubernetes
         hostPath:
           path: /var/lib/cni/networks/ovn-k8s-cni-overlay
+      tolerations:
+      - operator: "Exists"


### PR DESCRIPTION
Some nodes may be tainted and disallow scheduling new pods. This should
not apply to OVN pods, as these should at least attempt to run on all
nodes.

This is ported from:
https://github.com/openshift/openshift-ansible/pull/10310

JIRA SDN-232 Make sure openshift-sdn manifests ignore all taints

Signed-off-by: Phil Cameron <pcameron@redhat.com>