### PR TITLE
Allocate gateway router port addresses dynamically

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -74,8 +74,8 @@ var _ = Describe("Gateway Init Operations", func() {
 				nodeName          string = "node1"
 				lrpMAC            string = "00:00:00:05:46:C3"
 				brLocalnetMAC     string = "11:22:33:44:55:66"
-				lrpIP             string = "100.64.1.3"
-				lrpCIDR           string = lrpIP + "/24"
+				lrpIP             string = "100.64.0.3"
+				lrpCIDR           string = lrpIP + "/16"
 				clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
 				systemID          string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
 				tcpLBUUID         string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
@@ -118,18 +118,18 @@ var _ = Describe("Gateway Init Operations", func() {
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join external-ids:join-subnet-prefix-length",
-				Output: "24",
+				Output: "16",
 			})
 			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
 				"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + lrpMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
 				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.1.1",
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.0.1",
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 				Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
 				Output: fmt.Sprintf(`GR_openshift-node-2      chassis=5befb1e1-b0b1-4277-bb1d-54e8732a39c6 lb_force_snat_ip=%s
-GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_snat_ip=100.64.1.2
-GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.1.4`, lrpIP),
+GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_snat_ip=100.64.0.2
+GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.4`, lrpIP),
 			})
 			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
@@ -254,8 +254,8 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				const (
 					nodeName          string = "node1"
 					lrpMAC            string = "00:00:00:05:46:C3"
-					lrpIP             string = "100.64.1.3"
-					lrpCIDR           string = lrpIP + "/24"
+					lrpIP             string = "100.64.0.3"
+					lrpCIDR           string = lrpIP + "/16"
 					clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
 					systemID          string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
 					tcpLBUUID         string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
@@ -317,18 +317,18 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				})
 				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join external-ids:join-subnet-prefix-length",
-					Output: "24",
+					Output: "16",
 				})
 				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
 					"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + lrpMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
 					"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
-					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.1.1",
+					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.0.1",
 				})
 				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 					Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
 					Output: fmt.Sprintf(`GR_openshift-node-2      chassis=5befb1e1-b0b1-4277-bb1d-54e8732a39c6 lb_force_snat_ip=%s
-GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_snat_ip=100.64.1.2
-GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.1.4`, lrpIP),
+GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_snat_ip=100.64.0.2
+GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.4`, lrpIP),
 				})
 				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
 					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
@@ -470,8 +470,8 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 				const (
 					nodeName          string = "node1"
 					lrpMAC            string = "00:00:00:05:46:C3"
-					lrpIP             string = "100.64.1.3"
-					lrpCIDR           string = lrpIP + "/24"
+					lrpIP             string = "100.64.0.3"
+					lrpCIDR           string = lrpIP + "/16"
 					clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
 					systemID          string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
 					tcpLBUUID         string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
@@ -506,18 +506,18 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 				})
 				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join external-ids:join-subnet-prefix-length",
-					Output: "24",
+					Output: "16",
 				})
 				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
 					"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + lrpMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
 					"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
-					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.1.1",
+					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.0.1",
 				})
 				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 					Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
 					Output: fmt.Sprintf(`GR_openshift-node-2      chassis=5befb1e1-b0b1-4277-bb1d-54e8732a39c6 lb_force_snat_ip=%s
-GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_snat_ip=100.64.1.2
-GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.1.4`, lrpIP),
+GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_snat_ip=100.64.0.2
+GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.4`, lrpIP),
 				})
 				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
 					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,

--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				nodeName          string = "node1"
 				lrpMAC            string = "00:00:00:05:46:C3"
 				brLocalnetMAC     string = "11:22:33:44:55:66"
-				lrpIP             string = "100.64.2.3"
+				lrpIP             string = "100.64.1.3"
 				lrpCIDR           string = lrpIP + "/24"
 				clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
 				systemID          string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
@@ -106,17 +106,33 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2",
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-" + gwRouter + " mac",
-				Output: lrpMAC,
-			})
-			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_router_port rtoj-" + gwRouter + " networks",
-				Output: "[" + lrpCIDR + "]",
+				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+				Output: "",
 			})
 			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=\"" + lrpMAC + "\"",
+				"ovn-nbctl --timeout=15 --wait=sb --may-exist lsp-add join jtor-GR_" + nodeName + " -- --if-exists clear logical_switch_port jtor-GR_" + nodeName + " dynamic_addresses -- lsp-set-addresses jtor-GR_" + nodeName + " dynamic",
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+				Output: lrpMAC + " " + lrpIP,
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join external-ids:join-subnet-prefix-length",
+				Output: "24",
+			})
+			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+				"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + lrpMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
+				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.1.1",
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 100.64.1.2",
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
+				Output: fmt.Sprintf(`GR_openshift-node-2      chassis=5befb1e1-b0b1-4277-bb1d-54e8732a39c6 lb_force_snat_ip=%s
+GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_snat_ip=100.64.1.2
+GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.1.4`, lrpIP),
+			})
+			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
 			})
 			fakeCmds = addNodeportLBs(nodeName, tcpLBUUID, udpLBUUID, fakeCmds)
 			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
@@ -135,7 +151,6 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 rtoe-" + gwRouter,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
-				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
 			})
 
@@ -239,7 +254,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				const (
 					nodeName          string = "node1"
 					lrpMAC            string = "00:00:00:05:46:C3"
-					lrpIP             string = "100.64.2.3"
+					lrpIP             string = "100.64.1.3"
 					lrpCIDR           string = lrpIP + "/24"
 					clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
 					systemID          string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
@@ -290,17 +305,33 @@ var _ = Describe("Gateway Init Operations", func() {
 					"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + eth0IP,
 				})
 				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-" + gwRouter + " mac",
-					Output: lrpMAC,
-				})
-				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_router_port rtoj-" + gwRouter + " networks",
-					Output: "[" + lrpCIDR + "]",
+					Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+					Output: "",
 				})
 				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
-					"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=\"" + lrpMAC + "\"",
+					"ovn-nbctl --timeout=15 --wait=sb --may-exist lsp-add join jtor-GR_" + nodeName + " -- --if-exists clear logical_switch_port jtor-GR_" + nodeName + " dynamic_addresses -- lsp-set-addresses jtor-GR_" + nodeName + " dynamic",
+				})
+				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+					Output: lrpMAC + " " + lrpIP,
+				})
+				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join external-ids:join-subnet-prefix-length",
+					Output: "24",
+				})
+				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+					"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + lrpMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
+					"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.1.1",
-					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 100.64.1.2",
+				})
+				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+					Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
+					Output: fmt.Sprintf(`GR_openshift-node-2      chassis=5befb1e1-b0b1-4277-bb1d-54e8732a39c6 lb_force_snat_ip=%s
+GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_snat_ip=100.64.1.2
+GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.1.4`, lrpIP),
+				})
+				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
 				})
 				fakeCmds = addNodeportLBs(nodeName, tcpLBUUID, udpLBUUID, fakeCmds)
 				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
@@ -319,7 +350,6 @@ var _ = Describe("Gateway Init Operations", func() {
 					"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + eth0MAC + "\"",
 					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 " + eth0GWIP + " rtoe-" + gwRouter,
 					"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat " + eth0IP + " " + clusterCIDR,
-					"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 					"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
 				})
 				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
@@ -440,7 +470,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 				const (
 					nodeName          string = "node1"
 					lrpMAC            string = "00:00:00:05:46:C3"
-					lrpIP             string = "100.64.2.3"
+					lrpIP             string = "100.64.1.3"
 					lrpCIDR           string = lrpIP + "/24"
 					clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
 					systemID          string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
@@ -464,17 +494,33 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 					"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + eth0IP,
 				})
 				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-" + gwRouter + " mac",
-					Output: lrpMAC,
-				})
-				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_router_port rtoj-" + gwRouter + " networks",
-					Output: "[" + lrpCIDR + "]",
+					Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+					Output: "",
 				})
 				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
-					"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=\"" + lrpMAC + "\"",
+					"ovn-nbctl --timeout=15 --wait=sb --may-exist lsp-add join jtor-GR_" + nodeName + " -- --if-exists clear logical_switch_port jtor-GR_" + nodeName + " dynamic_addresses -- lsp-set-addresses jtor-GR_" + nodeName + " dynamic",
+				})
+				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+					Output: lrpMAC + " " + lrpIP,
+				})
+				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join external-ids:join-subnet-prefix-length",
+					Output: "24",
+				})
+				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+					"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + lrpMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
+					"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.1.1",
-					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 100.64.1.2",
+				})
+				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+					Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
+					Output: fmt.Sprintf(`GR_openshift-node-2      chassis=5befb1e1-b0b1-4277-bb1d-54e8732a39c6 lb_force_snat_ip=%s
+GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_snat_ip=100.64.1.2
+GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.1.4`, lrpIP),
+				})
+				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
 				})
 				fakeCmds = addNodeportLBs(nodeName, tcpLBUUID, udpLBUUID, fakeCmds)
 				fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
@@ -492,7 +538,6 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 					"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + eth0MAC + "\"",
 					"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 " + eth0GWIP + " rtoe-" + gwRouter,
 					"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat " + eth0IP + " " + clusterCIDR,
-					"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 					"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
 				})
 

--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -309,7 +309,12 @@ func (cluster *OvnClusterController) SetupMaster(masterNodeName string) error {
 
 	// Create a logical switch called "join" that will be used to connect gateway routers to the distributed router.
 	// The "join" will be allocated IP addresses in the range 100.64.1.0/24.
-	stdout, stderr, err = util.RunOVNNbctl("--may-exist", "ls-add", "join")
+	joinIP, joinCIDR, _ := net.ParseCIDR("100.64.1.1/24")
+	prefixLen, _ := joinCIDR.Mask.Size()
+	stdout, stderr, err = util.RunOVNNbctl("--may-exist", "ls-add", "join",
+		"--", "set", "logical_switch", "join", fmt.Sprintf("other-config:subnet=%s", joinCIDR.String()),
+		"--", "set", "logical_switch", "join", fmt.Sprintf("other-config:exclude_ips=%s", joinIP.String()),
+		"--", "set", "logical_switch", "join", fmt.Sprintf("external-ids:join-subnet-prefix-length=%d", prefixLen))
 	if err != nil {
 		logrus.Errorf("Failed to create logical switch called \"join\", stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err
@@ -324,8 +329,7 @@ func (cluster *OvnClusterController) SetupMaster(masterNodeName string) error {
 	if routerMac == "" {
 		routerMac = util.GenerateMac()
 		stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lrp-add", OvnClusterRouter,
-			"rtoj-"+OvnClusterRouter, routerMac, "100.64.1.1/24", "--", "set", "logical_router_port",
-			"rtoj-"+OvnClusterRouter, "external_ids:connect_to_join=yes")
+			"rtoj-"+OvnClusterRouter, routerMac, "100.64.1.1/24")
 		if err != nil {
 			logrus.Errorf("Failed to add logical router port rtoj-%v, stdout: %q, stderr: %q, error: %v",
 				OvnClusterRouter, stdout, stderr, err)
@@ -340,15 +344,6 @@ func (cluster *OvnClusterController) SetupMaster(masterNodeName string) error {
 	if err != nil {
 		logrus.Errorf("Failed to add router-type logical switch port to join, stdout: %q, stderr: %q, error: %v",
 			stdout, stderr, err)
-		return err
-	}
-
-	// Create a lock for gateway-init to co-ordinate.
-	stdout, stderr, err = util.RunOVNNbctl("--", "set", "nb_global", ".",
-		"external-ids:gateway-lock=\"\"")
-	if err != nil {
-		logrus.Errorf("Failed to create lock for gateways, "+
-			"stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err
 	}
 

--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -308,8 +308,8 @@ func (cluster *OvnClusterController) SetupMaster(masterNodeName string) error {
 	}
 
 	// Create a logical switch called "join" that will be used to connect gateway routers to the distributed router.
-	// The "join" will be allocated IP addresses in the range 100.64.1.0/24.
-	joinIP, joinCIDR, _ := net.ParseCIDR("100.64.1.1/24")
+	// The "join" switch will be allocated IP addresses in the range 100.64.0.0/16.
+	joinIP, joinCIDR, _ := net.ParseCIDR("100.64.0.1/16")
 	prefixLen, _ := joinCIDR.Mask.Size()
 	stdout, stderr, err = util.RunOVNNbctl("--may-exist", "ls-add", "join",
 		"--", "set", "logical_switch", "join", fmt.Sprintf("other-config:subnet=%s", joinCIDR.String()),
@@ -329,7 +329,7 @@ func (cluster *OvnClusterController) SetupMaster(masterNodeName string) error {
 	if routerMac == "" {
 		routerMac = util.GenerateMac()
 		stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lrp-add", OvnClusterRouter,
-			"rtoj-"+OvnClusterRouter, routerMac, "100.64.1.1/24")
+			"rtoj-"+OvnClusterRouter, routerMac, fmt.Sprintf("%s/%d", joinIP.String(), prefixLen))
 		if err != nil {
 			logrus.Errorf("Failed to add logical router port rtoj-%v, stdout: %q, stderr: %q, error: %v",
 				OvnClusterRouter, stdout, stderr, err)

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -42,12 +42,9 @@ func (ovn *Controller) getDefaultGatewayLoadBalancer(protocol kapi.Protocol) str
 		return outStr
 	}
 
-	var gw string
-	gw, _, _ = util.RunOVNNbctl("--data=bare",
-		"--no-heading", "--columns=name", "find", "logical_router",
-		"options:lb_force_snat_ip=100.64.1.2")
-	if len(gw) == 0 {
-		logrus.Errorf("Error locating default gateway")
+	gw, _, err := util.GetDefaultGatewayRouterIP()
+	if err != nil {
+		logrus.Errorf(err.Error())
 		return ""
 	}
 

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -248,16 +248,11 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		return
 	}
 
+	var podMac, podIP string
 	count := 30
 	for count > 0 {
-		if isStaticIP {
-			out, stderr, err = util.RunOVNNbctl("get",
-				"logical_switch_port", portName, "addresses")
-		} else {
-			out, stderr, err = util.RunOVNNbctl("get",
-				"logical_switch_port", portName, "dynamic_addresses")
-		}
-		if err == nil && out != "[]" {
+		podMac, podIP, err = util.GetPortAddresses(portName, isStaticIP)
+		if err == nil && podMac != "" && podIP != "" {
 			break
 		}
 		if err != nil {
@@ -274,26 +269,15 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		return
 	}
 
-	// static addresses have format ["0a:00:00:00:00:01 192.168.1.3"], while
-	// dynamic addresses have format "0a:00:00:00:00:01 192.168.1.3".
-	outStr := strings.TrimLeft(out, `[`)
-	outStr = strings.TrimRight(outStr, `]`)
-	outStr = strings.Trim(outStr, `"`)
-	addresses := strings.Split(outStr, " ")
-	if len(addresses) != 2 {
-		logrus.Errorf("Error while obtaining addresses for %s", portName)
-		return
-	}
-
 	if !isStaticIP {
-		annotation = fmt.Sprintf(`{\"ip_address\":\"%s/%s\", \"mac_address\":\"%s\", \"gateway_ip\": \"%s\"}`, addresses[1], mask, addresses[0], gatewayIP)
-		logrus.Debugf("Annotation values: ip=%s/%s ; mac=%s ; gw=%s\nAnnotation=%s", addresses[1], mask, addresses[0], gatewayIP, annotation)
+		annotation = fmt.Sprintf(`{\"ip_address\":\"%s/%s\", \"mac_address\":\"%s\", \"gateway_ip\": \"%s\"}`, podIP, mask, podMac, gatewayIP)
+		logrus.Debugf("Annotation values: ip=%s/%s ; mac=%s ; gw=%s\nAnnotation=%s", podMac, mask, podIP, gatewayIP, annotation)
 		err = oc.kube.SetAnnotationOnPod(pod, "ovn", annotation)
 		if err != nil {
 			logrus.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
 		}
 	}
-	oc.addPodToNamespaceAddressSet(pod.Namespace, addresses[1])
+	oc.addPodToNamespaceAddressSet(pod.Namespace, podIP)
 
 	return
 }

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -180,7 +180,7 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 	for _, entry := range clusterIPSubnet {
 		// Add a static route in GR with distributed router as the nexthop.
 		stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
-			gatewayRouter, entry, "100.64.1.1")
+			gatewayRouter, entry, "100.64.0.1")
 		if err != nil {
 			return fmt.Errorf("Failed to add a static route in GR with distributed "+
 				"router as the nexthop, stdout: %q, stderr: %q, error: %v",

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -40,68 +40,77 @@ func getLocalSystemID() (string, error) {
 	return localSystemID, nil
 }
 
-func lockNBForGateways() error {
-	localSystemID, err := getLocalSystemID()
+// GetDefaultGatewayRouterIP returns the first gateway logical router name
+// and IP address as listed in the OVN database
+func GetDefaultGatewayRouterIP() (string, net.IP, error) {
+	stdout, stderr, err := RunOVNNbctl("--data=bare", "--format=table",
+		"--no-heading", "--columns=name,options", "find", "logical_router",
+		"options:lb_force_snat_ip!=-")
 	if err != nil {
-		return err
-	}
-
-	stdout, stderr, err := RunOVNNbctlWithTimeout(60, "--", "wait-until",
-		"nb_global", ".", "external-ids:gateway-lock=\"\"", "--", "set",
-		"nb_global", ".", "external_ids:gateway-lock="+localSystemID)
-	if err != nil {
-		return fmt.Errorf("Failed to set gateway-lock "+
-			"stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-	}
-	return nil
-}
-
-func unlockNBForGateways() {
-	stdout, stderr, err := RunOVNNbctl("--", "set", "nb_global", ".",
-		"external-ids:gateway-lock=\"\"")
-	if err != nil {
-		logrus.Errorf("Failed to delete lock for gateways, "+
-			"stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-	}
-}
-
-func generateGatewayIP() (string, error) {
-	// All the routers connected to "join" switch are in 100.64.1.0/24
-	// network and they have their external_ids:connect_to_join set.
-	stdout, stderr, err := RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=network", "find", "logical_router_port",
-		"external_ids:connect_to_join=yes")
-	if err != nil {
-		logrus.Errorf("Failed to get logical router ports which connect to "+
-			"\"join\" switch, stdout: %q, stderr: %q, error: %v",
-			stdout, stderr, err)
-		return "", err
+		return "", nil, fmt.Errorf("failed to get logical routers, stdout: %q, "+
+			"stderr: %q, err: %v", stdout, stderr, err)
 	}
 	// Convert \r\n to \n to support Windows line endings
 	stdout = strings.Replace(strings.TrimSpace(stdout), "\r\n", "\n", -1)
-	ips := strings.Split(stdout, "\n")
-
-	ipStart, ipStartNet, _ := net.ParseCIDR("100.64.1.0/24")
-	ipMax, _, _ := net.ParseCIDR("100.64.1.255/24")
-	n, _ := ipStartNet.Mask.Size()
-	for !ipStart.Equal(ipMax) {
-		ipStart = NextIP(ipStart)
-		used := 0
-		for _, v := range ips {
-			ipCompare, _, _ := net.ParseCIDR(v)
-			if ipStart.String() == ipCompare.String() {
-				used = 1
-				break
-			}
-		}
-		if used == 1 {
-			continue
-		} else {
+	gatewayRouters := strings.Split(stdout, "\n")
+	if len(gatewayRouters) == 0 {
+		return "", nil, fmt.Errorf("failed to get default gateway router (no routers found)")
+	}
+	parts := strings.Fields(gatewayRouters[0])
+	var ip net.IP
+	for _, p := range parts {
+		const forceTag string = "lb_force_snat_ip="
+		if strings.HasPrefix(p, forceTag) {
+			ip = net.ParseIP(p[len(forceTag):])
 			break
 		}
 	}
-	ipMask := fmt.Sprintf("%s/%d", ipStart.String(), n)
-	return ipMask, nil
+	if ip == nil {
+		return "", nil, fmt.Errorf("failed to parse gateway router %q IP", parts[0])
+	}
+	return parts[0], ip, nil
+}
+
+func ensureGatewayPortAddress(portName string) (string, *net.IPNet, error) {
+	routerMac, routerIP, _ := GetPortAddresses(portName, false)
+	if routerMac == "" || routerIP == "" {
+		// Create the gateway switch port in 'join' if it doesn't exist yet
+		stdout, stderr, err := RunOVNNbctl("--wait=sb",
+			"--may-exist", "lsp-add", "join", portName,
+			"--", "--if-exists", "clear", "logical_switch_port", portName, "dynamic_addresses",
+			"--", "lsp-set-addresses", portName, "dynamic")
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to add logical switch "+
+				"port %s, stdout: %q, stderr: %q, error: %v",
+				portName, stdout, stderr, err)
+		}
+		// Should have an address already since we waited for the SB above
+		routerMac, routerIP, err = GetPortAddresses(portName, false)
+		if err != nil {
+			return "", nil, fmt.Errorf("error while waiting for addresses "+
+				"for gateway switch port %q: %v", portName, err)
+		}
+		if routerMac == "" || routerIP == "" {
+			return "", nil, fmt.Errorf("empty addresses for gateway "+
+				"switch port %q", portName)
+		}
+	}
+
+	// Grab the 'join' switch prefix length to add to our gateway router's IP
+	joinPrefixLen, stderr, err := RunOVNNbctl("--if-exists", "get",
+		"logical_switch", "join", "external-ids:join-subnet-prefix-length")
+	if err != nil {
+		return "", nil, fmt.Errorf("Failed to get 'join' switch external-ids: "+
+			"stderr: %q, %v", stderr, err)
+	}
+	stringCIDR := routerIP + "/" + joinPrefixLen
+	ip, cidr, err := net.ParseCIDR(stringCIDR)
+	if err != nil {
+		return "", nil, fmt.Errorf("Invalid router CIDR %q: %v", stringCIDR, err)
+	}
+	cidr.IP = ip
+
+	return routerMac, cidr, nil
 }
 
 // GatewayInit creates a gateway router for the local chassis.
@@ -142,61 +151,29 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 			"stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
 	}
 
-	// Connect gateway router to switch "join".
-	routerMac, stderr, err := RunOVNNbctl("--if-exist", "get",
-		"logical_router_port", "rtoj-"+gatewayRouter, "mac")
+	gwSwitchPort := "jtor-" + gatewayRouter
+	gwRouterPort := "rtoj-" + gatewayRouter
+	routerMac, routerCIDR, err := ensureGatewayPortAddress(gwSwitchPort)
 	if err != nil {
-		return fmt.Errorf("Failed to get logical router port, stderr: %q, "+
-			"error: %v", stderr, err)
+		return err
 	}
 
-	var routerIP string
-	if routerMac == "" {
-		routerMac = GenerateMac()
-		if err = func() error {
-			err = lockNBForGateways()
-			if err != nil {
-				return err
-			}
-			defer unlockNBForGateways()
-			routerIP, err = generateGatewayIP()
-			if err != nil {
-				return err
-			}
-
-			stdout, stderr, err = RunOVNNbctl("--", "--may-exist", "lrp-add",
-				gatewayRouter, "rtoj-"+gatewayRouter, routerMac, routerIP,
-				"--", "set", "logical_router_port", "rtoj-"+gatewayRouter,
-				"external_ids:connect_to_join=yes")
-			if err != nil {
-				return fmt.Errorf("failed to add logical port to router, stdout: %q, "+
-					"stderr: %q, error: %v", stdout, stderr, err)
-			}
-			return nil
-		}(); err != nil {
-			return err
-		}
-	}
-
-	if routerIP == "" {
-		stdout, stderr, err = RunOVNNbctl("--if-exists", "get",
-			"logical_router_port", "rtoj-"+gatewayRouter, "networks")
-		if err != nil {
-			return fmt.Errorf("failed to get routerIP for %s "+
-				"stdout: %q, stderr: %q, error: %v",
-				"rtoj-"+gatewayRouter, stdout, stderr, err)
-		}
-		routerIP = strings.Trim(stdout, "[]\"")
-	}
-
-	// Connect the switch "join" to the router.
-	stdout, stderr, err = RunOVNNbctl("--", "--may-exist", "lsp-add",
-		"join", "jtor-"+gatewayRouter, "--", "set", "logical_switch_port",
-		"jtor-"+gatewayRouter, "type=router",
-		"options:router-port=rtoj-"+gatewayRouter,
-		"addresses="+"\""+routerMac+"\"")
+	// Must move the IP from the LSP to the LRP and set the LSP addresses
+	// to 'router' in one transaction, because IPAM doesn't consider LSPs that
+	// are attached to routers when checking reserved addresses.
+	stdout, stderr, err = RunOVNNbctl(
+		"--", "--may-exist", "lrp-add", gatewayRouter, gwRouterPort, routerMac, routerCIDR.String(),
+		"--", "set", "logical_switch_port", gwSwitchPort, "type=router",
+		"options:router-port="+gwRouterPort, "addresses=router")
 	if err != nil {
-		return fmt.Errorf("Failed to add logical port to switch, stdout: %q, "+
+		return fmt.Errorf("failed to add logical port to router, stdout: %q, "+
+			"stderr: %q, error: %v", stdout, stderr, err)
+	}
+
+	stdout, stderr, err = RunOVNNbctl("set", "logical_router",
+		gatewayRouter, "options:lb_force_snat_ip="+routerCIDR.IP.String())
+	if err != nil {
+		return fmt.Errorf("Failed to set logical router, stdout: %q, "+
 			"stderr: %q, error: %v", stdout, stderr, err)
 	}
 
@@ -212,8 +189,12 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 	}
 
 	// Add a default route in distributed router with first GR as the nexthop.
+	_, defGatewayIP, err := GetDefaultGatewayRouterIP()
+	if err != nil {
+		return err
+	}
 	stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
-		k8sClusterRouter, "0.0.0.0/0", "100.64.1.2")
+		k8sClusterRouter, "0.0.0.0/0", defGatewayIP.String())
 	if err != nil {
 		return fmt.Errorf("Failed to add a default route in distributed router "+
 			"with first GR as the nexthop, stdout: %q, stderr: %q, error: %v",
@@ -413,35 +394,23 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 	// default for any sane deployment), we need to SNAT traffic
 	// heading to the logical space with the Gateway router's IP so that
 	// return traffic comes back to the same gateway router.
-	if routerIP != "" {
-		routerIPByte, _, err := net.ParseCIDR(routerIP)
-		if err != nil {
-			return err
-		}
-		stdout, stderr, err = RunOVNNbctl("set", "logical_router",
-			gatewayRouter, "options:lb_force_snat_ip="+routerIPByte.String())
-		if err != nil {
-			return fmt.Errorf("Failed to set logical router, stdout: %q, "+
-				"stderr: %q, error: %v", stdout, stderr, err)
-		}
-		if rampoutIPSubnet != "" {
-			rampoutIPSubnets := strings.Split(rampoutIPSubnet, ",")
-			for _, rampoutIPSubnet = range rampoutIPSubnets {
-				_, _, err = net.ParseCIDR(rampoutIPSubnet)
-				if err != nil {
-					continue
-				}
+	if rampoutIPSubnet != "" {
+		rampoutIPSubnets := strings.Split(rampoutIPSubnet, ",")
+		for _, rampoutIPSubnet = range rampoutIPSubnets {
+			_, _, err = net.ParseCIDR(rampoutIPSubnet)
+			if err != nil {
+				continue
+			}
 
-				// Add source IP address based routes in distributed router
-				// for this gateway router.
-				stdout, stderr, err = RunOVNNbctl("--may-exist",
-					"--policy=src-ip", "lr-route-add", k8sClusterRouter,
-					rampoutIPSubnet, routerIPByte.String())
-				if err != nil {
-					return fmt.Errorf("Failed to add source IP address based "+
-						"routes in distributed router, stdout: %q, "+
-						"stderr: %q, error: %v", stdout, stderr, err)
-				}
+			// Add source IP address based routes in distributed router
+			// for this gateway router.
+			stdout, stderr, err = RunOVNNbctl("--may-exist",
+				"--policy=src-ip", "lr-route-add", k8sClusterRouter,
+				rampoutIPSubnet, routerCIDR.IP.String())
+			if err != nil {
+				return fmt.Errorf("Failed to add source IP address based "+
+					"routes in distributed router, stdout: %q, "+
+					"stderr: %q, error: %v", stdout, stderr, err)
 			}
 		}
 	}

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"math/rand"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -31,4 +32,36 @@ func ipToInt(ip net.IP) *big.Int {
 
 func intToIP(i *big.Int) net.IP {
 	return net.IP(i.Bytes())
+}
+
+// GetPortAddresses returns the MAC and IP of the given logical switch port
+func GetPortAddresses(portName string, isStaticIP bool) (string, string, error) {
+	addrType := "dynamic_addresses"
+	if isStaticIP {
+		addrType = "addresses"
+	}
+	out, _, err := RunOVNNbctl("get", "logical_switch_port", portName, addrType)
+	if err != nil {
+		return "", "", fmt.Errorf("Error while obtaining addresses for %s: %v", portName, err)
+	}
+	if out == "[]" {
+		// No addresses
+		return "", "", nil
+	}
+
+	// static addresses have format ["0a:00:00:00:00:01 192.168.1.3"], while
+	// dynamic addresses have format "0a:00:00:00:00:01 192.168.1.3".
+	outStr := strings.Trim(out, `[]`)
+	outStr = strings.Trim(outStr, `"`)
+	addresses := strings.Split(outStr, " ")
+	if len(addresses) != 2 {
+		return "", "", fmt.Errorf("Error while obtaining addresses for %s", portName)
+	}
+	if net.ParseIP(addresses[1]) == nil {
+		return "", "", fmt.Errorf("failed to parse logical switch port %q IP %q", portName, addresses[1])
+	}
+	if _, err := net.ParseMAC(addresses[0]); err != nil {
+		return "", "", fmt.Errorf("failed to parse logical switch port %q MAC %q: %v", portName, addresses[0], err)
+	}
+	return addresses[0], addresses[1], nil
 }


### PR DESCRIPTION
Instead of generating addresses in the 100.64.1.x range (eg, things connected to the 'join' switch, eg gateway routers) manually with locking, just let OVN dynamically allocate them.

@shettyg @rajatchopra @danwinship