### PR TITLE
Ansible dns

### DIFF
--- a/contrib/inventory/group_vars/all
+++ b/contrib/inventory/group_vars/all
@@ -11,8 +11,8 @@ MASTER_INTERNAL_IP: "10.0.0.2" # Should always be the second IP of CLUSTER_SUBNE
 
 SERVICE_CLUSTER_IP_RANGE: "10.1.0.0/24"
 K8S_DNS_DOMAIN: "cluster.local"
-K8S_DNS_SERVICE_IP: "10.0.9.10"
-K8S_API_SERVICE_IP: "10.0.9.1"
+K8S_DNS_SERVICE_IP: "10.1.0.10"
+K8S_API_SERVICE_IP: "10.1.0.1"
 
 # set this to true to build ovn-kubernetes only on master and then
 # distribute on the minion nodes. Set this to false if you have different

--- a/contrib/roles/linux/kubernetes/tasks/deploy_coredns.yml
+++ b/contrib/roles/linux/kubernetes/tasks/deploy_coredns.yml
@@ -1,0 +1,21 @@
+---
+- name: CoreDNS | check if CoreDNS is cloned
+  stat:
+    path: "{{ kubernetes_dns.tmp_path }}/coredns-checkout"
+  register: coredns_repo
+
+- name: CoreDNS | git clone
+  git:
+    repo: "{{ kubernetes_dns.coredns_git_url }}"
+    dest: "{{ kubernetes_dns.tmp_path }}/coredns-checkout"
+    version: "{{ kubernetes_dns.branch }}"
+  when: not coredns_repo.stat.exists
+
+- name: Docker | ensure docker packages are installed
+  shell: apt install jq -y
+
+- name: CoreDNS | generate yaml and apply it
+  shell: |
+    cd {{ kubernetes_dns.tmp_path }}/coredns-checkout/kubernetes
+    kubectl delete --namespace=kube-system deployment coredns
+    ./deploy.sh -i {{K8S_DNS_SERVICE_IP}} -d {{K8S_DNS_DOMAIN}} -s coredns.yaml.sed | kubectl apply -f -

--- a/contrib/roles/linux/kubernetes/tasks/main.yml
+++ b/contrib/roles/linux/kubernetes/tasks/main.yml
@@ -61,5 +61,9 @@
   include_tasks: ./prepare_minion.yml
   when: minion
 
+- name: Kubernetes | Deploy CoreDNS
+  include_tasks: ./deploy_coredns.yml
+  when: master
+
 - include_tasks: generate_global_vars.yml
   when: master

--- a/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
@@ -124,6 +124,7 @@
         --k8s-token {{TOKEN}} \
         --k8s-cacert /etc/openvswitch/k8s-ca.crt \
         --k8s-apiserver "http://{{ kubernetes_cluster_info.MASTER_IP }}:8080" \
+        --service-cluster-ip-range "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
         --nb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6641 \
         --sb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6642
   when: not init_gateway

--- a/contrib/roles/linux/kubernetes/vars/ubuntu.yml
+++ b/contrib/roles/linux/kubernetes/vars/ubuntu.yml
@@ -33,3 +33,8 @@ kubernetes_binaries:
   windows:
     - kubelet.exe
     - kubectl.exe
+
+kubernetes_dns:
+  coredns_git_url: https://github.com/coredns/deployment
+  tmp_path: /tmp
+  branch: master

--- a/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
+++ b/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
@@ -37,7 +37,7 @@
 - name: Kubelet | Create ovn-kubernetes-node service
   win_service:
     name: ovn-kubernetes-node
-    path: '"{{ install_info.install_path }}\\servicewrapper.exe" --log-file "{{ install_info.install_path }}/ovn-kubernetes-node.log" ovn-kubernetes-node {{ install_info.install_path }}\\ovnkube.exe --k8s-kubeconfig={{ install_info.install_path }}\\kubeconfig.yaml --k8s-apiserver http://{{ kubernetes_info.MASTER_IP }}:8080 --init-node {{ ansible_hostname|lower }} --k8s-token {{TOKEN}} --nb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6641" --sb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6642" --cluster-subnet {{ kubernetes_info.CLUSTER_SUBNET }} --cni-conf-dir="{{ install_info.install_path }}/cni" --cni-plugin "ovn-k8s-cni-overlay.exe" --encap-ip="{{host_internal_ip}}"'
+    path: '"{{ install_info.install_path }}\\servicewrapper.exe" --log-file "{{ install_info.install_path }}/ovn-kubernetes-node.log" ovn-kubernetes-node {{ install_info.install_path }}\\ovnkube.exe --k8s-kubeconfig={{ install_info.install_path }}\\kubeconfig.yaml --k8s-apiserver http://{{ kubernetes_info.MASTER_IP }}:8080 --init-node {{ ansible_hostname|lower }} --k8s-token {{TOKEN}} --nb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6641" --sb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6642" --cluster-subnet {{ kubernetes_info.CLUSTER_SUBNET }} --service-cluster-ip-range {{ kubernetes_info.SERVICE_CLUSTER_IP_RANGE }} --cni-conf-dir="{{ install_info.install_path }}/cni" --cni-plugin "ovn-k8s-cni-overlay.exe" --encap-ip="{{host_internal_ip}}"'
     display_name: OVN Kubernetes Node
     description: OVN Kubernetes Node CNI Server
     username: LocalSystem


### PR DESCRIPTION
Internal kubernetes dns is now enabled by the ansible playbooks by default.

Fixes #410 