### PR TITLE
Ansible: Update ovs and build

### DIFF
--- a/contrib/roles/linux/openvswitch/tasks/build_install_release_ovs.yml
+++ b/contrib/roles/linux/openvswitch/tasks/build_install_release_ovs.yml
@@ -19,6 +19,11 @@
     timeout: 30
   retries: 3
 
+- name: OVS | Remove remove directory if exists
+  file:
+    path: "{{ ovs_info.build_path }}/{{ ovs_info.release_name }}"
+    state: absent
+
 - name: OVS | unarchive tar.gz
   unarchive:
     src: "{{ ovs_info.build_path }}/{{ ovs_info.release_name }}.tar.gz"
@@ -26,7 +31,7 @@
     remote_src: yes
 
 - name: OVS | build debs
-  action: shell cd {{ ovs_info.build_path }}/{{ ovs_info.release_name }}; make clean; make uninstall; dpkg-checkbuilddeps; fakeroot debian/rules clean; DEB_BUILD_OPTIONS='nocheck parallel=4' fakeroot debian/rules binary
+  action: shell cd {{ ovs_info.build_path }}/{{ ovs_info.release_name }}; dpkg-checkbuilddeps; fakeroot debian/rules clean; DEB_BUILD_OPTIONS='nocheck parallel=4' fakeroot debian/rules binary
 
 - name: OVS | install debs
   apt: deb="{{ ovs_info.build_path }}/{{item}}{{ ovs_info.pkg_build_version }}_amd64.deb"

--- a/contrib/roles/linux/openvswitch/vars/ubuntu.yml
+++ b/contrib/roles/linux/openvswitch/vars/ubuntu.yml
@@ -29,11 +29,11 @@ ovs_info:
   modules_file_path: /etc/modules-load.d/modules.conf
   branch: branch-2.9
   service_path: /etc/systemd/system/openvswitch.service
-  release_link: http://openvswitch.org/releases/openvswitch-2.9.2.tar.gz
-  release_name: openvswitch-2.9.2
-  pkg_build_version: 2.9.2-1
+  release_link: http://openvswitch.org/releases/openvswitch-2.10.1.tar.gz
+  release_name: openvswitch-2.10.1
+  pkg_build_version: 2.10.1-1
   # Prebuilt packages info and download link
   install_prebuilt_packages: "{{ovs_install_prebuilt_packages | default(false)}}"
   prebuilt_packages_download_path: /tmp
-  prebuilt_version: "2.9.2-1"
+  prebuilt_version: "2.10.1-1"
   debs_targz_link: "replace_me"


### PR DESCRIPTION
Bump OVS version to 2.10 - needed for Ubuntu 18.04.
Fix hang when building debs.