### PR TITLE
dockerfile: add the missing package gawk to ubuntu dockerfile

### DIFF
--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -13,7 +13,7 @@ FROM ubuntu:18.04
 USER root
 
 RUN apt-get update
-RUN apt-get install -y iptables iproute2 curl software-properties-common
+RUN apt-get install -y iptables iproute2 curl gawk software-properties-common
 
 # We do not have much control over the exact version of OVS/OVN that can be
 # obtained from upstream Ubuntu. guru@ovn.org maintains more latest versions of


### PR DESCRIPTION
Without gawk, we are seeing this error inside of the OVN daemonsets:

{"log":"/root/ovnkube.sh: line 261: gawk: command not found\n","stream":"stderr","time":"2018-11-14T06:34:05.453256293Z"}