### PR TITLE
Disable IPv6 for Windows agents

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -30,6 +30,8 @@ Note: minimum required ansible version is 2.4.2.0
 
 ### Known issues
 
+- Windows containers do not support IPv6 at the moment. You can read more [here](https://docs.microsoft.com/en-us/virtualization/windowscontainers/container-networking/architecture#unsupported-features-and-network-options)
+
 - Warning: the firewall on Windows gets disabled for this test
 
 ## Ansible requirements

--- a/contrib/roles/windows/requirements/tasks/main.yml
+++ b/contrib/roles/windows/requirements/tasks/main.yml
@@ -1,4 +1,32 @@
 ---
+- name: Windows | include vars
+  include_vars: "{{ ansible_os_family|lower }}.yml"
+
+- name: Windows | Expect reboot_required to false
+  set_fact:
+    reboot_required: false
+
+- name: Windows | Get the IPv6 disable flags
+  win_reg_stat:
+    path: '{{ ipv6.reg_path }}'
+    name: '{{ ipv6.disable_flags_reg_name }}'
+  register: ipv6_flags
+
+- name: Windows | Disable IPv6 (if not already disabled)
+  block:
+    - name: Windows | Set the IPv6 disable flags
+      win_regedit:
+        path: '{{ ipv6.reg_path }}'
+        name: '{{ ipv6.disable_flags_reg_name }}'
+        data: '{{ ipv6.disable_flags_reg_value }}'
+        type: dword
+    - name: Windows | Set reboot_required to true for the IPv6 disable
+      set_fact:
+        reboot_required: true
+  when: (not ipv6_flags.exists or
+         ipv6_flags.type != 'REG_DWORD' or
+         ipv6_flags.raw_value != ipv6.disable_flags_reg_value)
+
 - name: Windows | Installing Required features
   win_feature:
     name: "{{item}}"
@@ -6,10 +34,6 @@
   register: features_installed
   with_items:
     - Containers
-
-- name: Windows | Expect reboot_required to false
-  set_fact:
-    reboot_required: false
 
 - name: Windows | Checking if reboot_required
   set_fact:

--- a/contrib/roles/windows/requirements/vars/windows.yml
+++ b/contrib/roles/windows/requirements/vars/windows.yml
@@ -1,0 +1,5 @@
+---
+ipv6:
+  reg_path: HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters
+  disable_flags_reg_name: DisabledComponents
+  disable_flags_reg_value: 4294967295  # Integer value for: 0xffffffff


### PR DESCRIPTION
This PR adds the Ansible logic `windows/requirements` to disable IPv6 on all the Windows agents.

This fixes https://github.com/openvswitch/ovn-kubernetes/issues/491.