### PR TITLE
Ansible: Fix retry logic

### DIFF
--- a/contrib/roles/linux/validation/tasks/main.yml
+++ b/contrib/roles/linux/validation/tasks/main.yml
@@ -49,12 +49,16 @@
     - name: Linux validation | Check the CoreDNS pods
       retries: 10
       delay: 5
+      register: result
       shell: |
         set -o pipefail
         kubectl get pod --selector k8s-app=kube-dns --namespace kube-system --output json | python3 "{{ python_script.path }}"
-        EXIT_CODE=$?
-        rm -f "{{ python_script.path }}"
-        exit $EXIT_CODE
       args:
         executable: /bin/bash
+      until: result.rc == 0
+
+    - name: Linux validation | Cleanup the temp Python script file
+      file:
+        path: "{{ python_script.path }}"
+        state: absent
   when: master

--- a/contrib/roles/windows/kubernetes/tasks/create_infracontainer.yml
+++ b/contrib/roles/windows/kubernetes/tasks/create_infracontainer.yml
@@ -17,6 +17,8 @@
 - name: Kubernetes infracontainer | Create container {{ kubernetes_info.infracontainername }}
   retries: 10
   delay: 5
+  register: result
   win_shell: |
     cd {{ install_path }}
     docker image build -t {{ kubernetes_info.infracontainername }} .
+  until: result.rc == 0


### PR DESCRIPTION
The retry logic when executing shell commands on both Linux and Windows
lacked the comparison for exit code.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>