### PR TITLE
Rename the distributed router to ovn_cluster_router

### DIFF
--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -44,6 +44,8 @@ const (
 	DefaultNamespace = "default"
 	// MasterOverlayIP is the overlay IP address on master node
 	MasterOverlayIP = "master_overlay_ip"
+	// Name of the distributed router
+	OvnClusterRouter = "ovn_cluster_router"
 )
 
 // NewClusterController creates a new controller for IP subnet allocation to


### PR DESCRIPTION
In the OVN topology that is build, the name of the K8s master node's
Logical Switch and the name of the distributed router for the entire
K8s cluster are same. For example: if the hostname of the K8s master
node is k8s-ubuntu-master, then we will have two OVN resources -- one
logical switch and one logical router -- that will be named as
k8s-ubuntu-master.

This causes some issues while displaying the logical flows for the OVN
resources as can be seen below (just an example of one of the issues).

\ # ovn-sbctl lflow-list k8s-ubuntu-master
 ovn-sbctl: multiple rows in Datapath_Binding match "k8s-ubuntu-master"

To resolve the above problem, one would need to resort to UUID of the
OVN resource.

Fixes ovn-kubernetes issue #484

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>