### PR TITLE
gateway: use localnet ports on external logical switch

### DIFF
--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -105,6 +105,15 @@ func initLocalnetGatewayInternal(nodeName string, clusterIPSubnet []string,
 			", stderr:%s (%v)", localnetBridgeName, stderr, err)
 	}
 
+	// ovn-bridge-mappings maps a physical network name to a local ovs bridge
+	// that provides connectivity to that network.
+	_, stderr, err = util.RunOVSVsctl("set", "Open_vSwitch", ".",
+		fmt.Sprintf("external_ids:ovn-bridge-mappings=%s:%s", util.PhysicalNetworkName, localnetBridgeName))
+	if err != nil {
+		return fmt.Errorf("Failed to set ovn-bridge-mappings for ovs bridge %s"+
+			", stderr:%s (%v)", localnetBridgeName, stderr, err)
+	}
+
 	_, _, err = util.RunIP("link", "set", localnetBridgeName, "up")
 	if err != nil {
 		return fmt.Errorf("failed to up %s (%v)", localnetBridgeName, err)


### PR DESCRIPTION
The external OVN logical switch that connects the OVN l3gateway router
(and all of the logical ports behind that gateway router) to physical
network should make use of 'localnet' logical port type.

The localnet ports are defined as below in ovn-architecture(7) document

   Localnet  ports represent the points of connectivity between
   logical switches and the physical network. They  are  implemented as
   OVS patch ports between the integration bridge  and  the  separate
   Open vSwitch  bridge that underlay physical ports attach to.

and it fits our requirement very well.

They are also essential to support the physical network that is tagged
or VLAN based. From the ovn-nb(5) we have

   When port is localnet, tag_request can be set to indicate that the
   port represents a  connection  to  a  specific VLAN  on  a  locally
   accessible network. The VLAN ID is used to match incoming traffic and
   is also added to outgoing traffic.

 The new logical topology will look like:

       +--------------------------------+
       |      GR_k8s_minion_node1       |
       |       (L3Gateway Router)       |
       +----------------+---------------+
              rtoe-GR_k8s_minion_node1
                        |
                        |
                        |
              etor-GR_k8s_minion_node1
       +----------------+---------------+
       |      ext_k8s_minion_node1      |
       |        (Logical Switch)        |
       |+----------+                    |
       ++ localnet +--------------------+
        +---+------+
     brenp5s0_k8s_minion_node1
            |
            |
     -------+---------------
       underlay network (can be tagged or VLAN based)

Fixes #485

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>