### PR TITLE
factory: defer handler removal to a goroutine

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -18,14 +18,27 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// Handler represents an event handler and is private to the factory module
+type Handler struct {
+	cache.FilteringResourceEventHandler
+
+	id uint64
+	// tombstone is used to track the handler's lifetime. handlerAlive
+	// indicates the handler can be called, while handlerDead indicates
+	// it has been scheduled for removal and should not be called.
+	// tombstone should only be set using atomic operations since it is
+	// used from multiple goroutines.
+	tombstone uint32
+}
+
 type informer struct {
 	sync.Mutex
 	oType    reflect.Type
 	inf      cache.SharedIndexInformer
-	handlers map[uint64]cache.ResourceEventHandler
+	handlers map[uint64]*Handler
 }
 
-func (i *informer) forEachHandler(obj interface{}, f func(id uint64, handler cache.ResourceEventHandler)) {
+func (i *informer) forEachHandler(obj interface{}, f func(h *Handler)) {
 	i.Lock()
 	defer i.Unlock()
 
@@ -35,8 +48,11 @@ func (i *informer) forEachHandler(obj interface{}, f func(id uint64, handler cac
 		return
 	}
 
-	for id, handler := range i.handlers {
-		f(id, handler)
+	for _, handler := range i.handlers {
+		// Only run alive handlers
+		if !atomic.CompareAndSwapUint32(&handler.tombstone, handlerDead, handlerDead) {
+			f(handler)
+		}
 	}
 }
 
@@ -48,14 +64,16 @@ type WatchFactory struct {
 }
 
 const (
-	resyncInterval = 12 * time.Hour
+	resyncInterval        = 12 * time.Hour
+	handlerAlive   uint32 = 0
+	handlerDead    uint32 = 1
 )
 
-func newInformer(oType reflect.Type, inf cache.SharedIndexInformer) *informer {
+func newInformer(oType reflect.Type, sharedInformer cache.SharedIndexInformer) *informer {
 	return &informer{
 		oType:    oType,
-		inf:      inf,
-		handlers: make(map[uint64]cache.ResourceEventHandler),
+		inf:      sharedInformer,
+		handlers: make(map[uint64]*Handler),
 	}
 }
 
@@ -104,15 +122,15 @@ func NewWatchFactory(c kubernetes.Interface, stopChan <-chan struct{}) (*WatchFa
 func (wf *WatchFactory) newFederatedHandler(inf *informer) cache.ResourceEventHandlerFuncs {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			inf.forEachHandler(obj, func(id uint64, handler cache.ResourceEventHandler) {
-				logrus.Debugf("running %v ADD event for handler %d", inf.oType, id)
-				handler.OnAdd(obj)
+			inf.forEachHandler(obj, func(h *Handler) {
+				logrus.Debugf("running %v ADD event for handler %d", inf.oType, h.id)
+				h.OnAdd(obj)
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			inf.forEachHandler(newObj, func(id uint64, handler cache.ResourceEventHandler) {
-				logrus.Debugf("running %v UPDATE event for handler %d", inf.oType, id)
-				handler.OnUpdate(oldObj, newObj)
+			inf.forEachHandler(newObj, func(h *Handler) {
+				logrus.Debugf("running %v UPDATE event for handler %d", inf.oType, h.id)
+				h.OnUpdate(oldObj, newObj)
 			})
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -129,9 +147,9 @@ func (wf *WatchFactory) newFederatedHandler(inf *informer) cache.ResourceEventHa
 					return
 				}
 			}
-			inf.forEachHandler(obj, func(id uint64, handler cache.ResourceEventHandler) {
-				logrus.Debugf("running %v DELETE event for handler %d", inf.oType, id)
-				handler.OnDelete(obj)
+			inf.forEachHandler(obj, func(h *Handler) {
+				logrus.Debugf("running %v DELETE event for handler %d", inf.oType, h.id)
+				h.OnDelete(obj)
 			})
 		},
 	}
@@ -167,15 +185,15 @@ func getObjectMeta(objType reflect.Type, obj interface{}) (*metav1.ObjectMeta, e
 	return nil, fmt.Errorf("cannot get ObjectMeta from type %v", objType)
 }
 
-func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, lsel *metav1.LabelSelector, funcs cache.ResourceEventHandler, processExisting func([]interface{})) (uint64, error) {
+func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, lsel *metav1.LabelSelector, funcs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
 	inf, ok := wf.informers[objType]
 	if !ok {
-		return 0, fmt.Errorf("unknown object type %v", objType)
+		return nil, fmt.Errorf("unknown object type %v", objType)
 	}
 
 	sel, err := metav1.LabelSelectorAsSelector(lsel)
 	if err != nil {
-		return 0, fmt.Errorf("error creating label selector: %v", err)
+		return nil, fmt.Errorf("error creating label selector: %v", err)
 	}
 
 	filterFunc := func(obj interface{}) bool {
@@ -215,10 +233,15 @@ func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, lsel 
 	inf.Lock()
 	defer inf.Unlock()
 
-	inf.handlers[handlerID] = cache.FilteringResourceEventHandler{
-		FilterFunc: filterFunc,
-		Handler:    funcs,
+	handler := &Handler{
+		cache.FilteringResourceEventHandler{
+			FilterFunc: filterFunc,
+			Handler:    funcs,
+		},
+		handlerID,
+		handlerAlive,
 	}
+	inf.handlers[handlerID] = handler
 	logrus.Debugf("added %v event handler %d", objType, handlerID)
 
 	// Send existing items to the handler's add function; informers usually
@@ -228,91 +251,103 @@ func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, lsel 
 		inf.handlers[handlerID].OnAdd(obj)
 	}
 
-	return handlerID, nil
+	return handler, nil
 }
 
-func (wf *WatchFactory) removeHandler(objType reflect.Type, handlerID uint64) error {
+func (wf *WatchFactory) removeHandler(objType reflect.Type, handler *Handler) error {
 	inf, ok := wf.informers[objType]
 	if !ok {
 		return fmt.Errorf("tried to remove unknown object type %v event handler", objType)
 	}
 
-	inf.Lock()
-	defer inf.Unlock()
-	if _, ok := inf.handlers[handlerID]; !ok {
-		return fmt.Errorf("tried to remove unknown object type %v event handler %d", objType, handlerID)
+	if !atomic.CompareAndSwapUint32(&handler.tombstone, handlerAlive, handlerDead) {
+		// Already removed
+		return fmt.Errorf("tried to remove already removed object type %v event handler %d", objType, handler.id)
 	}
-	delete(inf.handlers, handlerID)
-	logrus.Debugf("removed %v event handler %d", objType, handlerID)
+
+	logrus.Debugf("sending %v event handler %d for removal", objType, handler.id)
+
+	go func() {
+		inf.Lock()
+		defer inf.Unlock()
+		if _, ok := inf.handlers[handler.id]; ok {
+			// Remove the handler
+			delete(inf.handlers, handler.id)
+			logrus.Debugf("removed %v event handler %d", objType, handler.id)
+		} else {
+			logrus.Warningf("tried to remove unknown object type %v event handler %d", objType, handler.id)
+		}
+	}()
+
 	return nil
 }
 
 // AddPodHandler adds a handler function that will be executed on Pod object changes
-func (wf *WatchFactory) AddPodHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (uint64, error) {
+func (wf *WatchFactory) AddPodHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
 	return wf.addHandler(podType, "", nil, handlerFuncs, processExisting)
 }
 
 // AddFilteredPodHandler adds a handler function that will be executed when Pod objects that match the given filters change
-func (wf *WatchFactory) AddFilteredPodHandler(namespace string, lsel *metav1.LabelSelector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (uint64, error) {
+func (wf *WatchFactory) AddFilteredPodHandler(namespace string, lsel *metav1.LabelSelector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
 	return wf.addHandler(podType, namespace, lsel, handlerFuncs, processExisting)
 }
 
 // RemovePodHandler removes a Pod object event handler function
-func (wf *WatchFactory) RemovePodHandler(handlerID uint64) error {
-	return wf.removeHandler(podType, handlerID)
+func (wf *WatchFactory) RemovePodHandler(handler *Handler) error {
+	return wf.removeHandler(podType, handler)
 }
 
 // AddServiceHandler adds a handler function that will be executed on Service object changes
-func (wf *WatchFactory) AddServiceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (uint64, error) {
+func (wf *WatchFactory) AddServiceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
 	return wf.addHandler(serviceType, "", nil, handlerFuncs, processExisting)
 }
 
 // RemoveServiceHandler removes a Service object event handler function
-func (wf *WatchFactory) RemoveServiceHandler(handlerID uint64) error {
-	return wf.removeHandler(serviceType, handlerID)
+func (wf *WatchFactory) RemoveServiceHandler(handler *Handler) error {
+	return wf.removeHandler(serviceType, handler)
 }
 
 // AddEndpointsHandler adds a handler function that will be executed on Endpoints object changes
-func (wf *WatchFactory) AddEndpointsHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (uint64, error) {
+func (wf *WatchFactory) AddEndpointsHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
 	return wf.addHandler(endpointsType, "", nil, handlerFuncs, processExisting)
 }
 
 // RemoveEndpointsHandler removes a Endpoints object event handler function
-func (wf *WatchFactory) RemoveEndpointsHandler(handlerID uint64) error {
-	return wf.removeHandler(endpointsType, handlerID)
+func (wf *WatchFactory) RemoveEndpointsHandler(handler *Handler) error {
+	return wf.removeHandler(endpointsType, handler)
 }
 
 // AddPolicyHandler adds a handler function that will be executed on NetworkPolicy object changes
-func (wf *WatchFactory) AddPolicyHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (uint64, error) {
+func (wf *WatchFactory) AddPolicyHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
 	return wf.addHandler(policyType, "", nil, handlerFuncs, processExisting)
 }
 
 // RemovePolicyHandler removes a NetworkPolicy object event handler function
-func (wf *WatchFactory) RemovePolicyHandler(handlerID uint64) error {
-	return wf.removeHandler(policyType, handlerID)
+func (wf *WatchFactory) RemovePolicyHandler(handler *Handler) error {
+	return wf.removeHandler(policyType, handler)
 }
 
 // AddNamespaceHandler adds a handler function that will be executed on Namespace object changes
-func (wf *WatchFactory) AddNamespaceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (uint64, error) {
+func (wf *WatchFactory) AddNamespaceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
 	return wf.addHandler(namespaceType, "", nil, handlerFuncs, processExisting)
 }
 
 // AddFilteredNamespaceHandler adds a handler function that will be executed when Namespace objects that match the given filters change
-func (wf *WatchFactory) AddFilteredNamespaceHandler(namespace string, lsel *metav1.LabelSelector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (uint64, error) {
+func (wf *WatchFactory) AddFilteredNamespaceHandler(namespace string, lsel *metav1.LabelSelector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
 	return wf.addHandler(namespaceType, namespace, lsel, handlerFuncs, processExisting)
 }
 
 // RemoveNamespaceHandler removes a Namespace object event handler function
-func (wf *WatchFactory) RemoveNamespaceHandler(handlerID uint64) error {
-	return wf.removeHandler(namespaceType, handlerID)
+func (wf *WatchFactory) RemoveNamespaceHandler(handler *Handler) error {
+	return wf.removeHandler(namespaceType, handler)
 }
 
 // AddNodeHandler adds a handler function that will be executed on Node object changes
-func (wf *WatchFactory) AddNodeHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (uint64, error) {
+func (wf *WatchFactory) AddNodeHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
 	return wf.addHandler(nodeType, "", nil, handlerFuncs, processExisting)
 }
 
 // RemoveNodeHandler removes a Node object event handler function
-func (wf *WatchFactory) RemoveNodeHandler(handlerID uint64) error {
-	return wf.removeHandler(nodeType, handlerID)
+func (wf *WatchFactory) RemoveNodeHandler(handler *Handler) error {
+	return wf.removeHandler(nodeType, handler)
 }

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -2,7 +2,8 @@ package ovn
 
 import (
 	"fmt"
-	util "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	knet "k8s.io/api/networking/v1"
 	"net"
@@ -12,16 +13,16 @@ import (
 
 type namespacePolicy struct {
 	sync.Mutex
-	name             string
-	namespace        string
-	ingressPolicies  []*gressPolicy
-	egressPolicies   []*gressPolicy
-	podHandlerIDList []uint64
-	nsHandlerIDList  []uint64
-	localPods        map[string]bool //pods effected by this policy
-	portGroupUUID    string          //uuid for OVN port_group
-	portGroupName    string
-	deleted          bool //deleted policy
+	name            string
+	namespace       string
+	ingressPolicies []*gressPolicy
+	egressPolicies  []*gressPolicy
+	podHandlerList  []*factory.Handler
+	nsHandlerList   []*factory.Handler
+	localPods       map[string]bool //pods effected by this policy
+	portGroupUUID   string          //uuid for OVN port_group
+	portGroupName   string
+	deleted         bool //deleted policy
 }
 
 type gressPolicy struct {
@@ -255,10 +256,10 @@ func (oc *Controller) deleteNetworkPolicy(
 }
 
 func (oc *Controller) shutdownHandlers(np *namespacePolicy) {
-	for _, id := range np.podHandlerIDList {
-		_ = oc.watchFactory.RemovePodHandler(id)
+	for _, handler := range np.podHandlerList {
+		_ = oc.watchFactory.RemovePodHandler(handler)
 	}
-	for _, id := range np.nsHandlerIDList {
-		_ = oc.watchFactory.RemoveNamespaceHandler(id)
+	for _, handler := range np.nsHandlerList {
+		_ = oc.watchFactory.RemoveNamespaceHandler(handler)
 	}
 }

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -2,7 +2,8 @@ package ovn
 
 import (
 	"fmt"
-	util "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
@@ -607,7 +608,7 @@ func (oc *Controller) handleLocalPodSelectorDelFuncOld(
 func (oc *Controller) handleLocalPodSelectorOld(
 	policy *knet.NetworkPolicy, np *namespacePolicy) {
 
-	id, err := oc.watchFactory.AddFilteredPodHandler(policy.Namespace,
+	h, err := oc.watchFactory.AddFilteredPodHandler(policy.Namespace,
 		&policy.Spec.PodSelector,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -626,7 +627,7 @@ func (oc *Controller) handleLocalPodSelectorOld(
 		return
 	}
 
-	np.podHandlerIDList = append(np.podHandlerIDList, id)
+	np.podHandlerList = append(np.podHandlerList, h)
 
 }
 
@@ -634,7 +635,7 @@ func (oc *Controller) handlePeerPodSelectorOld(
 	policy *knet.NetworkPolicy, podSelector *metav1.LabelSelector,
 	addressSet string, addressMap map[string]bool, np *namespacePolicy) {
 
-	id, err := oc.watchFactory.AddFilteredPodHandler(policy.Namespace,
+	h, err := oc.watchFactory.AddFilteredPodHandler(policy.Namespace,
 		podSelector,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -710,7 +711,7 @@ func (oc *Controller) handlePeerPodSelectorOld(
 		return
 	}
 
-	np.podHandlerIDList = append(np.podHandlerIDList, id)
+	np.podHandlerList = append(np.podHandlerList, h)
 
 }
 
@@ -752,7 +753,7 @@ func (oc *Controller) handlePeerNamespaceSelectorOld(
 	namespaceSelector *metav1.LabelSelector,
 	gress *gressPolicy, np *namespacePolicy) {
 
-	id, err := oc.watchFactory.AddFilteredNamespaceHandler("",
+	h, err := oc.watchFactory.AddFilteredNamespaceHandler("",
 		namespaceSelector,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -793,7 +794,7 @@ func (oc *Controller) handlePeerNamespaceSelectorOld(
 		return
 	}
 
-	np.nsHandlerIDList = append(np.nsHandlerIDList, id)
+	np.nsHandlerList = append(np.nsHandlerList, h)
 
 }
 
@@ -819,8 +820,8 @@ func (oc *Controller) addNetworkPolicyOld(policy *knet.NetworkPolicy) {
 	np.namespace = policy.Namespace
 	np.ingressPolicies = make([]*gressPolicy, 0)
 	np.egressPolicies = make([]*gressPolicy, 0)
-	np.podHandlerIDList = make([]uint64, 0)
-	np.nsHandlerIDList = make([]uint64, 0)
+	np.podHandlerList = make([]*factory.Handler, 0)
+	np.nsHandlerList = make([]*factory.Handler, 0)
 	np.localPods = make(map[string]bool)
 
 	// Go through each ingress rule.  For each ingress rule, create an


### PR DESCRIPTION
It's possible to deadlock if two events come in quick succession,
and one of the events triggers a watch handler removal. In one
specific case:

1) NetworkPolicy added -> addNetworkPolicyOld() -> handleLocalPodSelectorOld()
    ∘ adds pod event handler
2) Pod is deleted from API
    ∘ Pod informer Lock() grabbed
    ∘ handleLocalPodSelectorDelFuncOld()
        ∘ tries to grab np.Lock()
3) NetworkPolicy deleted -> deleteNetworkPolicyOld()
    ∘ grabs np.Lock()
    ∘ shutdownHandlers()
       ∘ RemovePodHandler()
           ‣ tries to grab Pod informer Lock()

Fix the deadlock by setting a tombstone on handlers so they
are not called after they are "removed", but do the removal
from a separate goroutine that can lock/unlock the informer
independently of any of the actual OVN logic.

@rajatchopra @shettyg @JacobTanenbaum @squeed @danwinship