### PR TITLE
gateway: use localnet ports on external logical switch

### DIFF
--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -105,6 +105,15 @@ func initLocalnetGatewayInternal(nodeName string, clusterIPSubnet []string,
 			", stderr:%s (%v)", localnetBridgeName, stderr, err)
 	}
 
+	// ovn-bridge-mappings maps a physical network name to a local ovs bridge
+	// that provides connectivity to that network.
+	_, stderr, err = util.RunOVSVsctl("set", "Open_vSwitch", ".",
+		fmt.Sprintf("external_ids:ovn-bridge-mappings=%s:%s", util.PhysicalNetworkName, localnetBridgeName))
+	if err != nil {
+		return fmt.Errorf("Failed to set ovn-bridge-mappings for ovs bridge %s"+
+			", stderr:%s (%v)", localnetBridgeName, stderr, err)
+	}
+
 	_, _, err = util.RunIP("link", "set", localnetBridgeName, "up")
 	if err != nil {
 		return fmt.Errorf("failed to up %s (%v)", localnetBridgeName, err)

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -146,8 +146,10 @@ func syncServices(services []interface{}, gwBridge, gwIntf string) {
 	}
 }
 
-func nodePortWatcher(gwBridge, gwIntf string, wf *factory.WatchFactory) error {
-	patchPort := "k8s-patch-" + gwBridge + "-br-int"
+func nodePortWatcher(nodeName, gwBridge, gwIntf string, wf *factory.WatchFactory) error {
+	// the name of the patch port created by ovn-controller is of the form
+	// patch-<logical_port_name_of_localnet_port>-to-br-int
+	patchPort := "patch-" + gwBridge + "_" + nodeName + "-to-br-int"
 	// Get ofport of patchPort
 	ofportPatch, stderr, err := util.RunOVSVsctl("--if-exists", "get",
 		"interface", patchPort, "ofport")
@@ -182,8 +184,10 @@ func nodePortWatcher(gwBridge, gwIntf string, wf *factory.WatchFactory) error {
 	return err
 }
 
-func addDefaultConntrackRules(gwBridge, gwIntf string) error {
-	patchPort := "k8s-patch-" + gwBridge + "-br-int"
+func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string) error {
+	// the name of the patch port created by ovn-controller is of the form
+	// patch-<logical_port_name_of_localnet_port>-to-br-int
+	patchPort := "patch-" + gwBridge + "_" + nodeName + "-to-br-int"
 	// Get ofport of pathPort
 	ofportPatch, stderr, err := util.RunOVSVsctl("--if-exists", "get",
 		"interface", patchPort, "ofport")
@@ -271,6 +275,15 @@ func initSharedGateway(
 		gwIntf = intfName
 	}
 
+	// ovn-bridge-mappings maps a physical network name to a local ovs bridge
+	// that provides connectivity to that network.
+	_, stderr, err := util.RunOVSVsctl("set", "Open_vSwitch", ".",
+		fmt.Sprintf("external_ids:ovn-bridge-mappings=%s:%s", util.PhysicalNetworkName, bridgeName))
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to set ovn-bridge-mappings for ovs bridge %s"+
+			", stderr:%s (%v)", bridgeName, stderr, err)
+	}
+
 	// Now, we get IP address from OVS bridge. If IP does not exist,
 	// error out.
 	ipAddress, err := getIPv4Address(bridgeName)
@@ -289,13 +302,13 @@ func initSharedGateway(
 
 	// Program cluster.GatewayIntf to let non-pod traffic to go to host
 	// stack
-	if err := addDefaultConntrackRules(bridgeName, gwIntf); err != nil {
+	if err := addDefaultConntrackRules(nodeName, bridgeName, gwIntf); err != nil {
 		return "", "", err
 	}
 
 	if nodeportEnable {
 		// Program cluster.GatewayIntf to let nodePort traffic to go to pods.
-		if err := nodePortWatcher(bridgeName, gwIntf, wf); err != nil {
+		if err := nodePortWatcher(nodeName, bridgeName, gwIntf, wf); err != nil {
 			return "", "", err
 		}
 	}

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+const (
+	// PhysicalNetworkName is the name that maps to an OVS bridge that provides
+	// access to physical/external network
+	PhysicalNetworkName = "physnet"
+)
+
 // GetK8sClusterRouter returns back the OVN distibuted router
 func GetK8sClusterRouter() (string, error) {
 	k8sClusterRouter, stderr, err := RunOVNNbctl("--data=bare",
@@ -286,6 +292,7 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 	}
 
 	var ifaceID, macAddress string
+	var localNetArgs = []string{}
 	if physicalInterface != "" {
 		// Connect physical interface to br-int. Get its mac address.
 		ifaceID = physicalInterface + "_" + nodeName
@@ -333,14 +340,19 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 				"error: %v", stdout, stderr, err)
 		}
 		ifaceID = bridgeInterface + "_" + nodeName
+		localNetArgs = []string{"--", "lsp-set-type", ifaceID, "localnet",
+			"--", "lsp-set-options", ifaceID,
+			fmt.Sprintf("network_name=%s", PhysicalNetworkName)}
 
-		// Connect bridge interface to br-int via patch ports.
-		patch1 := "k8s-patch-br-int-" + bridgeInterface
-		patch2 := "k8s-patch-" + bridgeInterface + "-br-int"
+		// Connect bridge interface to br-int via patch ports. We use the name format
+		// as used by ovn-controller for localnet ports.
+		patch1 := "patch-br-int-to-" + ifaceID
+		patch2 := "patch-" + ifaceID + "-to-br-int"
 
 		stdout, stderr, err = RunOVSVsctl("--may-exist", "add-port",
 			bridgeInterface, patch2, "--", "set", "interface", patch2,
-			"type=patch", "options:peer="+patch1)
+			"type=patch", "options:peer="+patch1, "--", "set", "port", patch2,
+			"external_ids:ovn-localnet-port="+ifaceID)
 		if err != nil {
 			return fmt.Errorf("Failed to add port, stdout: %q, stderr: %q, "+
 				"error: %v", stdout, stderr, err)
@@ -348,7 +360,8 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 
 		stdout, stderr, err = RunOVSVsctl("--may-exist", "add-port",
 			"br-int", patch1, "--", "set", "interface", patch1, "type=patch",
-			"options:peer="+patch2, "external-ids:iface-id="+ifaceID)
+			"options:peer="+patch2, "--", "set", "port", patch1,
+			"external_ids:ovn-localnet-port="+ifaceID)
 		if err != nil {
 			return fmt.Errorf("Failed to add port, stdout: %q, stderr: %q, "+
 				"error: %v", stdout, stderr, err)
@@ -358,8 +371,10 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 	// Add external interface as a logical port to external_switch.
 	// This is a learning switch port with "unknown" address. The external
 	// world is accessed via this port.
-	stdout, stderr, err = RunOVNNbctl("--", "--may-exist", "lsp-add",
-		externalSwitch, ifaceID, "--", "lsp-set-addresses", ifaceID, "unknown")
+	cmdArgs := []string{"--", "--may-exist", "lsp-add", externalSwitch, ifaceID,
+		"--", "lsp-set-addresses", ifaceID, "unknown"}
+	cmdArgs = append(cmdArgs, localNetArgs...)
+	stdout, stderr, err = RunOVNNbctl(cmdArgs...)
 	if err != nil {
 		return fmt.Errorf("Failed to add logical port to switch, stdout: %q, "+
 			"stderr: %q, error: %v", stdout, stderr, err)

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -236,21 +236,45 @@ func BridgeToNic(bridge string) error {
 		return err
 	}
 
+	// for every bridge interface that is of type "patch", find the peer
+	// interface and delete that interface from the integration bridge
+	stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)
+	if err != nil {
+		logrus.Errorf("Failed to get interfaces for OVS bridge: %q, "+
+			"stderr: %q, error: %v", bridge, stderr, err)
+		return err
+	}
+	ifacesList := strings.Split(strings.TrimSpace(stdout), "\n")
+	for _, iface := range ifacesList {
+		stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "type")
+		if err != nil {
+			logrus.Warnf("Failed to determine the type of interface: %q, "+
+				"stderr: %q, error: %v", iface, stderr, err)
+			continue
+		} else if stdout != "patch" {
+			continue
+		}
+		stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "options:peer")
+		if err != nil {
+			logrus.Warnf("Failed to get the peer port for patch interface: %q, "+
+				"stderr: %q, error: %v", iface, stderr, err)
+			continue
+		}
+		// stdout has the peer interface, just delete it
+		peer := strings.TrimSpace(stdout)
+		_, stderr, err = RunOVSVsctl("--if-exists", "del-port", "br-int", peer)
+		if err != nil {
+			logrus.Warnf("Failed to delete patch port %q on br-int, "+
+				"stderr: %q, error: %v", peer, stderr, err)
+		}
+	}
+
 	// Now delete the bridge
-	stdout, stderr, err := RunOVSVsctl("--", "--if-exists", "del-br", bridge)
+	stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)
 	if err != nil {
 		logrus.Errorf("Failed to delete OVS bridge, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err
 	}
 	logrus.Infof("Successfully deleted OVS bridge %q", bridge)
-
-	// Now delete the patch port on the integration bridge, if present
-	stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-port", "br-int",
-		fmt.Sprintf("k8s-patch-br-int-%s", bridge))
-	if err != nil {
-		logrus.Errorf("Failed to delete patch port on br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return err
-	}
-
 	return nil
 }


### PR DESCRIPTION
The external OVN logical switch that connects the OVN l3gateway router
(and all of the logical ports behind that gateway router) to physical
network should make use of 'localnet' logical port type.

The localnet ports are defined as below in ovn-architecture(7) document
   -----
   Localnet  ports represent the points of connectivity between
   logical switches and the physical network. They  are  implemented as
   OVS patch ports between the integration bridge  and  the  separate
   Open vSwitch  bridge that underlay physical ports attach to.
   -----
and it fits our requirement very well.

They are also essential to support the physical network that is tagged
or VLAN based. From the ovn-nb(5) we have
   -----
   When port is localnet, tag_request can be set to indicate that the
   port represents a  connection  to  a  specific VLAN  on  a  locally
   accessible network. The VLAN ID is used to match incoming traffic and
   is also added to outgoing traffic.
   -----

 The new logical topology will look like:

       +--------------------------------+
       |      GR_k8s_minion_node1       |
       |       (L3Gateway Router)       |
       +----------------+---------------+
              rtoe-GR_k8s_minion_node1
                        |
                        |
                        |
              etor-GR_k8s_minion_node1
       +----------------+---------------+
       |      ext_k8s_minion_node1      |
       |        (Logical Switch)        |
       |+----------+                    |
       ++ localnet +--------------------+
        +---+------+
     brenp5s0_k8s_minion_node1
            |
            |
     -------+---------------
       underlay network (can be tagged or VLAN based)

Fixes #485

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>