### PR TITLE
OVN start containers properly, improve logs

### DIFF
--- a/dist/ansible/ovn-uninstall.yaml
+++ b/dist/ansible/ovn-uninstall.yaml
@@ -54,3 +54,9 @@
     file:
       state: absent
       name: /etc/cni/net.d/10-ovn-kubernetes.conf
+
+  - name: Remove old log files
+    shell: rm -rf /var/log/openvswitch/ovn*log /var/log/openvswitch/ovs*log
+
+  - name: remove old unix sockets
+    shell: rm -rf /var/run/openvswitch/ovn*ctl /var/run/openvswitch/ovn*pid /var/run/openvswitch/ovs*ctl /var/run/openvswitch/ovs*pid

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -73,6 +73,8 @@ spec:
           name: host-var-lib-ovs
         - mountPath: /var/lib/openvswitch/
           name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
        #  readOnly: false
@@ -97,6 +99,8 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
+        - name: OVN_LOG_NORTHD
+          value: "-vconsole:info"
         - name: OVN_NORTH
           valueFrom:
             configMapKeyRef:
@@ -170,6 +174,8 @@ spec:
           name: host-var-lib-ovs
         - mountPath: /var/lib/openvswitch/
           name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
        #  readOnly: false
@@ -194,6 +200,8 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
+        - name: OVN_LOG_NB
+          value: "-vconsole:info -vfile:info"
         - name: OVN_NORTH
           valueFrom:
             configMapKeyRef:
@@ -267,6 +275,8 @@ spec:
           name: host-var-lib-ovs
         - mountPath: /var/lib/openvswitch/
           name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
        #  readOnly: false
@@ -291,6 +301,8 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
+        - name: OVN_LOG_SB
+          value: "-vconsole:info -vfile:info"
         - name: OVN_NORTH
           valueFrom:
             configMapKeyRef:
@@ -363,6 +375,8 @@ spec:
           name: host-var-lib-ovs
         - mountPath: /var/lib/openvswitch/
           name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
        #  readOnly: false
@@ -456,6 +470,9 @@ spec:
       - name: host-var-lib-ovs
         hostPath:
           path: /var/lib/openvswitch
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
       - name: host-var-run-ovs
         hostPath:
           path: /var/run/openvswitch

--- a/dist/templates/ovnkube.yaml.j2
+++ b/dist/templates/ovnkube.yaml.j2
@@ -105,6 +105,8 @@ spec:
           readOnly: true
         - mountPath: /var/lib/openvswitch/
           name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
        #  readOnly: false
@@ -200,6 +202,8 @@ spec:
           readOnly: true
         - mountPath: /var/lib/openvswitch/
           name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
        #  readOnly: false
@@ -291,6 +295,9 @@ spec:
       - name: host-var-lib-ovs
         hostPath:
           path: /var/lib/openvswitch
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
       - name: host-run-ovs
         hostPath:
           path: /run/openvswitch


### PR DESCRIPTION
The ovn northd and the nb and sb database containers now start properly.
Improved logging in northd, ovnsdb and ovnndb.
Cleanup /var/run/openvswitch files and /var/log/openvswitch files during
uninstall.

Signed-off-by: Phil Cameron <pcameron@redhat.com>