### PR TITLE
When OVN cmd fails - add the actual command to the errorw

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -182,7 +182,7 @@ func runOVNretry(cmdPath string, args ...string) (*bytes.Buffer, *bytes.Buffer, 
 			time.Sleep(2 * time.Second)
 		} else {
 			// Some other problem for caller to handle
-			return stdout, stderr, err
+			return stdout, stderr, fmt.Errorf("OVN command '%s %s' failed: %s", cmdPath, strings.Join(args, " "), err)
 		}
 	}
 }


### PR DESCRIPTION
When OVN commands fail, it is useful to log the actual command that failed.