### PR TITLE
Ansible: Cleanup the K8s Linux certs setup

### DIFF
--- a/contrib/roles/linux/kubernetes/tasks/generate_certs_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/generate_certs_master.yml
@@ -18,7 +18,7 @@
       set -o pipefail
 
       cert_group=kube-cert
-      cert_dir=/etc/kubernetes/tls
+      cert_dir={{ kubernetes_certificates.directory }}
 
       pem_ca=$cert_dir/ca.pem
       pem_ca_key=$cert_dir/ca-key.pem

--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -20,10 +20,10 @@
         --secure-port=443 \
         --advertise-address={{ host_internal_ip }} \
         --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota \
-        --tls-cert-file=/etc/kubernetes/tls/apiserver.pem \
-        --tls-private-key-file=/etc/kubernetes/tls/apiserver-key.pem \
-        --client-ca-file=/etc/kubernetes/tls/ca.pem \
-        --service-account-key-file=/etc/kubernetes/tls/apiserver-key.pem \
+        --tls-cert-file={{ kubernetes_certificates.directory }}/apiserver.pem \
+        --tls-private-key-file={{ kubernetes_certificates.directory }}/apiserver-key.pem \
+        --client-ca-file={{ kubernetes_certificates.directory }}/ca.pem \
+        --service-account-key-file={{ kubernetes_certificates.directory }}/apiserver-key.pem \
         --runtime-config=extensions/v1beta1=true,extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true
       Restart=on-failure
       RestartSec=10
@@ -44,10 +44,10 @@
         --master={{ host_public_ip }}:8080 \
         --v=2 \
         --cluster-cidr={{ kubernetes_cluster_info.CLUSTER_SUBNET }} \
-        --service-account-private-key-file=/etc/kubernetes/tls/apiserver-key.pem \
-        --root-ca-file=/etc/kubernetes/tls/ca.pem \
-        --cluster-signing-cert-file=/etc/kubernetes/tls/ca.pem \
-        --cluster-signing-key-file=/etc/kubernetes/tls/ca-key.pem
+        --service-account-private-key-file={{ kubernetes_certificates.directory }}/apiserver-key.pem \
+        --root-ca-file={{ kubernetes_certificates.directory }}/ca.pem \
+        --cluster-signing-cert-file={{ kubernetes_certificates.directory }}/ca.pem \
+        --cluster-signing-key-file={{ kubernetes_certificates.directory }}/ca-key.pem
       Restart=on-failure
       RestartSec=10
       [Install]
@@ -92,27 +92,54 @@
       [Install]
       WantedBy=multi-user.target
 
-- name: Kubernetes Master | Checking certs
-  stat:
-    path: /etc/kubernetes/tls/admin.pem
-  register: certs_check
-
-- name: Kubernetes Master | Setting certs generated to false
+- name: Kubernetes Master | Assume that the certs were not generated now
   set_fact:
     certs_generated: false
 
-- name: Kubernetes Master | Generate certs
+- name: Kubernetes Master | Check if all the certs are present
+  block:
+    - stat:
+        path: "{{ kubernetes_certificates.directory }}/ca.pem"
+      register: ca_cert
+
+    - stat:
+        path: "{{ kubernetes_certificates.directory }}/ca-key.pem"
+      register: ca_cert_key
+
+    - stat:
+        path: "{{ kubernetes_certificates.directory }}/apiserver.pem"
+      register: apiserver_cert
+
+    - stat:
+        path: "{{ kubernetes_certificates.directory }}/apiserver-key.pem"
+      register: apiserver_cert_key
+
+    - stat:
+        path: "{{ kubernetes_certificates.directory }}/admin.pem"
+      register: admin_cert
+
+    - stat:
+        path: "{{ kubernetes_certificates.directory }}/admin-key.pem"
+      register: admin_cert_key
+
+- name: Kubernetes Master | Generate certs if needed
   block:
     - include_tasks: ./generate_certs_master.yml
+
     - set_fact:
         certs_generated: true
-  when: not certs_check.stat.exists
+  when: (not ca_cert.stat.exists or
+         not ca_cert_key.stat.exists or
+         not apiserver_cert.stat.exists or
+         not apiserver_cert_key.stat.exists or
+         not admin_cert.stat.exists or
+         not admin_cert_key.stat.exists)
 
 - name: Kubernetes Master | Fetching certificates on the ansible host
   fetch:
     flat: yes
-    src: /etc/kubernetes/tls/{{item}}
-    dest: "{{ansible_tmp_dir}}/k8s_{{item}}"
+    src: "{{ kubernetes_certificates.directory }}/{{ item }}"
+    dest: "{{ ansible_tmp_dir }}/k8s_{{ item }}"
   with_items:
     - ca.pem
     - ca-key.pem
@@ -133,8 +160,8 @@
 - name: Kubernetes Master | Setting kubectl context
   shell: |
     set -o errexit
-    kubectl config set-cluster default-cluster --server=https://{{ host_public_ip }} --certificate-authority=/etc/kubernetes/tls/ca.pem
-    kubectl config set-credentials default-admin --certificate-authority=/etc/kubernetes/tls/ca.pem --client-key=/etc/kubernetes/tls/admin-key.pem --client-certificate=/etc/kubernetes/tls/admin.pem
+    kubectl config set-cluster default-cluster --server=https://{{ host_public_ip }} --certificate-authority={{ kubernetes_certificates.directory }}/ca.pem
+    kubectl config set-credentials default-admin --certificate-authority={{ kubernetes_certificates.directory }}/ca.pem --client-key={{ kubernetes_certificates.directory }}/admin-key.pem --client-certificate={{ kubernetes_certificates.directory }}/admin.pem
     kubectl config set-context local --cluster=default-cluster --user=default-admin
     kubectl config use-context local
   changed_when: false
@@ -227,7 +254,7 @@
     ovs-vsctl --timeout={{TIMEOUT}} set Open_vSwitch . \
       external_ids:k8s-api-server="https://{{ host_public_ip }}" \
       external_ids:k8s-api-token="{{TOKEN}}"
-    ln -fs /etc/kubernetes/tls/ca.pem /etc/openvswitch/k8s-ca.crt
+    ln -fs {{ kubernetes_certificates.directory }}/ca.pem /etc/openvswitch/k8s-ca.crt
   changed_when: false
 
 - name: Kubernetes Master | restart ovn-kubernetes-master

--- a/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
@@ -25,14 +25,14 @@
       kind: Config
       clusters:
       - cluster:
-          certificate-authority: /etc/kubernetes/tls/ca.pem
+          certificate-authority: {{ kubernetes_certificates.directory }}/ca.pem
           server: https://{{ kubernetes_cluster_info.MASTER_IP }}
         name: local
       users:
       - name: kubelet
         user:
-          client-certificate: /etc/kubernetes/tls/node.pem
-          client-key: /etc/kubernetes/tls/node-key.pem
+          client-certificate: {{ kubernetes_certificates.directory }}/node.pem
+          client-key: {{ kubernetes_certificates.directory }}/node-key.pem
       contexts:
       - context:
           cluster: local
@@ -58,8 +58,8 @@
         --cni-bin-dir=/opt/cni/bin \
         --cni-conf-dir=/etc/cni/net.d \
         --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
-        --tls-cert-file=/etc/kubernetes/tls/node.pem \
-        --tls-private-key-file=/etc/kubernetes/tls/node-key.pem \
+        --tls-cert-file={{ kubernetes_certificates.directory }}/node.pem \
+        --tls-private-key-file={{ kubernetes_certificates.directory }}/node-key.pem \
         --fail-swap-on=false
       Restart=on-failure
       RestartSec=10
@@ -90,7 +90,7 @@
     ovs-vsctl --timeout={{TIMEOUT}} set Open_vSwitch . \
       external_ids:k8s-api-server="http://{{ host_public_ip }}:8080" \
       external_ids:k8s-api-token="{{TOKEN}}"
-    ln -fs /etc/kubernetes/tls/ca.pem /etc/openvswitch/k8s-ca.crt
+    ln -fs {{ kubernetes_certificates.directory }}/ca.pem /etc/openvswitch/k8s-ca.crt
   changed_when: false
 
 - name: Kubernetes Minion | Ensure /etc/hosts is updated

--- a/contrib/roles/linux/kubernetes/vars/ubuntu.yml
+++ b/contrib/roles/linux/kubernetes/vars/ubuntu.yml
@@ -20,6 +20,7 @@ kubernetes_cluster_info:
 
 kubernetes_certificates:
   tmp_generate_path: /tmp/k8s_certs
+  directory: /etc/kubernetes/tls
 
 kubernetes_binaries:
   linux_common:


### PR DESCRIPTION
Add variable with the root directory for the Kubernetes certificates, and use
this in the Ansible tasks.

Improve the check for the Kubernetes master certificates existence.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>