### PR TITLE
delete old ovn-controller control connection file (.ctl files)

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -501,6 +501,7 @@ ovn-controller () {
 
   echo "=============== ovn-controller"
   rm -f /var/run/ovn-kubernetes/cni/*
+  rm -f /var/run/openvswitch/ovn-controller.*.ctl
   /usr/share/openvswitch/scripts/ovn-ctl --no-monitor start_controller \
     ${ovn_controller_opts}
   echo "=============== ovn-controller ========== running"
@@ -605,6 +606,7 @@ start_ovn () {
   wait_for_northdb
   echo "=============== start ovn-controller"
   rm -f /var/run/ovn-kubernetes/cni/*
+  rm -f /var/run/openvswitch/ovn-controller.*.ctl
   /usr/share/openvswitch/scripts/ovn-ctl --no-monitor start_controller \
     ${ovn_controller_opts}
 


### PR DESCRIPTION
after several iteration of node reset and delete, i ended up with ton
of ovn-controller.PID.ctl files in /var/run/openvswitch

...
...
srwxr-x--- 1 root root 0 Dec  4 07:09 /var/run/openvswitch/ovn-controller.56009.ctl
srwxr-x--- 1 root root 0 Dec  4 07:07 /var/run/openvswitch/ovn-controller.51498.ctl
srwxr-x--- 1 root root 0 Dec  4 07:05 /var/run/openvswitch/ovn-controller.45440.ctl
srwxr-x--- 1 root root 0 Dec  4 07:02 /var/run/openvswitch/ovn-controller.39742.ctl
srwxr-x--- 1 root root 0 Dec  4 06:59 /var/run/openvswitch/ovn-controller.34090.ctl
srwxr-x--- 1 root root 0 Dec  3 22:21 /var/run/openvswitch/ovn-controller.940.ctl
srwxr-x--- 1 root root 0 Dec  3 22:11 /var/run/openvswitch/ovn-controller.76009.ctl
...
...

 this commit removes these files before it starts ovn_controller daemon

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>