### PR TITLE
Return proper exit code for make check

### DIFF
--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -16,5 +16,7 @@ fi
 GO=`which go`
 # sudo is required because some testcases manipulate network namespaces
 sudo -E bash -c "umask 0; CGO_ENABLED=0 ${GO} test "${goflags[@]:+${goflags[@]}}" ${PKGS}"
+retcode=$?
 
 popd
+exit $retcode


### PR DESCRIPTION
In the test-go.sh the last command is popd which will be the exit
code of the script. This means that even if running the actual tests
will fail, the exit code of the script will always be 0.

This change will also fix travis ci to fail when tests are failing.

Signed-off-by: Alin-Gheorghe Balutoiu <alinbalutoiu@gmail.com>

Example where this can be seen: https://travis-ci.org/openvswitch/ovn-kubernetes/builds/452974514