### PR TITLE
Ansible: replace fetch with synchronize

### DIFF
--- a/contrib/roles/linux/kubernetes/tasks/fetch_k8s_binaries.yml
+++ b/contrib/roles/linux/kubernetes/tasks/fetch_k8s_binaries.yml
@@ -1,20 +1,20 @@
 ---
 - name: Kubernetes bins | fetch Linux binaries to the ansible host
-  fetch:
-    fail_on_missing: yes
-    flat: yes
+  synchronize:
+    mode: pull
     src: "{{kubernetes_binaries_info.tmp_download_path}}/kubernetes/server/kubernetes/server/bin/{{item}}"
     dest: "{{ansible_tmp_dir}}/{{item}}"
+    use_ssh_args: yes
   with_items:
     - "{{kubernetes_binaries.linux_common}}"
     - "{{kubernetes_binaries.linux_master}}"
     - "{{kubernetes_binaries.linux_minion}}"
 
 - name: Kubernetes bins | fetch Windows binaries to the ansible host
-  fetch:
-    fail_on_missing: yes
-    flat: yes
+  synchronize:
+    mode: pull
     src: "{{kubernetes_binaries_info.tmp_download_path}}/kubernetes/node/bin/{{item}}"
     dest: "{{ansible_tmp_dir}}/{{item}}"
+    use_ssh_args: yes
   with_items:
     - "{{kubernetes_binaries.windows}}"

--- a/contrib/roles/linux/kubernetes/tasks/generate_global_vars.yml
+++ b/contrib/roles/linux/kubernetes/tasks/generate_global_vars.yml
@@ -32,8 +32,8 @@
   changed_when: false
 
 - name: Kubernetes global vars | Fetch vars
-  fetch:
-    fail_on_missing: yes
-    flat: yes
+  synchronize:
+    mode: pull
     src: /tmp/generated_global_vars.yml
     dest: "{{ansible_tmp_dir}}/generated_global_vars.yml"
+    use_ssh_args: yes

--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -136,10 +136,11 @@
          not admin_cert_key.stat.exists)
 
 - name: Kubernetes Master | Fetching certificates on the ansible host
-  fetch:
-    flat: yes
+  synchronize:
+    mode: pull
     src: "{{ kubernetes_certificates.directory }}/{{ item }}"
     dest: "{{ ansible_tmp_dir }}/k8s_{{ item }}"
+    use_ssh_args: yes
   with_items:
     - ca.pem
     - ca-key.pem

--- a/contrib/roles/linux/ovn-kubernetes/tasks/fetch_bins.yml
+++ b/contrib/roles/linux/ovn-kubernetes/tasks/fetch_bins.yml
@@ -1,18 +1,24 @@
 ---
+- name: ovn-kubernetes | create local temporary directory
+  local_action:
+    module: file
+    path: "{{ ansible_tmp_dir }}"
+    state: directory
+
 - name: ovn-kubernetes | fetch linux bins
-  fetch:
-    fail_on_missing: yes
-    flat: yes
+  synchronize:
+    mode: pull
     src: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller/_output/go/bin/{{item}}"
     dest: "{{ansible_tmp_dir}}/{{item}}"
+    use_ssh_args: yes
   with_items:
     - "{{ovn_kubernetes_binaries.linux}}"
 
 - name: ovn-kubernetes | fetch windows bins
-  fetch:
-    fail_on_missing: yes
-    flat: yes
+  synchronize:
+    mode: pull
     src: "{{ovn_kubernetes_info.build_path}}/ovn-kubernetes-checkout/go-controller/_output/go/windows/{{item}}"
     dest: "{{ansible_tmp_dir}}/{{item}}"
+    use_ssh_args: yes
   with_items:
     - "{{ovn_kubernetes_binaries.windows}}"


### PR DESCRIPTION
The fetch module has a bug which causes it to use memory proportional
to the file being transfered. 'synchronize' uses rsync which only has
low memory requirements.

Fixes #494

Signed-off-by: Sebastian Geiger <sbastig@gmx.net>