### PR TITLE
ovn version 3 ovnkube.sh and daemonsets

### DIFF
--- a/dist/ansible/ovn-playbook.yaml
+++ b/dist/ansible/ovn-playbook.yaml
@@ -56,10 +56,25 @@
     copy: src=../yaml/ovn-namespace.yaml dest=/root/ovn/yaml/ovn-namespace.yaml
   - name: Copy ovn-policy.yaml
     copy: src=../yaml/ovn-policy.yaml dest=/root/ovn/yaml/ovn-policy.yaml
-  - name: Copy ovn-policy.yaml
+  - name: Copy ovn-setup.sh
     copy:
       src: scripts/ovn-setup.sh
       dest: /root/ovn/scripts/ovn-setup.sh
+      mode: 0755
+  - name: Copy ovn-logs
+    copy:
+      src: scripts/ovn-logs
+      dest: /root/ovn/ovn-logs
+      mode: 0755
+  - name: Copy ovn-display
+    copy:
+      src: scripts/ovn-display
+      dest: /root/ovn/ovn-display
+      mode: 0755
+  - name: Copy ovn-debug
+    copy:
+      src: scripts/ovn-debug
+      dest: /root/ovn/ovn-debug
       mode: 0755
   - name: Copy ovnkube-master.yaml
     template: src=../templates/ovnkube-master.yaml.j2 dest=/root/ovn/yaml/ovnkube-master.yaml

--- a/dist/ansible/scripts/ovn-debug
+++ b/dist/ansible/scripts/ovn-debug
@@ -1,0 +1,53 @@
+#!/bin/bash
+#set -x
+
+# ./ovn-debug [pod]
+# By default all ovn pods are processed
+
+con_node="ovs-daemons ovn-controller ovn-node"
+con_master="run-ovn-northd nb-ovsdb sb-ovsdb ovnkube-master"
+
+if [[ $1 != "" ]] ; then
+  echo $1 | grep master > /dev/null 2>&1
+  if [[ $? == 0 ]] ; then
+    masters=$1
+  else
+    nodes=$1
+  fi
+else
+  nodes=$(oc get po -n ovn-kubernetes | grep ovnkube | grep -v ovnkube-master | awk '{ print $1 }')
+  masters=$(oc get po -n ovn-kubernetes | awk '/ovnkube-master/{print $1}')
+fi
+
+oc get po -n ovn-kubernetes -o wide
+
+con=run-ovn-northd
+for m in ${masters}; do
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "========================================= oc logs -n ovn-kubernetes -c ${con} ${m} ./ovnkube.sh ovn_debug"
+    echo "=============================================================================="
+    oc rsh -n ovn-kubernetes -c ${con} ${m} ./ovnkube.sh ovn_debug
+    echo " "
+    echo " "
+done
+
+echo " "
+echo " "
+echo " "
+echo " "
+
+con=ovn-node
+for n in ${nodes}; do
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "========================================= oc logs -n ovn-kubernetes -c ${con} ${n} ./ovnkube.sh ovn_debug"
+    echo "=============================================================================="
+    oc rsh -n ovn-kubernetes -c ${con} ${n} ./ovnkube.sh ovn_debug
+    echo " "
+    echo " "
+done
+
+exit 0

--- a/dist/ansible/scripts/ovn-display
+++ b/dist/ansible/scripts/ovn-display
@@ -1,0 +1,55 @@
+#!/bin/bash
+#set -x
+
+# ./ovn-display [pod]
+# By defaut all ovn pods are processed, both nodes and masters
+
+con_node="ovs-daemons ovn-controller ovn-node"
+con_master="run-ovn-northd nb-ovsdb sb-ovsdb ovnkube-master"
+
+if [[ $1 != "" ]] ; then
+  echo $1 | grep master > /dev/null 2>&1
+  if [[ $? == 0 ]] ; then
+    masters=$1
+  else
+    nodes=$1
+  fi
+else
+  nodes=$(oc get po -n ovn-kubernetes | grep ovnkube | grep -v ovnkube-master | awk '{ print $1 }')
+  masters=$(oc get po -n ovn-kubernetes | awk '/ovnkube-master/{print $1}')
+fi
+
+oc get po -n ovn-kubernetes -o wide
+
+for m in ${masters}; do
+  for c in ${con_master}; do
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "========================================= oc rsh -n ovn-kubernetes -c ${c} ${m} ./ovnkube.sh display"
+    echo "=============================================================================="
+    oc rsh -n ovn-kubernetes -c ${c} ${m} ./ovnkube.sh display
+    echo " "
+    echo " "
+  done
+done
+
+echo " "
+echo " "
+echo " "
+echo " "
+
+for n in ${nodes}; do
+  for c in ${con_node}; do
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "========================================= oc rsh -n ovn-kubernetes -c ${c} ${n} ./ovnkube.sh display"
+    echo "=============================================================================="
+    oc rsh -n ovn-kubernetes -c ${c} ${n} ./ovnkube.sh display
+    echo " "
+    echo " "
+  done
+done
+
+exit 0

--- a/dist/ansible/scripts/ovn-logs
+++ b/dist/ansible/scripts/ovn-logs
@@ -1,0 +1,55 @@
+#!/bin/bash
+#set -x
+
+# ./ovn-logs [pod]
+# By defaut all ovn pods are processed, both nodes and masters
+
+con_node="ovs-daemons ovn-controller ovn-node"
+con_master="run-ovn-northd nb-ovsdb sb-ovsdb ovnkube-master"
+
+if [[ $1 != "" ]] ; then
+  echo $1 | grep master > /dev/null 2>&1
+  if [[ $? == 0 ]] ; then
+    masters=$1
+  else
+    nodes=$1
+  fi
+else
+  nodes=$(oc get po -n ovn-kubernetes | grep ovnkube | grep -v ovnkube-master | awk '{ print $1 }')
+  masters=$(oc get po -n ovn-kubernetes | awk '/ovnkube-master/{print $1}')
+fi
+
+oc get po -n ovn-kubernetes -o wide
+
+for m in ${masters}; do
+  for c in ${con_master}; do
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "========================================= oc logs -n ovn-kubernetes -c ${c} ${m}"
+    echo "=============================================================================="
+    oc logs -n ovn-kubernetes -c ${c} ${m}
+    echo " "
+    echo " "
+  done
+done
+
+echo " "
+echo " "
+echo " "
+echo " "
+
+for n in ${nodes}; do
+  for c in ${con_node}; do
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "=============================================================================="
+    echo "========================================= oc logs -n ovn-kubernetes -c ${c} ${n}"
+    echo "=============================================================================="
+    oc logs -n ovn-kubernetes -c ${c} ${n}
+    echo " "
+    echo " "
+  done
+done
+
+exit 0

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -1,5 +1,5 @@
 # ovnkube-master
-# daemonset version 2
+# daemonset version 3
 # starts master daemons, each in a separate container
 # it is run on the master node(s)
 kind: DaemonSet
@@ -42,11 +42,13 @@ spec:
       # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
       # ovs flow for ovn (geneve)
       # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
-      - name: ovn-northd
+
+      # run-ovn-northd - v3
+      - name: run-ovn-northd
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
 
-        command: ["/root/ovnkube.sh", "ovn-northd"]
+        command: ["/root/ovnkube.sh", "run-ovn-northd"]
 
         securityContext:
           runAsUser: 0
@@ -94,9 +96,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "2"
-        - name: OVN_MASTER
-          value: "true"
+          value: "3"
         - name: OVN_NORTH
           valueFrom:
             configMapKeyRef:
@@ -136,6 +136,200 @@ spec:
         #   httpGet:
         #     path: /healthz
         #     port: 10257
+        #     scheme: HTTP
+        lifecycle:
+      # end of container
+
+      # nb-ovsdb - v3
+      - name: nb-ovsdb
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "nb-ovsdb"]
+
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        - mountPath: /etc/sysconfig/origin-node
+          name: host-sysconfig-node
+          readOnly: true
+        # Mount the entire run directory for socket access for Docker or CRI-o
+        # TODO: remove
+        - mountPath: /var/run
+          name: host-var-run
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        # ovn db is stored in the pod in /etc/openvswitch
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+       #  readOnly: false
+        - mountPath: /var/run/kubernetes/
+          name: host-var-run-kubernetes
+          readOnly: true
+        # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /host/opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-ovn-kubernetes
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_NORTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnNorth
+        - name: OVN_SOUTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnSouth
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - name: healthz
+          containerPort: 10256
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10256
+        #     scheme: HTTP
+        lifecycle:
+      # end of container
+
+      # sb-ovsdb - v3
+      - name: sb-ovsdb
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "sb-ovsdb"]
+
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        - mountPath: /etc/sysconfig/origin-node
+          name: host-sysconfig-node
+          readOnly: true
+        # Mount the entire run directory for socket access for Docker or CRI-o
+        # TODO: remove
+        - mountPath: /var/run
+          name: host-var-run
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        # ovn db is stored in the pod in /etc/openvswitch
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+       #  readOnly: false
+        - mountPath: /var/run/kubernetes/
+          name: host-var-run-kubernetes
+          readOnly: true
+        # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /host/opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-ovn-kubernetes
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_NORTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnNorth
+        - name: OVN_SOUTH
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: OvnSouth
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - name: healthz
+          containerPort: 10255
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10255
         #     scheme: HTTP
         lifecycle:
       # end of container
@@ -192,7 +386,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "2"
+          value: "3"
         - name: OVN_MASTER
           value: "true"
         - name: OVNKUBE_LOGLEVEL
@@ -228,14 +422,14 @@ spec:
               fieldPath: spec.nodeName
         ports:
         - name: healthz
-          containerPort: 10256
+          containerPort: 10254
         # TODO: Temporarily disabled until we determine how to wait for clean default
         # config
         # livenessProbe:
         #   initialDelaySeconds: 10
         #   httpGet:
         #     path: /healthz
-        #     port: 10256
+        #     port: 10254
         #     scheme: HTTP
         lifecycle:
       # end of container

--- a/dist/templates/ovnkube.yaml.j2
+++ b/dist/templates/ovnkube.yaml.j2
@@ -67,6 +67,9 @@ spec:
           limits:
             cpu: 200m
             memory: 400Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
 
 
       # firewall rules for ovn - assumed to be setup
@@ -125,7 +128,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "2"
+          value: "3"
         - name: OVNKUBE_LOGLEVEL
           value: "4"
         - name: OVN_NORTH
@@ -167,7 +170,7 @@ spec:
         #   initialDelaySeconds: 10
         #   httpGet:
         #     path: /healthz
-        #     port: 10256
+        #     port: 10258
         #     scheme: HTTP
         lifecycle:
 
@@ -220,7 +223,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "2"
+          value: "3"
         - name: OVNKUBE_LOGLEVEL
           value: "5"
         - name: OVN_NORTH
@@ -262,7 +265,7 @@ spec:
         #   initialDelaySeconds: 10
         #   httpGet:
         #     path: /healthz
-        #     port: 10256
+        #     port: 10259
         #     scheme: HTTP
         lifecycle:
 


### PR DESCRIPTION
Separate containers for northd and the nb and sb databases
Change display target to list pid and log for the container

General cleanups and restructuring:
- daemon output to stdout so oc logs can display it.
- Restart when a daemon fails.
- Add scripts to get logs and ovn debug info from all nodes.
- document changes: READMEopenshifttechpreview.md

SDN-119 The OVN daemonset should be reliable and easy to debug
SDN-110 Split daemonset in to multiple containers
SDN-114 Separate master and node components in to two daemonsets
SDN-221 Write daemonset templates for OVN
SDN-195 Split daemonset in to *even more* containers.
SDN-193 OVN: improve logging and error handling
https://jira.coreos.com/browse/SDN-193

Signed-off-by: Phil Cameron <pcameron@redhat.com>