### PR TITLE
Dockerfile: failing to build ubuntu based daemonset images

### DIFF
--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -12,8 +12,7 @@ FROM ubuntu:18.04
 
 USER root
 
-RUN apt-get update
-RUN apt-get install -y iptables iproute2 curl gawk software-properties-common
+RUN apt-get update && apt-get install -y iptables iproute2 curl gawk software-properties-common
 
 # We do not have much control over the exact version of OVS/OVN that can be
 # obtained from upstream Ubuntu. guru@ovn.org maintains more latest versions of
@@ -21,11 +20,9 @@ RUN apt-get install -y iptables iproute2 curl gawk software-properties-common
 # you prefer to use upstream Ubuntu packages instead.
 RUN echo "deb http://18.191.116.101/openvswitch/stable /" |  tee /etc/apt/sources.list.d/openvswitch.list
 RUN curl http://18.191.116.101/openvswitch/keyFile |  apt-key add -
-RUN apt-get update
 
 # Install OVS and OVN packages.
-RUN apt-get install -y openvswitch-switch openvswitch-common
-RUN apt-get install -y ovn-central ovn-common ovn-host
+RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host
 
 RUN mkdir -p /var/run/openvswitch
 RUN mkdir -p /etc/cni/net.d


### PR DESCRIPTION
Currently, the Dockerfile.ubuntu has following two lines

RUN apt-get update
RUN apt-get install -y iptables iproute2 curl gawk software-properties-common

Very recently, `gawk` was added to the list of packages to be installed.
Since, the first line `apt-get update` didn't change when you build the
docker image on the build system it skips that step and installing gawk
fails because the apt package index has not been updated.

Per Dockerfile best practices guide, we need to merge those lines into
one like below:

RUN apt-get update && apt-get install -y iptables iproute2 curl gawk\
    software-properties-common

With that `apt-get update` always run and this technique is called
cache-busting.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>