### PR TITLE
Ansible: Update `init_gateway` boolean flag

### DIFF
--- a/contrib/inventory/host_vars/README.md
+++ b/contrib/inventory/host_vars/README.md
@@ -24,3 +24,10 @@ following configuration option:
 ```
 sdn_preferred_nic_name: "Ethernet 2"
 ```
+
+By default, all the Kubernetes minions will be configured as gateway nodes.
+If you don't want a particular node to be a gateway, use the following
+configuration option:
+```
+init_gateway: false
+```

--- a/contrib/ovn-kubernetes-cluster.yml
+++ b/contrib/ovn-kubernetes-cluster.yml
@@ -24,9 +24,6 @@
   any_errors_fatal: true
   gather_facts: true
   become: true
-  vars:
-    # This will init the gateway on the first minion from the hosts
-    init_gateway: true
   tasks:
     - import_role:
         name: linux/version_check
@@ -56,9 +53,6 @@
   gather_facts: true
   become_method: runas
   any_errors_fatal: true
-  vars:
-    # This will init the gateway on the first minion from the hosts
-    init_gateway: true
   tasks:
     - set_fact:
         windows_container_tag: 1709

--- a/contrib/roles/linux/kubernetes/tasks/init_gateway.yml
+++ b/contrib/roles/linux/kubernetes/tasks/init_gateway.yml
@@ -1,8 +1,4 @@
 ---
-- name: OVN Gateway | Set init_gateway to false
-  set_fact:
-    init_gateway: false
-
 # The following makes sure that the second time we enter init_gateway we actually
 # fetch the physical interface name and not the bridge name
 # TODO: interfaces that start with 'br' are not supported

--- a/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
@@ -118,6 +118,11 @@
     dest: "/opt/cni/bin/"
     remote_src: yes
 
+- name: Kubernetes Minion | Set default "init_gateway" fact if not already defined
+  set_fact:
+    init_gateway: true
+  when: init_gateway is not defined
+
 - name: Kubernetes Minion | Minion init
   shell: |
     /usr/bin/ovnkube \

--- a/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
+++ b/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
@@ -49,6 +49,11 @@
       log-file={{ install_path }}/ovn-kubernetes-node.log
       service-name=ovn-kubernetes-node
 
+- name: Kubernetes minion | Set default "init_gateway" fact if not already defined
+  set_fact:
+    init_gateway: true
+  when: init_gateway is not defined
+
 - name: Kubernetes minion | Set the ovnkube service-command with gateway args
   win_lineinfile:
     path: '{{ install_path }}\ovnkube-servicewrapper-config.ini'


### PR DESCRIPTION
Remove the `init_gateway` flag from the main playbook file and
have it to be used as a host specific configuration option.

This will easily allow users to disable gateway for some
k8s minions, if desirable.

The default value is considered `true` to maintain backwards
compatibility.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>