### PR TITLE
Ansible: Remove insecure-experimental-approve-all-kubelet-csrs-for-group flag

### DIFF
--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -47,8 +47,7 @@
         --service-account-private-key-file=/etc/kubernetes/tls/apiserver-key.pem \
         --root-ca-file=/etc/kubernetes/tls/ca.pem \
         --cluster-signing-cert-file=/etc/kubernetes/tls/ca.pem \
-        --cluster-signing-key-file=/etc/kubernetes/tls/ca-key.pem \
-        --insecure-experimental-approve-all-kubelet-csrs-for-group=system:kubelet-bootstrap
+        --cluster-signing-key-file=/etc/kubernetes/tls/ca-key.pem
       Restart=on-failure
       RestartSec=10
       [Install]


### PR DESCRIPTION
Flag prevents kube-controller-manager to start with k8s master ( 1.14+ ) builds as it was removed.