### PR TITLE
Access kube-apiserver with ovn pod's secret

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -149,7 +149,7 @@ wait_for_event () {
 ready_to_start_node () {
 
   # See if ep is available ...
-  ovn_master_host=$(KUBECONFIG=${KUBECONFIG:-"/etc/origin/node/node.kubeconfig"} kubectl get ep -n ovn-kubernetes ovnkube-master 2>/dev/null | grep 6642 | sed 's/:/ /' | awk '/ovnkube-master/{ print $2 }')
+  ovn_master_host=$(kubectl --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) get ep -n ovn-kubernetes ovnkube-master 2>/dev/null | grep 6642 | sed 's/:/ /' | gawk '/ovnkube-master/{ print $2 }')
   if [[ ${ovn_master_host} == "" ]] ; then
     # ... if not (we may be on the master) see if northd is up
     get_master_ovn_vars
@@ -754,7 +754,7 @@ echo "================== ovnkube.sh --- version: ${ovnkube_version} ============
   display_version
 
   # get api server
-  k8s_server=$(KUBECONFIG=${KUBECONFIG:-"/etc/origin/node/node.kubeconfig"} kubectl config view --minify | awk '/server:/{ print $2 }')
+  k8s_server="https://${KUBERNETES_PORT_443_TCP_ADDR}:${KUBERNETES_SERVICE_PORT_HTTPS}"
   k8s_apiserver=${K8S_APISERVER:-${k8s_server}}
 
   # display_env


### PR DESCRIPTION
Instead of using node kubeconfig file, use the ovn pod token to access kube-apiserver.
Retrieve kube-apiserver URL from pod env variables.

Fixes #602
