### PR TITLE
Ansible: Fix Linux minions without gateway flags

### DIFF
--- a/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
@@ -123,17 +123,38 @@
     init_gateway: true
   when: init_gateway is not defined
 
-- name: Kubernetes Minion | Minion init
-  shell: |
-    /usr/bin/ovnkube \
-        --init-node "{{ ansible_hostname }}" \
-        --cluster-subnet "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
-        --k8s-token {{TOKEN}} \
-        --k8s-cacert /etc/openvswitch/k8s-ca.crt \
-        --k8s-apiserver "http://{{ kubernetes_cluster_info.MASTER_IP }}:8080" \
-        --service-cluster-ip-range "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
-        --nb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6641 \
-        --sb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6642
+- name: Kubernetes Minion | Setup OVN Kube service
+  block:
+    - name: Kubernetes Minion | Create OVN Kube systemd service file
+      blockinfile:
+        path: /etc/systemd/system/ovn-kubernetes-node.service
+        create: yes
+        block: |
+          [Unit]
+          Description=OVN Kube Systemd Daemon
+          Documentation=https://github.com/openvswitch/ovn-kubernetes
+          [Service]
+          ExecStart=/usr/bin/ovnkube \
+            --init-node "{{ ansible_hostname }}" \
+            --cluster-subnet "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
+            --k8s-token {{TOKEN}} \
+            --k8s-cacert /etc/openvswitch/k8s-ca.crt \
+            --k8s-apiserver "http://{{ kubernetes_cluster_info.MASTER_IP }}:8080" \
+            --service-cluster-ip-range "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
+            --nb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6641 \
+            --sb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6642
+          Restart=on-failure
+          RestartSec=10
+          WorkingDirectory=/root/
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Kubernetes Minion | Start OVN Kube service
+      service:
+        name: "ovn-kubernetes-node"
+        enabled: yes
+        state: restarted
+        daemon_reload: yes
   when: not init_gateway
 
 - name: Kubernetes Minion | Minion init with gateway


### PR DESCRIPTION
Previously, Linux minions didn't have a systemd service
for the ovnkube service when `init_gateway` is disabled.

This is required, otherwise the Ansible task executing
`ovnkube` hangs forever.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>