### PR TITLE
daemonset: miscellaneous fixes to get daemonset to work

### DIFF
--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -12,7 +12,7 @@ FROM ubuntu:18.04
 
 USER root
 
-RUN apt-get update && apt-get install -y iptables iproute2 curl gawk software-properties-common
+RUN apt-get update && apt-get install -y iptables iproute2 curl software-properties-common
 
 # We do not have much control over the exact version of OVS/OVN that can be
 # obtained from upstream Ubuntu. guru@ovn.org maintains more latest versions of

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -87,8 +87,6 @@ spec:
         # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
-        - mountPath: /etc/origin/node
-          name: host-origin-node
         # CNI related mounts which we take over
         - mountPath: /host/opt/cni/bin
           name: host-opt-cni-bin
@@ -116,6 +114,11 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
         - name: K8S_NODE
           valueFrom:
             fieldRef:
@@ -175,8 +178,6 @@ spec:
         # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
-        - mountPath: /etc/origin/node
-          name: host-origin-node
         # CNI related mounts which we take over
         - mountPath: /host/opt/cni/bin
           name: host-opt-cni-bin
@@ -204,6 +205,11 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
         - name: K8S_NODE
           valueFrom:
             fieldRef:
@@ -263,8 +269,6 @@ spec:
         # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
-        - mountPath: /etc/origin/node
-          name: host-origin-node
         # CNI related mounts which we take over
         - mountPath: /host/opt/cni/bin
           name: host-opt-cni-bin
@@ -292,6 +296,11 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
         - name: K8S_NODE
           valueFrom:
             fieldRef:
@@ -350,8 +359,6 @@ spec:
         # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
-        - mountPath: /etc/origin/node
-          name: host-origin-node
         # CNI related mounts which we take over
         - mountPath: /host/opt/cni/bin
           name: host-opt-cni-bin
@@ -381,6 +388,11 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
         - name: K8S_NODE
           valueFrom:
             fieldRef:
@@ -433,9 +445,6 @@ spec:
       - name: host-var-run-ovn-kubernetes
         hostPath:
           path: /var/run/ovn-kubernetes
-      - name: host-origin-node
-        hostPath:
-          path: /etc/origin/node
       - name: host-opt-cni-bin
         hostPath:
           path: /opt/cni/bin

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -67,8 +67,6 @@ spec:
         - mountPath: /sys
           name: host-sys
           readOnly: true
-        - mountPath: /etc/origin/node
-          name: host-origin-node
         - mountPath: /etc/openvswitch
           name: host-config-openvswitch
         resources:
@@ -81,6 +79,11 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
 
 
       # firewall rules for ovn - assumed to be setup
@@ -127,8 +130,6 @@ spec:
         # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
-        - mountPath: /etc/origin/node
-          name: host-origin-node
         # CNI related mounts which we take over
         - mountPath: /host/opt/cni/bin
           name: host-opt-cni-bin
@@ -156,6 +157,11 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
         - name: K8S_NODE
           valueFrom:
             fieldRef:
@@ -211,8 +217,6 @@ spec:
         # We mount our socket here
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
-        - mountPath: /etc/origin/node
-          name: host-origin-node
         # CNI related mounts which we take over
         - mountPath: /host/opt/cni/bin
           name: host-opt-cni-bin
@@ -240,6 +244,11 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
         - name: K8S_NODE
           valueFrom:
             fieldRef:
@@ -298,10 +307,6 @@ spec:
       - name: host-sys
         hostPath:
           path: /sys
-
-      - name: host-origin-node
-        hostPath:
-          path: /etc/origin/node
       - name: host-opt-cni-bin
         hostPath:
           path: /opt/cni/bin


### PR DESCRIPTION
No need for KUBECONFIG file within the POD to access cluster
out-of-band (without using service IP). Use the 'ovn' serviceaccount
token and ca.crt instead. Require user to specify K8S_APISERVER
parameter through ovn-k8s ConfigMap like we had before.

Remove all the /etc/origin/node mountpath since we don't need the
kubeconfig file anymore.

Add `bind9-host` debian package which provides `host' command that was
being used in ovnkube.sh

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>