### PR TITLE
Ansible: Small cleanup when at 'with_items' loops

### DIFF
--- a/contrib/roles/linux/openvswitch/tasks/build_install_release_ovs.yml
+++ b/contrib/roles/linux/openvswitch/tasks/build_install_release_ovs.yml
@@ -40,19 +40,19 @@
     chdir: "{{ ovs_info.build_path }}/{{ ovs_info.release_name }}"
 
 - name: OVS | install debs
-  apt: deb="{{ ovs_info.build_path }}/{{item}}{{ ovs_info.pkg_build_version }}_amd64.deb"
+  apt: deb="{{ ovs_info.build_path }}/{{item}}_{{ ovs_info.pkg_build_version }}_amd64.deb"
   with_items:
-    - libopenvswitch_
-    - openvswitch-common_
-    - openvswitch-switch_
-    - ovn-common_
-    - ovn-host_
+    - libopenvswitch
+    - openvswitch-common
+    - openvswitch-switch
+    - ovn-common
+    - ovn-host
 
 - name: OVS | install additional debs
-  apt: deb="{{ ovs_info.build_path }}/{{item}}{{ ovs_info.pkg_build_version }}_all.deb"
+  apt: deb="{{ ovs_info.build_path }}/{{item}}_{{ ovs_info.pkg_build_version }}_all.deb"
   with_items:
-    - openvswitch-datapath-dkms_
-    - python-openvswitch_
+    - openvswitch-datapath-dkms
+    - python-openvswitch
 
 - name: OVS | install controller deb if applicable
   apt: deb="{{ ovs_info.build_path }}/ovn-central_{{ ovs_info.pkg_build_version }}_amd64.deb"

--- a/contrib/roles/linux/openvswitch/tasks/download_install_packages.yml
+++ b/contrib/roles/linux/openvswitch/tasks/download_install_packages.yml
@@ -16,19 +16,19 @@
     remote_src: yes
 
 - name: OVS | install debs
-  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/{{item}}{{ ovs_info.prebuilt_version }}_amd64.deb"
+  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/{{item}}_{{ ovs_info.prebuilt_version }}_amd64.deb"
   with_items:
-    - libopenvswitch_
-    - openvswitch-common_
-    - openvswitch-switch_
-    - ovn-common_
-    - ovn-host_
+    - libopenvswitch
+    - openvswitch-common
+    - openvswitch-switch
+    - ovn-common
+    - ovn-host
 
 - name: OVS | install additional debs
-  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/{{item}}{{ ovs_info.prebuilt_version }}_all.deb"
+  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/{{item}}_{{ ovs_info.prebuilt_version }}_all.deb"
   with_items:
-    - openvswitch-datapath-dkms_
-    - python-openvswitch_
+    - openvswitch-datapath-dkms
+    - python-openvswitch
 
 - name: OVS | install controller deb if applicable
   apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/ovn-central_{{ ovs_info.prebuilt_version }}_amd64.deb"


### PR DESCRIPTION
This is only a small cleanup PR. It removes the common `_` for every item in the `with_items` loop.

Signed-off-by: Ionut Balutoiu ibalutoiu@cloudbasesolutions.com