### PR TITLE
RunOVNNbctlHA() makes an incorrect assumption on which scheme to use

### DIFF
--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -37,7 +37,7 @@ func hashedPortGroup(s string) string {
 // namespaceName.suffix1.suffix2. .suffixN)
 func (oc *Controller) forEachAddressSetUnhashedName(iteratorFn func(
 	string, string, string)) error {
-	output, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	output, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=external_ids", "find", "address_set")
 	if err != nil {
 		logrus.Errorf("Error in obtaining list of address sets from OVN: "+
@@ -63,7 +63,7 @@ func (oc *Controller) forEachAddressSetUnhashedName(iteratorFn func(
 func (oc *Controller) setAddressSet(hashName string, addresses []string) {
 	logrus.Debugf("setAddressSet for %s with %s", hashName, addresses)
 	if len(addresses) == 0 {
-		_, stderr, err := util.RunOVNNbctlHA("clear", "address_set",
+		_, stderr, err := util.RunOVNNbctl("clear", "address_set",
 			hashName, "addresses")
 		if err != nil {
 			logrus.Errorf("failed to clear address_set, stderr: %q (%v)",
@@ -73,7 +73,7 @@ func (oc *Controller) setAddressSet(hashName string, addresses []string) {
 	}
 
 	ips := strings.Join(addresses, " ")
-	_, stderr, err := util.RunOVNNbctlHA("set", "address_set",
+	_, stderr, err := util.RunOVNNbctl("set", "address_set",
 		hashName, fmt.Sprintf("addresses=%s", ips))
 	if err != nil {
 		logrus.Errorf("failed to set address_set, stderr: %q (%v)",
@@ -84,7 +84,7 @@ func (oc *Controller) setAddressSet(hashName string, addresses []string) {
 func (oc *Controller) createAddressSet(name string, hashName string,
 	addresses []string) {
 	logrus.Debugf("createAddressSet with %s and %s", name, addresses)
-	addressSet, stderr, err := util.RunOVNNbctlHA("--data=bare",
+	addressSet, stderr, err := util.RunOVNNbctl("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "address_set",
 		fmt.Sprintf("name=%s", hashName))
 	if err != nil {
@@ -95,7 +95,7 @@ func (oc *Controller) createAddressSet(name string, hashName string,
 
 	// addressSet has already been created in the database and nothing to set.
 	if addressSet != "" && len(addresses) == 0 {
-		_, stderr, err = util.RunOVNNbctlHA("clear", "address_set",
+		_, stderr, err = util.RunOVNNbctl("clear", "address_set",
 			hashName, "addresses")
 		if err != nil {
 			logrus.Errorf("failed to clear address_set, stderr: %q (%v)",
@@ -109,7 +109,7 @@ func (oc *Controller) createAddressSet(name string, hashName string,
 	// An addressSet has already been created. Just set addresses.
 	if addressSet != "" {
 		// Set the addresses
-		_, stderr, err = util.RunOVNNbctlHA("set", "address_set",
+		_, stderr, err = util.RunOVNNbctl("set", "address_set",
 			hashName, fmt.Sprintf("addresses=%s", ips))
 		if err != nil {
 			logrus.Errorf("failed to set address_set, stderr: %q (%v)",
@@ -120,11 +120,11 @@ func (oc *Controller) createAddressSet(name string, hashName string,
 
 	// addressSet has not been created yet. Create it.
 	if len(addresses) == 0 {
-		_, stderr, err = util.RunOVNNbctlHA("create", "address_set",
+		_, stderr, err = util.RunOVNNbctl("create", "address_set",
 			fmt.Sprintf("name=%s", hashName),
 			fmt.Sprintf("external-ids:name=%s", name))
 	} else {
-		_, stderr, err = util.RunOVNNbctlHA("create", "address_set",
+		_, stderr, err = util.RunOVNNbctl("create", "address_set",
 			fmt.Sprintf("name=%s", hashName),
 			fmt.Sprintf("external-ids:name=%s", name),
 			fmt.Sprintf("addresses=%s", ips))
@@ -138,7 +138,7 @@ func (oc *Controller) createAddressSet(name string, hashName string,
 func (oc *Controller) deleteAddressSet(hashName string) {
 	logrus.Debugf("deleteAddressSet %s", hashName)
 
-	_, stderr, err := util.RunOVNNbctlHA("--if-exists", "destroy",
+	_, stderr, err := util.RunOVNNbctl("--if-exists", "destroy",
 		"address_set", hashName)
 	if err != nil {
 		logrus.Errorf("failed to destroy address set %s, stderr: %q, (%v)",
@@ -150,7 +150,7 @@ func (oc *Controller) deleteAddressSet(hashName string) {
 func (oc *Controller) createPortGroup(name string,
 	hashName string) (string, error) {
 	logrus.Debugf("createPortGroup with %s", name)
-	portGroup, stderr, err := util.RunOVNNbctlHA("--data=bare",
+	portGroup, stderr, err := util.RunOVNNbctl("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "port_group",
 		fmt.Sprintf("name=%s", hashName))
 	if err != nil {
@@ -162,7 +162,7 @@ func (oc *Controller) createPortGroup(name string,
 		return portGroup, nil
 	}
 
-	portGroup, stderr, err = util.RunOVNNbctlHA("create", "port_group",
+	portGroup, stderr, err = util.RunOVNNbctl("create", "port_group",
 		fmt.Sprintf("name=%s", hashName),
 		fmt.Sprintf("external-ids:name=%s", name))
 	if err != nil {
@@ -176,7 +176,7 @@ func (oc *Controller) createPortGroup(name string,
 func (oc *Controller) deletePortGroup(hashName string) {
 	logrus.Debugf("deletePortGroup %s", hashName)
 
-	portGroup, stderr, err := util.RunOVNNbctlHA("--data=bare",
+	portGroup, stderr, err := util.RunOVNNbctl("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "port_group",
 		fmt.Sprintf("name=%s", hashName))
 	if err != nil {
@@ -189,7 +189,7 @@ func (oc *Controller) deletePortGroup(hashName string) {
 		return
 	}
 
-	_, stderr, err = util.RunOVNNbctlHA("--if-exists", "destroy",
+	_, stderr, err = util.RunOVNNbctl("--if-exists", "destroy",
 		"port_group", portGroup)
 	if err != nil {
 		logrus.Errorf("failed to destroy port_group %s, stderr: %q, (%v)",

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -152,7 +152,7 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 			continue
 		}
 		key := fmt.Sprintf("\"%s:%d\"", svc.Spec.ClusterIP, svcPort.Port)
-		_, stderr, err := util.RunOVNNbctlHA("remove", "load_balancer", lb,
+		_, stderr, err := util.RunOVNNbctl("remove", "load_balancer", lb,
 			"vips", key)
 		if err != nil {
 			logrus.Errorf("Error in deleting endpoints for lb %s, "+

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -9,7 +9,7 @@ import (
 
 func (ovn *Controller) getOvnGateways() ([]string, string, error) {
 	// Return all created gateways.
-	out, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	out, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=name", "find",
 		"logical_router",
 		"options:chassis!=null")
@@ -18,7 +18,7 @@ func (ovn *Controller) getOvnGateways() ([]string, string, error) {
 
 func (ovn *Controller) getGatewayPhysicalIP(
 	physicalGateway string) (string, error) {
-	physicalIP, _, err := util.RunOVNNbctlHA("get", "logical_router",
+	physicalIP, _, err := util.RunOVNNbctl("get", "logical_router",
 		physicalGateway, "external_ids:physical_ip")
 	if err != nil {
 		return "", err
@@ -30,7 +30,7 @@ func (ovn *Controller) getGatewayPhysicalIP(
 func (ovn *Controller) getGatewayLoadBalancer(physicalGateway,
 	protocol string) (string, error) {
 	externalIDKey := protocol + "_lb_gateway_router"
-	loadBalancer, _, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	loadBalancer, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "load_balancer",
 		"external_ids:"+externalIDKey+"="+
 			physicalGateway)

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -19,11 +19,11 @@ func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string,
 	var out string
 	var err error
 	if protocol == kapi.ProtocolTCP {
-		out, _, err = util.RunOVNNbctlHA("--data=bare",
+		out, _, err = util.RunOVNNbctl("--data=bare",
 			"--no-heading", "--columns=_uuid", "find", "load_balancer",
 			"external_ids:k8s-cluster-lb-tcp=yes")
 	} else if protocol == kapi.ProtocolUDP {
-		out, _, err = util.RunOVNNbctlHA("--data=bare", "--no-heading",
+		out, _, err = util.RunOVNNbctl("--data=bare", "--no-heading",
 			"--columns=_uuid", "find", "load_balancer",
 			"external_ids:k8s-cluster-lb-udp=yes")
 	}
@@ -63,7 +63,7 @@ func (ovn *Controller) getDefaultGatewayLoadBalancer(protocol kapi.Protocol) str
 
 func (ovn *Controller) getLoadBalancerVIPS(
 	loadBalancer string) (map[string]interface{}, error) {
-	outStr, _, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	outStr, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"get", "load_balancer", loadBalancer, "vips")
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func (ovn *Controller) getLoadBalancerVIPS(
 
 func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) {
 	vipQuotes := fmt.Sprintf("\"%s\"", vip)
-	stdout, stderr, err := util.RunOVNNbctlHA("--if-exists", "remove",
+	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
 		"load_balancer", loadBalancer, "vips", vipQuotes)
 	if err != nil {
 		logrus.Errorf("Error in deleting load balancer vip %s for %s"+
@@ -100,7 +100,7 @@ func (ovn *Controller) createLoadBalancerVIP(lb string, serviceIP string, port i
 	key := fmt.Sprintf("\"%s:%d\"", serviceIP, port)
 
 	if len(ips) == 0 {
-		_, _, err := util.RunOVNNbctlHA("remove", "load_balancer", lb,
+		_, _, err := util.RunOVNNbctl("remove", "load_balancer", lb,
 			"vips", key)
 		return err
 	}
@@ -115,7 +115,7 @@ func (ovn *Controller) createLoadBalancerVIP(lb string, serviceIP string, port i
 	}
 	target := fmt.Sprintf("vips:\"%s:%d\"=\"%s\"", serviceIP, port, commaSeparatedEndpoints)
 
-	out, stderr, err := util.RunOVNNbctlHA("set", "load_balancer", lb,
+	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb,
 		target)
 	if err != nil {
 		logrus.Errorf("Error in creating load balancer: %s "+

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -107,7 +107,7 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory,
 
 // Run starts the actual watching. Also initializes any local structures needed.
 func (oc *Controller) Run() error {
-	_, _, err := util.RunOVNNbctlHA("--columns=_uuid", "list",
+	_, _, err := util.RunOVNNbctl("--columns=_uuid", "list",
 		"port_group")
 	if err == nil {
 		oc.portGroupSupport = true

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -24,7 +24,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 	}
 
 	// get the list of logical ports from OVN
-	output, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	output, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=name", "find", "logical_switch_port", "external_ids:pod=true")
 	if err != nil {
 		logrus.Errorf("Error in obtaining list of logical ports, "+
@@ -37,7 +37,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 		if _, ok := expectedLogicalPorts[existingPort]; !ok {
 			// not found, delete this logical port
 			logrus.Infof("Stale logical port found: %s. This logical port will be deleted.", existingPort)
-			out, stderr, err := util.RunOVNNbctlHA("--if-exists", "lsp-del",
+			out, stderr, err := util.RunOVNNbctl("--if-exists", "lsp-del",
 				existingPort)
 			if err != nil {
 				logrus.Errorf("Error in deleting pod's logical port "+
@@ -53,7 +53,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 
 func (oc *Controller) deletePodAcls(logicalPort string) {
 	// delete the ACL rules on OVN that corresponding pod has been deleted
-	uuids, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuids, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL",
 		fmt.Sprintf("external_ids:logical_port=%s", logicalPort))
 	if err != nil {
@@ -71,7 +71,7 @@ func (oc *Controller) deletePodAcls(logicalPort string) {
 	uuidSlice := strings.Fields(uuids)
 	for _, uuid := range uuidSlice {
 		// Get logical switch
-		out, stderr, err := util.RunOVNNbctlHA("--data=bare",
+		out, stderr, err := util.RunOVNNbctl("--data=bare",
 			"--no-heading", "--columns=_uuid", "find", "logical_switch",
 			fmt.Sprintf("acls{>=}%s", uuid))
 		if err != nil {
@@ -85,7 +85,7 @@ func (oc *Controller) deletePodAcls(logicalPort string) {
 		}
 		logicalSwitch := out
 
-		_, stderr, err = util.RunOVNNbctlHA("--if-exists", "remove",
+		_, stderr, err = util.RunOVNNbctl("--if-exists", "remove",
 			"logical_switch", logicalSwitch, "acls", uuid)
 		if err != nil {
 			logrus.Errorf("failed to delete the allow-from rule %s for"+
@@ -101,7 +101,7 @@ func (oc *Controller) getLogicalPortUUID(logicalPort string) string {
 		return oc.logicalPortUUIDCache[logicalPort]
 	}
 
-	out, stderr, err := util.RunOVNNbctlHA("--if-exists", "get",
+	out, stderr, err := util.RunOVNNbctl("--if-exists", "get",
 		"logical_switch_port", logicalPort, "_uuid")
 	if err != nil {
 		logrus.Errorf("Error while getting uuid for logical_switch_port "+
@@ -125,7 +125,7 @@ func (oc *Controller) getGatewayFromSwitch(logicalSwitch string) (string, string
 	oc.lsMutex.Lock()
 	defer oc.lsMutex.Unlock()
 	if gatewayIPMaskStr, ok = oc.gatewayCache[logicalSwitch]; !ok {
-		gatewayIPMaskStr, stderr, err = util.RunOVNNbctlHA("--if-exists",
+		gatewayIPMaskStr, stderr, err = util.RunOVNNbctl("--if-exists",
 			"get", "logical_switch", logicalSwitch,
 			"external_ids:gateway_ip")
 		if err != nil {
@@ -153,7 +153,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 
 	logrus.Infof("Deleting pod: %s", pod.Name)
 	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
-	out, stderr, err := util.RunOVNNbctlHA("--if-exists", "lsp-del",
+	out, stderr, err := util.RunOVNNbctl("--if-exists", "lsp-del",
 		logicalPort)
 	if err != nil {
 		logrus.Errorf("Error in deleting pod logical port "+
@@ -213,7 +213,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		ipAddress := oc.getIPFromOvnAnnotation(annotation)
 		macAddress := oc.getMacFromOvnAnnotation(annotation)
 
-		out, stderr, err = util.RunOVNNbctlHA("--may-exist", "lsp-add",
+		out, stderr, err = util.RunOVNNbctl("--may-exist", "lsp-add",
 			logicalSwitch, portName, "--", "lsp-set-addresses", portName,
 			fmt.Sprintf("%s %s", macAddress, ipAddress), "--", "--if-exists",
 			"clear", "logical_switch_port", portName, "dynamic_addresses")
@@ -224,7 +224,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 			return
 		}
 	} else {
-		out, stderr, err = util.RunOVNNbctlHA("--wait=sb", "--",
+		out, stderr, err = util.RunOVNNbctl("--wait=sb", "--",
 			"--may-exist", "lsp-add", logicalSwitch, portName,
 			"--", "lsp-set-addresses",
 			portName, "dynamic", "--", "set",
@@ -251,10 +251,10 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 	count := 30
 	for count > 0 {
 		if isStaticIP {
-			out, stderr, err = util.RunOVNNbctlHA("get",
+			out, stderr, err = util.RunOVNNbctl("get",
 				"logical_switch_port", portName, "addresses")
 		} else {
-			out, stderr, err = util.RunOVNNbctlHA("get",
+			out, stderr, err = util.RunOVNNbctl("get",
 				"logical_switch_port", portName, "dynamic_addresses")
 		}
 		if err == nil && out != "[]" {
@@ -318,7 +318,7 @@ func (oc *Controller) AddLogicalPortWithIP(pod *kapi.Pod) {
 	ipAddress := oc.getIPFromOvnAnnotation(annotation)
 	macAddress := oc.getMacFromOvnAnnotation(annotation)
 
-	stdout, stderr, err := util.RunOVNNbctlHA("--", "--may-exist", "lsp-add",
+	stdout, stderr, err := util.RunOVNNbctl("--", "--may-exist", "lsp-add",
 		logicalSwitch, portName, "--", "lsp-set-addresses", portName,
 		fmt.Sprintf("%s %s", macAddress, ipAddress))
 	if err != nil {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -55,7 +55,7 @@ func (oc *Controller) addACLAllow(np *namespacePolicy,
 		action = "allow"
 	}
 
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL",
 		fmt.Sprintf("external-ids:l4Match=\"%s\"", l4Match),
 		fmt.Sprintf("external-ids:ipblock_cidr=%t", ipBlockCidr),
@@ -74,7 +74,7 @@ func (oc *Controller) addACLAllow(np *namespacePolicy,
 		return
 	}
 
-	_, stderr, err = util.RunOVNNbctlHA("--id=@acl", "create",
+	_, stderr, err = util.RunOVNNbctl("--id=@acl", "create",
 		"acl", fmt.Sprintf("priority=%s", defaultAllowPriority),
 		fmt.Sprintf("direction=%s", direction), match,
 		fmt.Sprintf("action=%s", action),
@@ -96,7 +96,7 @@ func (oc *Controller) addACLAllow(np *namespacePolicy,
 func (oc *Controller) modifyACLAllow(namespace, policy,
 	oldMatch string, newMatch string, gressNum int,
 	policyType knet.PolicyType) {
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL", oldMatch,
 		fmt.Sprintf("external-ids:namespace=%s", namespace),
 		fmt.Sprintf("external-ids:policy=%s", policy),
@@ -111,7 +111,7 @@ func (oc *Controller) modifyACLAllow(namespace, policy,
 
 	if uuid != "" {
 		// We already have an ACL. We will update it.
-		_, stderr, err = util.RunOVNNbctlHA("set", "acl", uuid,
+		_, stderr, err = util.RunOVNNbctl("set", "acl", uuid,
 			fmt.Sprintf("%s", newMatch))
 		if err != nil {
 			logrus.Errorf("failed to modify the allow-from rule for "+
@@ -136,7 +136,7 @@ func (oc *Controller) addIPBlockACLDeny(np *namespacePolicy,
 		match = fmt.Sprintf("match=\"%s && %s\"", lportMatch, l3Match)
 	}
 
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL", match, "action=drop",
 		fmt.Sprintf("external-ids:ipblock-deny-policy-type=%s", policyType),
 		fmt.Sprintf("external-ids:namespace=%s", np.namespace),
@@ -153,7 +153,7 @@ func (oc *Controller) addIPBlockACLDeny(np *namespacePolicy,
 		return
 	}
 
-	_, stderr, err = util.RunOVNNbctlHA("--id=@acl", "create", "acl",
+	_, stderr, err = util.RunOVNNbctl("--id=@acl", "create", "acl",
 		fmt.Sprintf("priority=%s", priority),
 		fmt.Sprintf("direction=%s", direction), match, "action=drop",
 		fmt.Sprintf("external-ids:ipblock-deny-policy-type=%s", policyType),
@@ -179,7 +179,7 @@ func (oc *Controller) addACLDenyPortGroup(portGroupUUID, portGroupName,
 		match = fmt.Sprintf("match=\"inport == @%s\"", portGroupName)
 	}
 
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL", match, "action=drop",
 		fmt.Sprintf("external-ids:default-deny-policy-type=%s", policyType))
 	if err != nil {
@@ -191,7 +191,7 @@ func (oc *Controller) addACLDenyPortGroup(portGroupUUID, portGroupName,
 		return nil
 	}
 
-	_, stderr, err = util.RunOVNNbctlHA("--id=@acl", "create", "acl",
+	_, stderr, err = util.RunOVNNbctl("--id=@acl", "create", "acl",
 		fmt.Sprintf("priority=%s", priority),
 		fmt.Sprintf("direction=%s", direction), match, "action=drop",
 		fmt.Sprintf("external-ids:default-deny-policy-type=%s", policyType),
@@ -210,7 +210,7 @@ func (oc *Controller) addToACLDeny(portGroup, logicalPort string) {
 		return
 	}
 
-	_, stderr, err := util.RunOVNNbctlHA("--if-exists", "remove",
+	_, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
 		"port_group", portGroup, "ports", logicalPortUUID, "--",
 		"add", "port_group", portGroup, "ports", logicalPortUUID)
 	if err != nil {
@@ -225,7 +225,7 @@ func (oc *Controller) deleteFromACLDeny(portGroup, logicalPort string) {
 		return
 	}
 
-	_, stderr, err := util.RunOVNNbctlHA("--if-exists", "remove",
+	_, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
 		"port_group", portGroup, "ports", logicalPortUUID)
 	if err != nil {
 		logrus.Errorf("Failed to delete logicalPort %s to portGroup %s "+
@@ -419,7 +419,7 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(
 		return
 	}
 
-	_, stderr, err := util.RunOVNNbctlHA("--if-exists", "remove",
+	_, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
 		"port_group", np.portGroupUUID, "ports", logicalPortUUID, "--",
 		"add", "port_group", np.portGroupUUID, "ports", logicalPortUUID)
 	if err != nil {
@@ -461,7 +461,7 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 		return
 	}
 
-	_, stderr, err := util.RunOVNNbctlHA("--if-exists", "remove",
+	_, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
 		"port_group", np.portGroupUUID, "ports", logicalPortUUID)
 	if err != nil {
 		logrus.Errorf("Failed to delete logicalPort %s from portGroup %s "+

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -175,7 +175,7 @@ const (
 )
 
 func (oc *Controller) addAllowACLFromNode(logicalSwitch string) {
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL",
 		fmt.Sprintf("external-ids:logical_switch=%s", logicalSwitch),
 		"external-ids:node-acl=yes")
@@ -189,7 +189,7 @@ func (oc *Controller) addAllowACLFromNode(logicalSwitch string) {
 		return
 	}
 
-	subnet, stderr, err := util.RunOVNNbctlHA("get", "logical_switch",
+	subnet, stderr, err := util.RunOVNNbctl("get", "logical_switch",
 		logicalSwitch, "other-config:subnet")
 	if err != nil {
 		logrus.Errorf("failed to get the logical_switch %s subnet, "+
@@ -215,7 +215,7 @@ func (oc *Controller) addAllowACLFromNode(logicalSwitch string) {
 
 	match := fmt.Sprintf("match=\"ip4.src == %s\"", address)
 
-	_, stderr, err = util.RunOVNNbctlHA("--id=@acl", "create", "acl",
+	_, stderr, err = util.RunOVNNbctl("--id=@acl", "create", "acl",
 		fmt.Sprintf("priority=%s", defaultAllowPriority),
 		"direction=to-lport", match, "action=allow-related",
 		fmt.Sprintf("external-ids:logical_switch=%s", logicalSwitch),

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -51,7 +51,7 @@ func (oc *Controller) addACLAllowOld(namespace, policy, logicalSwitch,
 		action = "allow"
 	}
 
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL",
 		fmt.Sprintf("external-ids:l4Match=\"%s\"", l4Match),
 		fmt.Sprintf("external-ids:ipblock_cidr=%t", ipBlockCidr),
@@ -72,7 +72,7 @@ func (oc *Controller) addACLAllowOld(namespace, policy, logicalSwitch,
 		return
 	}
 
-	_, stderr, err = util.RunOVNNbctlHA("--id=@acl", "create",
+	_, stderr, err = util.RunOVNNbctl("--id=@acl", "create",
 		"acl", fmt.Sprintf("priority=%s", defaultAllowPriority),
 		fmt.Sprintf("direction=%s", direction), match,
 		fmt.Sprintf("action=%s", action),
@@ -95,7 +95,7 @@ func (oc *Controller) addACLAllowOld(namespace, policy, logicalSwitch,
 
 func (oc *Controller) modifyACLAllowOld(namespace, policy, logicalPort,
 	oldMatch string, newMatch string, gressNum int, policyType knet.PolicyType) {
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL", oldMatch,
 		fmt.Sprintf("external-ids:namespace=%s", namespace),
 		fmt.Sprintf("external-ids:policy=%s", policy),
@@ -111,7 +111,7 @@ func (oc *Controller) modifyACLAllowOld(namespace, policy, logicalPort,
 
 	if uuid != "" {
 		// We already have an ACL. We will update it.
-		_, stderr, err = util.RunOVNNbctlHA("set", "acl", uuid,
+		_, stderr, err = util.RunOVNNbctl("set", "acl", uuid,
 			fmt.Sprintf("%s", newMatch))
 		if err != nil {
 			logrus.Errorf("failed to modify the allow-from rule for "+
@@ -125,7 +125,7 @@ func (oc *Controller) modifyACLAllowOld(namespace, policy, logicalPort,
 func (oc *Controller) deleteACLAllowOld(namespace, policy, logicalSwitch,
 	logicalPort, match, l4Match string, ipBlockCidr bool, gressNum int,
 	policyType knet.PolicyType) {
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL",
 		fmt.Sprintf("external-ids:l4Match=\"%s\"", l4Match),
 		fmt.Sprintf("external-ids:ipblock_cidr=%t", ipBlockCidr),
@@ -147,7 +147,7 @@ func (oc *Controller) deleteACLAllowOld(namespace, policy, logicalSwitch,
 		return
 	}
 
-	_, stderr, err = util.RunOVNNbctlHA("remove", "logical_switch",
+	_, stderr, err = util.RunOVNNbctl("remove", "logical_switch",
 		logicalSwitch, "acls", uuid)
 	if err != nil {
 		logrus.Errorf("remove failed to delete the allow-from rule for "+
@@ -171,7 +171,7 @@ func (oc *Controller) addIPBlockACLDenyOld(namespace, policy, logicalSwitch,
 		match = fmt.Sprintf("match=\"%s && %s\"", lportMatch, l3Match)
 	}
 
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL", match, "action=drop",
 		fmt.Sprintf("external-ids:ipblock-deny-policy-type=%s", policyType),
 		fmt.Sprintf("external-ids:namespace=%s", namespace),
@@ -189,7 +189,7 @@ func (oc *Controller) addIPBlockACLDenyOld(namespace, policy, logicalSwitch,
 		return
 	}
 
-	_, stderr, err = util.RunOVNNbctlHA("--id=@acl", "create", "acl",
+	_, stderr, err = util.RunOVNNbctl("--id=@acl", "create", "acl",
 		fmt.Sprintf("priority=%s", priority),
 		fmt.Sprintf("direction=%s", direction), match, "action=drop",
 		fmt.Sprintf("external-ids:ipblock-deny-policy-type=%s", policyType),
@@ -219,7 +219,7 @@ func (oc *Controller) deleteIPBlockACLDenyOld(namespace, policy,
 		match = fmt.Sprintf("match=\"%s && %s\"", lportMatch, l3Match)
 	}
 
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL", match, "action=drop",
 		fmt.Sprintf("external-ids:ipblock-deny-policy-type=%s", policyType),
 		fmt.Sprintf("external-ids:namespace=%s", namespace),
@@ -237,7 +237,7 @@ func (oc *Controller) deleteIPBlockACLDenyOld(namespace, policy,
 		return
 	}
 
-	_, stderr, err = util.RunOVNNbctlHA("remove", "logical_switch",
+	_, stderr, err = util.RunOVNNbctl("remove", "logical_switch",
 		logicalSwitch, "acls", uuid)
 	if err != nil {
 		logrus.Errorf("remove failed to delete the deny rule for "+
@@ -258,7 +258,7 @@ func (oc *Controller) addACLDenyOld(namespace, logicalSwitch, logicalPort,
 		match = fmt.Sprintf("match=\"inport == \\\"%s\\\"\"", logicalPort)
 	}
 
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL", match, "action=drop",
 		fmt.Sprintf("external-ids:default-deny-policy-type=%s", policyType),
 		fmt.Sprintf("external-ids:namespace=%s", namespace),
@@ -275,7 +275,7 @@ func (oc *Controller) addACLDenyOld(namespace, logicalSwitch, logicalPort,
 		return
 	}
 
-	_, stderr, err = util.RunOVNNbctlHA("--id=@acl", "create", "acl",
+	_, stderr, err = util.RunOVNNbctl("--id=@acl", "create", "acl",
 		fmt.Sprintf("priority=%s", priority),
 		fmt.Sprintf("direction=%s", direction), match, "action=drop",
 		fmt.Sprintf("external-ids:default-deny-policy-type=%s", policyType),
@@ -300,7 +300,7 @@ func (oc *Controller) deleteACLDenyOld(namespace, logicalSwitch, logicalPort str
 		match = fmt.Sprintf("match=\"inport == \\\"%s\\\"\"", logicalPort)
 	}
 
-	uuid, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL", match, "action=drop",
 		fmt.Sprintf("external-ids:default-deny-policy-type=%s", policyType),
 		fmt.Sprintf("external-ids:namespace=%s", namespace),
@@ -317,7 +317,7 @@ func (oc *Controller) deleteACLDenyOld(namespace, logicalSwitch, logicalPort str
 		return
 	}
 
-	_, stderr, err = util.RunOVNNbctlHA("remove", "logical_switch",
+	_, stderr, err = util.RunOVNNbctl("remove", "logical_switch",
 		logicalSwitch, "acls", uuid)
 	if err != nil {
 		logrus.Errorf("remove failed to delete the deny rule for "+
@@ -329,7 +329,7 @@ func (oc *Controller) deleteACLDenyOld(namespace, logicalSwitch, logicalPort str
 }
 
 func (oc *Controller) deleteAclsPolicyOld(namespace, policy string) {
-	uuids, stderr, err := util.RunOVNNbctlHA("--data=bare", "--no-heading",
+	uuids, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "ACL",
 		fmt.Sprintf("external-ids:namespace=%s", namespace),
 		fmt.Sprintf("external-ids:policy=%s", policy))
@@ -349,7 +349,7 @@ func (oc *Controller) deleteAclsPolicyOld(namespace, policy string) {
 	uuidSlice := strings.Fields(uuids)
 	for _, uuid := range uuidSlice {
 		// Get logical switch
-		logicalSwitch, stderr, err := util.RunOVNNbctlHA("--data=bare",
+		logicalSwitch, stderr, err := util.RunOVNNbctl("--data=bare",
 			"--no-heading", "--columns=_uuid", "find", "logical_switch",
 			fmt.Sprintf("acls{>=}%s", uuid))
 		if err != nil {
@@ -362,7 +362,7 @@ func (oc *Controller) deleteAclsPolicyOld(namespace, policy string) {
 			continue
 		}
 
-		_, stderr, err = util.RunOVNNbctlHA("remove", "logical_switch",
+		_, stderr, err = util.RunOVNNbctl("remove", "logical_switch",
 			logicalSwitch, "acls", uuid)
 		if err != nil {
 			logrus.Errorf("remove failed to delete the allow-from rule %s for"+
@@ -937,7 +937,7 @@ func (oc *Controller) getLogicalSwitchForLogicalPort(
 		return oc.logicalPortCache[logicalPort]
 	}
 
-	logicalSwitch, stderr, err := util.RunOVNNbctlHA("get",
+	logicalSwitch, stderr, err := util.RunOVNNbctl("get",
 		"logical_switch_port", logicalPort, "external-ids:logical_switch")
 	if err != nil {
 		logrus.Errorf("Error obtaining logical switch for %s, stderr: %q (%v)",

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -197,18 +197,6 @@ func RunOVNNbctlUnix(args ...string) (string, string, error) {
 		stderr.String(), err
 }
 
-// RunOVNNbctlHA connects to multiple servers if they are provided as an input.
-// If there is a single server provided, it assumes that it is local and uses
-// Unix domain sockets for the connection.
-func RunOVNNbctlHA(args ...string) (string, string, error) {
-	ovnNorthAddress := config.OvnNorth.ClientAuth.OvnAddressForClient
-	ovnNorthAddresses := strings.Split(ovnNorthAddress, ",")
-	if len(ovnNorthAddresses) == 1 {
-		return RunOVNNbctlUnix(args...)
-	}
-	return RunOVNNbctl(args...)
-}
-
 // RunOVNNbctlWithTimeout runs command via ovn-nbctl with a specific timeout
 func RunOVNNbctlWithTimeout(timeout int, args ...string) (string, string,
 	error) {


### PR DESCRIPTION
RunOVNNbctlHA incorrectly assumes that if a single server is provided
for ovn-nb, then OVN NB is available locally and it switches the
connection to use AF_UNIX. It could be that the OVN DBs are external
to K8s cluster and may not be available locally on the master node
(or that the OVN DB is configured as active-standby or active-backup
nodes outside of K8s cluster)

If users are deploying a single instance of master and OVN DBs and
if they really need to use UNIX scheme for more reliability, then they
can always start the ovnkube.sh with --nb-address and --sb-address
set to nothing. This will automatically falls back to UNIX scheme.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>