### PR TITLE
pidfile handling should be done only for the ovnkube daemons

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -183,15 +183,6 @@ func runOvnKube(ctx *cli.Context) error {
 		return err
 	}
 
-	pidfile := ctx.String("pidfile")
-	if pidfile != "" {
-		defer delPidfile(pidfile)
-		err = setupPIDFile(pidfile)
-		if err != nil {
-			return err
-		}
-	}
-
 	nodeToRemove := ctx.String("remove-node")
 	if nodeToRemove != "" {
 		err = util.RemoveNode(nodeToRemove)
@@ -199,6 +190,15 @@ func runOvnKube(ctx *cli.Context) error {
 			logrus.Errorf("Failed to remove node %v", err)
 		}
 		return nil
+	}
+
+	pidfile := ctx.String("pidfile")
+	if pidfile != "" {
+		defer delPidfile(pidfile)
+		err = setupPIDFile(pidfile)
+		if err != nil {
+			return err
+		}
 	}
 
 	clientset, err := util.NewClientset(&config.Kubernetes)


### PR DESCRIPTION
Currently, we create pidfile and immediately delete it for the
transient command like `ovnkube remove-node`. This shoudln't
be done. Also, I have refactored the pidfile handling code to
it's own function. This is in preparation for adding subcommands
to ovnkube.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>