### PR TITLE
gateway: enable NodePort for localnet gateway

### DIFF
--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -31,7 +31,8 @@ func getIPv4Address(iface string) (string, error) {
 func (cluster *OvnClusterController) initGateway(
 	nodeName string, clusterIPSubnet []string, subnet string) error {
 	if cluster.LocalnetGateway {
-		return initLocalnetGateway(nodeName, clusterIPSubnet, subnet)
+		return initLocalnetGateway(nodeName, clusterIPSubnet, subnet,
+			cluster.NodePortEnable)
 	}
 
 	if cluster.GatewayNextHop == "" || cluster.GatewayIntf == "" {

--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -78,6 +78,8 @@ var _ = Describe("Gateway Init Operations", func() {
 				lrpCIDR           string = lrpIP + "/24"
 				clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
 				systemID          string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
+				tcpLBUUID         string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
+				udpLBUUID         string = "12832f14-eb0f-44d4-b8db-4cccbc73c792"
 				nodeSubnet        string = "10.1.1.0/24"
 				gwRouter          string = "GR_" + nodeName
 				clusterIPNet      string = "10.1.0.0"
@@ -115,6 +117,9 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=\"" + lrpMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.1.1",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 100.64.1.2",
+			})
+			fakeCmds = addNodeportLBs(nodeName, tcpLBUUID, udpLBUUID, fakeCmds)
+			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
 				"ovn-nbctl --timeout=15 --may-exist ls-add ext_" + nodeName,
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
@@ -149,7 +154,7 @@ var _ = Describe("Gateway Init Operations", func() {
 
 			ipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
 			Expect(err).NotTo(HaveOccurred())
-			err = initLocalnetGatewayInternal(nodeName, []string{clusterCIDR}, nodeSubnet, ipt)
+			err = initLocalnetGatewayInternal(nodeName, []string{clusterCIDR}, nodeSubnet, ipt, true)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CommandCalls).To(Equal(len(fakeCmds)))

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -85,16 +85,17 @@ func localnetGatewayNAT(ipt util.IPTablesHelper, ifname, ip string) error {
 }
 
 func initLocalnetGateway(nodeName string, clusterIPSubnet []string,
-	subnet string) error {
+	subnet string, nodePortEnable bool) error {
 	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 	if err != nil {
 		return fmt.Errorf("failed to initialize iptables: %v", err)
 	}
-	return initLocalnetGatewayInternal(nodeName, clusterIPSubnet, subnet, ipt)
+	return initLocalnetGatewayInternal(nodeName, clusterIPSubnet, subnet, ipt,
+		nodePortEnable)
 }
 
 func initLocalnetGatewayInternal(nodeName string, clusterIPSubnet []string,
-	subnet string, ipt util.IPTablesHelper) error {
+	subnet string, ipt util.IPTablesHelper, nodePortEnable bool) error {
 	// Create a localnet OVS bridge.
 	localnetBridgeName := "br-localnet"
 	_, stderr, err := util.RunOVSVsctl("--may-exist", "add-br",
@@ -141,7 +142,7 @@ func initLocalnetGatewayInternal(nodeName string, clusterIPSubnet []string,
 
 	err = util.GatewayInit(clusterIPSubnet, nodeName,
 		localnetGatewayIP, "", localnetBridgeName, localnetGatewayNextHop,
-		subnet, false)
+		subnet, nodePortEnable)
 	if err != nil {
 		return fmt.Errorf("failed to localnet gateway: %v", err)
 	}

--- a/go-controller/pkg/cluster/gateway_localnet_windows.go
+++ b/go-controller/pkg/cluster/gateway_localnet_windows.go
@@ -7,7 +7,7 @@ import (
 )
 
 func initLocalnetGateway(nodeName string, clusterIPSubnet []string,
-	subnet string) error {
+	subnet string, nodePortEnable bool) error {
 	// TODO: Implement this
 	return fmt.Errorf("Not implemented yet on Windows")
 }


### PR DESCRIPTION
Let the default gateway still create load balancer for nodeport/external-ip even
if the type is of localnet.

Rebase/fixup of https://github.com/openvswitch/ovn-kubernetes/pull/462

TODO:
 - [ ] Routing rules on the host to enable external-ip traffic to localnet device
 - [ ] iptables/firewall/dnat rules to enable nodeport on host translated to localnet device 

@shettyg @rajatchopra 