### PR TITLE
windows: Fixes MAC fetching during gateway-init

### DIFF
--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -3,7 +3,6 @@ package ovn
 import (
 	"fmt"
 	"net"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -283,15 +282,10 @@ func CreateManagementPort(nodeName, localSubnet,
 	}
 
 	if runtime.GOOS == windowsOS && macAddress == "00:00:00:00:00:00" {
-		var stdoutStderr []byte
-		stdoutStderr, err = exec.Command("powershell", "$(Get-NetAdapter", "-IncludeHidden", "|", "Where", "{", "$_.Name",
-			"-Match", fmt.Sprintf("\"%s\"", interfaceName), "}).MacAddress").CombinedOutput()
+		macAddress, err = util.FetchIfMacWindows(interfaceName)
 		if err != nil {
-			logrus.Errorf("Failed to get mac address of ovn-k8s-master, stderr: %q, error: %v", fmt.Sprintf("%s", stdoutStderr), err)
 			return err
 		}
-		// Windows returns it in 00-00-00-00-00-00 format, we want ':' instead of '-'
-		macAddress = strings.Replace(strings.TrimSpace(fmt.Sprintf("%s", stdoutStderr)), "-", ":", -1)
 	}
 
 	// Create the OVN logical port.

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"net"
+	"runtime"
 	"strings"
 )
 
@@ -318,6 +319,12 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 		}
 		if macAddress == "" {
 			return fmt.Errorf("No mac_address found for the bridge-interface")
+		}
+		if runtime.GOOS == windowsOS && macAddress == "00:00:00:00:00:00" {
+			macAddress, err = FetchIfMacWindows(bridgeInterface)
+			if err != nil {
+				return err
+			}
 		}
 		stdout, stderr, err = RunOVSVsctl("set", "bridge",
 			bridgeInterface, "other-config:hwaddr="+macAddress)

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -2,6 +2,9 @@ package util
 
 import (
 	"fmt"
+	"os/exec"
+	"strings"
+
 	"github.com/urfave/cli"
 )
 
@@ -12,4 +15,19 @@ func StringArg(context *cli.Context, name string) (string, error) {
 		return "", fmt.Errorf("argument --%s should be non-null", name)
 	}
 	return val, nil
+}
+
+// FetchIfMacWindows gets the mac of the interfaceName via powershell commands
+// There is a known issue with OVS not correctly picking up the
+// physical network interface MAC address.
+func FetchIfMacWindows(interfaceName string) (string, error) {
+	stdoutStderr, err := exec.Command("powershell", "$(Get-NetAdapter", "-IncludeHidden",
+		"-InterfaceAlias", fmt.Sprintf("\"%s\"", interfaceName), ").MacAddress").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get mac address of ovn-k8s-master, stderr: %q, error: %v", fmt.Sprintf("%s", stdoutStderr), err)
+	}
+	// Windows returns it in 00-00-00-00-00-00 format, we want ':' instead of '-'
+	macAddress := strings.Replace(strings.TrimSpace(fmt.Sprintf("%s", stdoutStderr)), "-", ":", -1)
+
+	return strings.ToLower(macAddress), nil
 }


### PR DESCRIPTION
There is a known issue with OVS not correctly picking up the
physical network interface MAC address.

Gateway-init will fail on the Windows node when trying to add
the router port with a different MAC than the initial one. This
happens after node reboot.

As a workaround, fetch the MAC address via powershell if
it is not picked up from OVS.

Fixes #516 

Signed-off-by: Alin-Gheorghe Balutoiu <alinbalutoiu@gmail.com>