### PR TITLE
Fix creation of the subnet allocated map on master startup

### DIFF
--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -224,9 +224,13 @@ func (cluster *OvnClusterController) StartClusterMaster(masterNodeName string) e
 	// but omitting any that exist in 'subrange' (third argument)
 	for _, clusterEntry := range cluster.ClusterIPNet {
 		subrange := make([]string, 0)
-		for _, entry := range alreadyAllocated {
-			if clusterEntry.CIDR.Contains(net.ParseIP(entry)) {
-				subrange = append(subrange, entry)
+		for _, allocatedRange := range alreadyAllocated {
+			firstAddress, _, err := net.ParseCIDR(allocatedRange)
+			if err != nil {
+				return err
+			}
+			if clusterEntry.CIDR.Contains(firstAddress) {
+				subrange = append(subrange, allocatedRange)
 			}
 		}
 		subnetAllocator, err := netutils.NewSubnetAllocator(clusterEntry.CIDR.String(), 32-clusterEntry.HostSubnetLength, subrange)


### PR DESCRIPTION
currently when starting the ovn kubernetes master in the function
StartClusterMaster() when building a list of already allocated
subnets net.ParseIP() is incorrectly used on a CIDR which returns nil
and causes an empty list to be passed when building subnetAllocator structs

Correcting this behavior by calling net.ParseCIDR on allocated hostsubnets
and check if ranges contain that address to correctly build the list of already
allocated hostsubnets

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

Corrects Issue: https://github.com/openvswitch/ovn-kubernetes/issues/463