### PR TITLE
Ansible: Fix the CoreDNS pods and add validation tasks

### DIFF
--- a/contrib/ovn-kubernetes-cluster.yml
+++ b/contrib/ovn-kubernetes-cluster.yml
@@ -95,6 +95,19 @@
       delegate_to: "{{ item }}"
       with_items: "{{ groups['kube-master'] }}"
 
+# TODO(ionutbalutoiu):
+# Remove below workaround when this is fixed: https://github.com/openvswitch/ovn-kubernetes/issues/531
+# Right now, the CoreDNS pods will never reach "running" state. We need to kill the existing pods and
+# new ones will be successfully created.
+- hosts: kube-master
+  any_errors_fatal: true
+  gather_facts: true
+  become: true
+  tasks:
+    - name: Kill the kube-dns pods
+      run_once: true
+      shell: kubectl delete pod --force --grace-period=0 --namespace kube-system --selector k8s-app=kube-dns
+
 - hosts: kube-master:kube-minions-linux
   any_errors_fatal: true
   gather_facts: true

--- a/contrib/roles/linux/validation/tasks/main.yml
+++ b/contrib/roles/linux/validation/tasks/main.yml
@@ -17,3 +17,42 @@
 - name: Linux validation | Validate the services success state
   include: "./validate_service.yml service_name={{ item }}"
   with_items: "{{ service_names }}"
+
+- name: Linux validation | Validate if the CoreDNS pods are running
+  run_once: true
+  block:
+    - name: Linux validation | Create temp file for Python script
+      tempfile:
+        state: file
+      register: python_script
+
+    - name: Linux validation | Set the Python script content
+      blockinfile:
+        path: "{{ python_script.path }}"
+        create: yes
+        block: |
+          import json
+          import sys
+          pods = json.load(sys.stdin)
+          for pod in pods['items']:
+              if pod['status']['phase'] != 'Running':
+                  #
+                  # More info about pod phase here:
+                  # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+                  #
+                  print('ERROR: Pod %s is not running.'
+                        'Current phase is: %s' % (pod['metadata']['name'],
+                                                  pod['status']['phase']))
+                  sys.exit(1)
+              print('Pod %s is running.' % (pod['metadata']['name']))
+
+    - name: Linux validation | Check the CoreDNS pods
+      shell: |
+        set -o pipefail
+        kubectl get pod --selector k8s-app=kube-dns --namespace kube-system --output json | python3 "{{ python_script.path }}"
+        EXIT_CODE=$?
+        rm -f "{{ python_script.path }}"
+        exit $EXIT_CODE
+      args:
+        executable: /bin/bash
+  when: master


### PR DESCRIPTION
This pull request adds a workaround for the stucked `pending` state of the CoreDNS pods when a deployment is initially created.

On top of this, validation tasks for checking `running` CoreDNS pods is added.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>