### PR TITLE
add source debug build options

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -3,12 +3,18 @@ export OUT_DIR
 PREFIX ?= ${DESTDIR}/usr
 BINDIR ?= ${PREFIX}/bin
 CNIBINDIR ?= ${DESTDIR}/opt/cni/bin
+GCFLAGS ?=
+export GCFLAGS
 
 .PHONY: all build check test
 
 # Example:
 #   make
 #   make all
+#   make all GCFLAGS="-N -l"
+#       (disables compiler optimization and inlining to aid source debugging tools
+#        like delve)
+
 
 all build:
 	hack/build-go.sh cmd/ovnkube/ovnkube.go

--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -18,7 +18,7 @@ build_binaries() {
     export GOBIN="${OVN_KUBE_OUTPUT_BINPATH}"
 
     # Add a buildid to the executable - needed by rpmbuild
-    go install -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" "${OVN_KUBE_BINARIES[@]}";
+    go install -gcflags "${GCFLAGS}" -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" "${OVN_KUBE_BINARIES[@]}";
 }
 
 build_windows_binaries() {


### PR DESCRIPTION
In order to use tools like delve successfully we need to disable some
compiler optimizations from the go binaries. This commit adds support
for the same.

Since, there are subtle differences in how this optimizations can be
achieved based on the version of the go compiler in use, I did not create
a `debug` target. For example:

Go 1.8.1:
    -gcflags 'arg list' ==> use '-N -l'

Go 1.11.2:
   	-gcflags '[pattern=]arg list'  ==> use 'all="-N -l"'

Instead of a 'debug' Makefile target, the developer needs to invoke
make like below:

$ make GCFLAGS="-N -l"
(if you use, GCFLAGS=all="-N -l", then the dependent packages are also
compiled with these flags)

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>