### PR TITLE
Fix sdn_preferred_nic_name for multi-node deployments

### DIFF
--- a/contrib/inventory/host_vars/README.md
+++ b/contrib/inventory/host_vars/README.md
@@ -18,3 +18,9 @@ one present in group_vars. Example for "node5":
 ansible_user: Administrator
 ansible_password: different_password
 ```
+
+If you want a preferred network interface for the SDN setup, use the
+following configuration option:
+```
+sdn_preferred_nic_name: "Ethernet 2"
+```

--- a/contrib/roles/windows/kubernetes/tasks/set_ip_facts.yml
+++ b/contrib/roles/windows/kubernetes/tasks/set_ip_facts.yml
@@ -13,7 +13,7 @@
         (Get-NetAdapter -Name $hnsNet.NetworkAdapterName).InterfaceIndex
         exit 0
     }
-    $preferredIfName = "{{ sdn_info.sdn_preferred_nic_name | default('') }}"
+    $preferredIfName = "{{ sdn_preferred_nic_name | default('') }}"
     if($preferredIfName) {
         (Get-NetAdapter -Name $preferredIfName).InterfaceIndex
         exit 0

--- a/contrib/roles/windows/kubernetes/vars/windows.yml
+++ b/contrib/roles/windows/kubernetes/vars/windows.yml
@@ -1,9 +1,6 @@
 ---
 sdn_info:
   sdn_network_name: external
-  # This should be set if you want a preferred network interface for the SDN setup.
-  # If this is not set, the interface with the default gateway configured is chosen.
-  # sdn_preferred_nic_name: "Ethernet"
 
 ovs_cmd_timeout: 30
 


### PR DESCRIPTION
The `sdn_preferred_nic_name` config variable is now a global host
specific variable.

This will cover the case when multiple Windows minions will have the
preferred NICs with different names.

Signed-off-by: Ionut Balutoiu ibalutoiu@cloudbasesolutions.com