### PR TITLE
Gateway: do not enforce that the interface name be embedded in bridge…

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Gateway Init Operations", func() {
 					Err: fmt.Errorf(""),
 				})
 				fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-					Cmd: "ovs-vsctl --timeout=15 -- --may-exist add-br breth0 -- br-set-external-id breth0 bridge-id breth0 -- set bridge breth0 fail-mode=standalone other_config:hwaddr=" + eth0MAC + " -- --may-exist add-port breth0 eth0 -- set port eth0 other-config:transient=true",
+					Cmd: "ovs-vsctl --timeout=15 -- --may-exist add-br breth0 -- br-set-external-id breth0 bridge-id breth0 -- br-set-external-id breth0 bridge-uplink eth0 -- set bridge breth0 fail-mode=standalone other_config:hwaddr=" + eth0MAC + " -- --may-exist add-port breth0 eth0 -- set port eth0 other-config:transient=true",
 					Action: func() error {
 						return testNS.Do(func(ns.NetNS) error {
 							defer GinkgoRecover()

--- a/go-controller/pkg/cluster/helper_linux.go
+++ b/go-controller/pkg/cluster/helper_linux.go
@@ -4,7 +4,6 @@ package cluster
 
 import (
 	"fmt"
-	"strings"
 	"syscall"
 
 	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
@@ -38,12 +37,8 @@ func getDefaultGatewayInterfaceDetails() (string, string, error) {
 }
 
 func getIntfName(gatewayIntf string) (string, error) {
-	// The given (or autodetected) interface is an OVS bridge;
-	// detect if we previously ran NIC/bridge setup
-	if !strings.HasPrefix(gatewayIntf, "br") {
-		return "", fmt.Errorf("gateway interface %s is an OVS bridge not "+
-			"a physical device", gatewayIntf)
-	}
+	// The given (or autodetected) interface is an OVS bridge and this could be
+	// created by us using util.NicToBridge() or it was pre-created by the user.
 
 	// Is intfName a port of gatewayIntf?
 	intfName := util.GetNicName(gatewayIntf)


### PR DESCRIPTION
… name

Currently, the ovnkube in node mode requires that the OVS bridge name
start with br<gw_inteface_name> for the shared gateway interface option.
This is hard to enforce if the bridge is already created in the host by
the user.

The following changeset adds a new key called 'bridge-uplink' to the
external_ids column of the bridge table. This key captures the shared
gateway interface. With that, if the user creates the bridge ahead of
time, then they will need to populate the bridge-uplink to the shared
gateway interface value and they can name the bridge whatever they want
(br-eth2, ovs-br, admin-br, and so on).

Also, when ovnkube creates a bridge using util.NICtoBridge() code it
will also populate the bridge-uplink key.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>