### PR TITLE
Ansible: Add more validation for K8s Minions

### DIFF
--- a/contrib/roles/linux/validation/tasks/main.yml
+++ b/contrib/roles/linux/validation/tasks/main.yml
@@ -34,3 +34,23 @@
     executable: /bin/bash
   until: result.rc == 0
   when: master
+
+- name: Linux validation | Confirm K8s minions health
+  retries: 10
+  delay: 5
+  register: result
+  shell: |
+    set -o errexit
+    READY_STATUS=$(kubectl get node {{ hostvars[item]['ansible_facts']['hostname'] | lower }} --output jsonpath='{@.status.conditions[?(@.type=="Ready")].status}')
+    if [[ "$READY_STATUS" != "True" ]]; then
+        echo "ERROR: Node {{ hostvars[item]['ansible_facts']['hostname'] | lower }} is not ready"
+        exit 1
+    fi
+    echo "Node {{ hostvars[item]['ansible_facts']['hostname'] | lower }} is ready"
+  args:
+    executable: /bin/bash
+  until: result.rc == 0
+  with_items:
+    - "{{ groups['kube-minions-linux'] }}"
+    - "{{ groups['kube-minions-windows'] }}"
+  when: master

--- a/contrib/roles/linux/validation/tasks/main.yml
+++ b/contrib/roles/linux/validation/tasks/main.yml
@@ -18,47 +18,19 @@
   include: "./validate_service.yml service_name={{ item }}"
   with_items: "{{ service_names }}"
 
-- name: Linux validation | Validate if the CoreDNS pods are running
+- name: Linux validation | Validate if the pods from namespace kube-system (CoreDNS) are running
   run_once: true
-  block:
-    - name: Linux validation | Create temp file for Python script
-      tempfile:
-        state: file
-      register: python_script
-
-    - name: Linux validation | Set the Python script content
-      blockinfile:
-        path: "{{ python_script.path }}"
-        create: yes
-        block: |
-          import json
-          import sys
-          pods = json.load(sys.stdin)
-          for pod in pods['items']:
-              if pod['status']['phase'] != 'Running':
-                  #
-                  # More info about pod phase here:
-                  # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
-                  #
-                  print('ERROR: Pod %s is not running.'
-                        'Current phase is: %s' % (pod['metadata']['name'],
-                                                  pod['status']['phase']))
-                  sys.exit(1)
-              print('Pod %s is running.' % (pod['metadata']['name']))
-
-    - name: Linux validation | Check the CoreDNS pods
-      retries: 10
-      delay: 5
-      register: result
-      shell: |
-        set -o pipefail
-        kubectl get pod --selector k8s-app=kube-dns --namespace kube-system --output json | python3 "{{ python_script.path }}"
-      args:
-        executable: /bin/bash
-      until: result.rc == 0
-
-    - name: Linux validation | Cleanup the temp Python script file
-      file:
-        path: "{{ python_script.path }}"
-        state: absent
+  retries: 10
+  delay: 5
+  register: result
+  shell: |
+    set -o errexit
+    for UNHEALTHY_POD in $(kubectl get pods --namespace kube-system --output jsonpath='{@.items[?(@.status.phase!="Running")].metadata.name}'); do
+        echo "ERROR: Pod $UNHEALTHY_POD from namespace kube-system is not running"
+        exit 1
+    done
+    echo "All the pods from namespace kube-system are running"
+  args:
+    executable: /bin/bash
+  until: result.rc == 0
   when: master


### PR DESCRIPTION
* Instead of using Python and a script created on the fly, we use native support for JSONPath from the kubectl CLI tool
* Add task to validate K8s API health for Linux and Windows minions

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>