### PR TITLE
Ansible: Validate healthy minions in K8s API

### DIFF
--- a/contrib/roles/linux/validation/tasks/main.yml
+++ b/contrib/roles/linux/validation/tasks/main.yml
@@ -52,7 +52,7 @@
       register: result
       shell: |
         set -o pipefail
-        kubectl get pod --selector k8s-app=kube-dns --namespace kube-system --output json | python3 "{{ python_script.path }}"
+        kubectl get pod --selector k8s-app=kube-dns --namespace kube-system --output json | {{ ansible_python.executable }} "{{ python_script.path }}"
       args:
         executable: /bin/bash
       until: result.rc == 0
@@ -93,7 +93,7 @@
       register: result
       shell: |
         set -o pipefail
-        kubectl get node {{ ansible_hostname | lower }} --output json | python3 "{{ python_script.path }}"
+        kubectl get node {{ ansible_hostname | lower }} --output json | {{ ansible_python.executable }} "{{ python_script.path }}"
       args:
         executable: /bin/bash
       until: result.rc == 0

--- a/contrib/roles/linux/validation/tasks/main.yml
+++ b/contrib/roles/linux/validation/tasks/main.yml
@@ -62,3 +62,44 @@
         path: "{{ python_script.path }}"
         state: absent
   when: master
+
+- name: Linux validation | Confirm that the minion is registered to the K8s API
+  block:
+    - name: Linux validation | Create temp file for Python script
+      tempfile:
+        state: file
+      register: python_script
+
+    - name: Linux validation | Set the Python script content
+      blockinfile:
+        path: "{{ python_script.path }}"
+        create: yes
+        block: |
+          import json
+          import sys
+          node_info = json.load(sys.stdin)
+          last_status = node_info['status']['conditions'][-1]
+
+          if last_status['type'] == 'Ready' and last_status['status'] == 'True':
+              print('Node %s is ready' % (node_info['metadata']['name']))
+              sys.exit(0)
+
+          print('ERROR: Node %s is not ready.' % (node_info['metadata']['name']))
+          sys.exit(1)
+
+    - name: Linux validation | Confirm K8s minion health
+      retries: 10
+      delay: 5
+      register: result
+      shell: |
+        set -o pipefail
+        kubectl get node {{ ansible_hostname | lower }} --output json | python3 "{{ python_script.path }}"
+      args:
+        executable: /bin/bash
+      until: result.rc == 0
+
+    - name: Linux validation | Cleanup the temp Python script file
+      file:
+        path: "{{ python_script.path }}"
+        state: absent
+  when: not master

--- a/contrib/roles/windows/validation/tasks/main.yml
+++ b/contrib/roles/windows/validation/tasks/main.yml
@@ -5,3 +5,25 @@
 - name: Windows validation | Validate the services success state
   include: "./validate_service.yml service_name={{ item }}"
   with_items: "{{ service_names }}"
+
+- name: Windows validation | Confirm that the minion is registered to the K8s API
+  retries: 10
+  delay: 5
+  register: result
+  win_shell: |
+    $ErrorActionPreference = "Stop"
+    $output = kubectl.exe get node {{ ansible_hostname | lower }} --output=json
+    if($LASTEXITCODE) {
+        Write-Output "ERROR: kubectl.exe CLI exec failed"
+        exit 1
+    }
+    $nodeInfo = $output | ConvertFrom-Json
+    $lastStatus = $nodeInfo.status.conditions[-1]
+    if($lastStatus.type -eq "Ready" -and $lastStatus.status -eq "True") {
+        Write-Output "Node $($nodeInfo.metadata.name) is ready"
+        exit 0
+    }
+    Write-Output "Node $($nodeInfo.metadata.name) is not ready"
+    exit 1
+
+  until: result.rc == 0


### PR DESCRIPTION
Add tasks for both Linux and Windows to confirm healthy
K8s minions.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>