### PR TITLE
cluster/ovn: move node logical switch creation to master

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -60,11 +60,6 @@ func main() {
 			Name:  "init-node",
 			Usage: "initialize node, requires the name that node is registered with in kubernetes cluster",
 		},
-		cli.StringFlag{
-			Name: "remove-node",
-			Usage: "Remove a node from the OVN cluster, requires the name " +
-				"that the node is registered with in the kubernetes cluster",
-		},
 
 		// Daemon file
 		cli.StringFlag{
@@ -186,15 +181,6 @@ func runOvnKube(ctx *cli.Context) error {
 	if err = util.SetExec(exec); err != nil {
 		logrus.Errorf("Failed to initialize exec helper: %v", err)
 		return err
-	}
-
-	nodeToRemove := ctx.String("remove-node")
-	if nodeToRemove != "" {
-		err = util.RemoveNode(nodeToRemove)
-		if err != nil {
-			logrus.Errorf("Failed to remove node %v", err)
-		}
-		return nil
 	}
 
 	pidfile := ctx.String("pidfile")

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -18,6 +18,9 @@ type OvnClusterController struct {
 	watchFactory              *factory.WatchFactory
 	masterSubnetAllocatorList []*netutils.SubnetAllocator
 
+	TCPLoadBalancerUUID string
+	UDPLoadBalancerUUID string
+
 	ClusterServicesSubnet string
 	ClusterIPNet          []CIDRNetworkEntry
 

--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -201,6 +201,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		stop := make(chan struct{})
 		wf, err := factory.NewWatchFactory(fakeClient, stop)
 		Expect(err).NotTo(HaveOccurred())
+		defer wf.Shutdown()
 
 		cluster := OvnClusterController{
 			watchFactory:     wf,
@@ -343,6 +344,7 @@ func spareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		stop := make(chan struct{})
 		wf, err := factory.NewWatchFactory(fakeClient, stop)
 		Expect(err).NotTo(HaveOccurred())
+		defer wf.Shutdown()
 
 		cluster := OvnClusterController{
 			watchFactory:     wf,

--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -503,7 +503,7 @@ func (cluster *OvnClusterController) deleteNode(nodeName string, nodeSubnet *net
 		logrus.Errorf("Error deleting node %s logical network: %v", nodeName, err)
 	}
 
-	if err := util.RemoveNode(nodeName); err != nil {
+	if err := util.GatewayCleanup(nodeName); err != nil {
 		return fmt.Errorf("Failed to clean up node %s gateway: (%v)", nodeName, err)
 	}
 

--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -269,27 +269,27 @@ func (cluster *OvnClusterController) SetupMaster(masterNodeName string) error {
 	}
 
 	// Create 2 load-balancers for east-west traffic.  One handles UDP and another handles TCP.
-	k8sClusterLbTCP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes")
+	cluster.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes")
 	if err != nil {
 		logrus.Errorf("Failed to get tcp load-balancer, stderr: %q, error: %v", stderr, err)
 		return err
 	}
 
-	if k8sClusterLbTCP == "" {
-		stdout, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes", "protocol=tcp")
+	if cluster.TCPLoadBalancerUUID == "" {
+		cluster.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes", "protocol=tcp")
 		if err != nil {
 			logrus.Errorf("Failed to create tcp load-balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 			return err
 		}
 	}
 
-	k8sClusterLbUDP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes")
+	cluster.UDPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes")
 	if err != nil {
 		logrus.Errorf("Failed to get udp load-balancer, stderr: %q, error: %v", stderr, err)
 		return err
 	}
-	if k8sClusterLbUDP == "" {
-		stdout, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes", "protocol=udp")
+	if cluster.UDPLoadBalancerUUID == "" {
+		cluster.UDPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes", "protocol=udp")
 		if err != nil {
 			logrus.Errorf("Failed to create udp load-balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 			return err

--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -241,17 +241,6 @@ func (cluster *OvnClusterController) StartClusterMaster(masterNodeName string) e
 	}
 	cluster.masterSubnetAllocatorList = masterSubnetAllocatorList
 
-	// now go over the 'existing' list again and create annotations for those who do not have it
-	for _, node := range existingNodes.Items {
-		_, ok := node.Annotations[OvnHostSubnet]
-		if !ok {
-			err := cluster.addNode(&node)
-			if err != nil {
-				logrus.Errorf("error creating subnet for node %s: %v", node.Name, err)
-			}
-		}
-	}
-
 	if err := cluster.SetupMaster(masterNodeName); err != nil {
 		logrus.Errorf("Failed to setup master (%v)", err)
 		return err

--- a/go-controller/pkg/cluster/master_test.go
+++ b/go-controller/pkg/cluster/master_test.go
@@ -113,9 +113,7 @@ var _ = Describe("Master Operations", func() {
 			stopChan := make(chan struct{})
 			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				close(stopChan)
-			}()
+			defer f.Shutdown()
 
 			clusterController := NewClusterController(fakeClient, f)
 			Expect(clusterController).NotTo(BeNil())
@@ -231,7 +229,7 @@ subnet=%s
 			stopChan := make(chan struct{})
 			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
+			defer f.Shutdown()
 
 			clusterController := NewClusterController(fakeClient, f)
 			Expect(clusterController).NotTo(BeNil())

--- a/go-controller/pkg/cluster/master_test.go
+++ b/go-controller/pkg/cluster/master_test.go
@@ -1,0 +1,141 @@
+package cluster
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/urfave/cli"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	fakeexec "k8s.io/utils/exec/testing"
+
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/factory"
+	ovntest "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Master Operations", func() {
+	var app *cli.App
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.RestoreDefaultConfig()
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+	})
+
+	It("creates logical network elements for a 2-node cluster", func() {
+		app.Action = func(ctx *cli.Context) error {
+			const (
+				tcpLBUUID    string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
+				udpLBUUID    string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
+				clusterIPNet string = "10.1.0.0"
+				clusterCIDR  string = clusterIPNet + "/16"
+				joinLRPMAC   string = "00:00:00:83:25:1C"
+			)
+
+			fakeCmds := ovntest.AddFakeCmdsNoOutputNoError(nil, []string{
+				"ovn-nbctl --timeout=15 -- --may-exist lr-add ovn_cluster_router -- set logical_router ovn_cluster_router external_ids:k8s-cluster-router=yes",
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+				Output: "",
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-tcp=yes protocol=tcp",
+				Output: tcpLBUUID,
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+				Output: "",
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-udp=yes protocol=udp",
+				Output: udpLBUUID,
+			})
+			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+				"ovn-nbctl --timeout=15 --may-exist ls-add join",
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-ovn_cluster_router mac",
+				Output: joinLRPMAC,
+			})
+			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-ovn_cluster_router -- set logical_switch_port jtor-ovn_cluster_router type=router options:router-port=rtoj-ovn_cluster_router addresses=\"" + joinLRPMAC + "\"",
+				"ovn-nbctl --timeout=15 -- set nb_global . external-ids:gateway-lock=\"\"",
+			})
+
+			var (
+				nodeName   string = "node1"
+				lrpMAC     string = "00:00:00:05:46:C3"
+				nodeSubnet string = "10.1.0.0/24"
+				gwCIDR     string = "10.1.0.1/24"
+			)
+
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd: "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtos-" + nodeName + " mac",
+				// Return a known MAC; otherwise code autogenerates it
+				Output: lrpMAC,
+			})
+			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+				"ovn-nbctl --timeout=15 --may-exist lrp-add ovn_cluster_router rtos-" + nodeName + " " + lrpMAC + " " + gwCIDR,
+				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + nodeName + " -- set logical_switch " + nodeName + " other-config:subnet=" + nodeSubnet + " external-ids:gateway_ip=" + gwCIDR,
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " stor-" + nodeName + " -- set logical_switch_port stor-" + nodeName + " type=router options:router-port=rtos-" + nodeName + " addresses=\"" + lrpMAC + "\"",
+				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
+				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
+			})
+
+			fexec := &fakeexec.FakeExec{
+				CommandScript: fakeCmds,
+				LookPathFunc: func(file string) (string, error) {
+					return fmt.Sprintf("/fake-bin/%s", file), nil
+				},
+			}
+
+			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
+				Items: []v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}},
+			})
+
+			err := util.SetExec(fexec)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			stopChan := make(chan struct{})
+			factory, err := factory.NewWatchFactory(fakeClient, stopChan)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				close(stopChan)
+			}()
+
+			clusterController := NewClusterController(fakeClient, factory)
+			Expect(clusterController).NotTo(BeNil())
+			clusterController.TCPLoadBalancerUUID = tcpLBUUID
+			clusterController.UDPLoadBalancerUUID = udpLBUUID
+
+			_, ipnet, err := net.ParseCIDR(clusterCIDR)
+			Expect(err).NotTo(HaveOccurred())
+			clusterController.ClusterIPNet = append(clusterController.ClusterIPNet, CIDRNetworkEntry{
+				CIDR:             ipnet,
+				HostSubnetLength: 24,
+			})
+
+			err = clusterController.StartClusterMaster("master")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fexec.CommandCalls).To(Equal(len(fakeCmds)))
+			return nil
+		}
+
+		err := app.Run([]string{app.Name})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(h).NotTo(BeNil())
 			wf.removeHandler(objType, h)
-			close(stop)
+			wf.Shutdown()
 		}
 
 		It("is called for each existing pod", func() {
@@ -250,7 +250,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(numAdded).To(Equal(2))
 			wf.removeHandler(objType, h)
-			close(stop)
+			wf.Shutdown()
 		}
 
 		It("calls ADD for each existing pod", func() {
@@ -349,7 +349,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.RemovePodHandler(h)
-		close(stop)
+		wf.Shutdown()
 	})
 
 	It("responds to namespace add/update/delete events", func() {
@@ -384,7 +384,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.RemoveNamespaceHandler(h)
-		close(stop)
+		wf.Shutdown()
 	})
 
 	It("responds to node add/update/delete events", func() {
@@ -419,7 +419,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.removeHandler(nodeType, h)
-		close(stop)
+		wf.Shutdown()
 	})
 
 	It("responds to policy add/update/delete events", func() {
@@ -454,7 +454,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.removeHandler(policyType, h)
-		close(stop)
+		wf.Shutdown()
 	})
 
 	It("responds to endpoints add/update/delete events", func() {
@@ -496,7 +496,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.removeHandler(endpointsType, h)
-		close(stop)
+		wf.Shutdown()
 	})
 
 	It("responds to service add/update/delete events", func() {
@@ -531,7 +531,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.removeHandler(serviceType, h)
-		close(stop)
+		wf.Shutdown()
 	})
 
 	It("stops processing events after the handler is removed", func() {
@@ -562,7 +562,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		namespaceWatch.Delete(added2)
 		Consistently(func() int { return numDeleted }, 2).Should(Equal(0))
 
-		close(stop)
+		wf.Shutdown()
 	})
 
 	It("filters correctly by label and namespace", func() {
@@ -628,7 +628,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		podWatch.Delete(passesFilter)
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
-		close(stop)
+		wf.Shutdown()
 	})
 
 	It("correctly handles object updates that cause filter changes", func() {
@@ -681,6 +681,6 @@ var _ = Describe("Watch Factory Operations", func() {
 		Consistently(func() int { return numUpdated }, 2).Should(Equal(0))
 
 		wf.RemovePodHandler(h)
-		close(stop)
+		wf.Shutdown()
 	})
 })

--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -187,21 +187,20 @@ func configureManagementPort(clusterSubnet []string, clusterServicesSubnet,
 	return nil
 }
 
-// CreateManagementPort creates a logical switch for the node and connect it to the distributed router. This switch will start with one logical port (A OVS internal interface).
-// 1. This logical port is via which a node can access all other nodes and the containers running inside them using the private IP addresses.
-// 2. When this port is created on the master node, the K8s daemons become reachable from the containers without any NAT.
-// 3. The nodes can health-check the pod IP addresses.
+// CreateManagementPort creates a management port attached to the node switch
+// that lets the node access its pods via their private IP address. This is used
+// for health checking and other management tasks.
 func CreateManagementPort(nodeName, localSubnet,
 	clusterServicesSubnet string, clusterSubnet []string) error {
-	// Create a router port and provide it the first address in the 'local_subnet'.
-	ip, localSubnetNet, err := net.ParseCIDR(localSubnet)
+
+	// Determine the IP of the node switch's logical router port on the cluster router
+	ip, subnet, err := net.ParseCIDR(localSubnet)
 	if err != nil {
-		return fmt.Errorf("Failed to parse local subnet %v : %v", localSubnetNet, err)
+		return fmt.Errorf("Failed to parse local subnet %s: %v", localSubnet, err)
 	}
 	ip = util.NextIP(ip)
-	n, _ := localSubnetNet.Mask.Size()
-	routerIPMask := fmt.Sprintf("%s/%d", ip.String(), n)
 	routerIP := ip.String()
+
 	// Kubernetes emits events when pods are created. The event will contain
 	// only lowercase letters of the hostname even though the kubelet is
 	// started with a hostname that contains lowercase and uppercase letters.
@@ -213,44 +212,8 @@ func CreateManagementPort(nodeName, localSubnet,
 	// initMinion.
 	nodeName = strings.ToLower(nodeName)
 
-	routerMac, stderr, err := util.RunOVNNbctl("--if-exist", "get", "logical_router_port", "rtos-"+nodeName, "mac")
-	if err != nil {
-		logrus.Errorf("Failed to get logical router port,stderr: %q, error: %v", stderr, err)
-		return err
-	}
-
-	var clusterRouter string
-	if routerMac == "" {
-		routerMac = util.GenerateMac()
-	}
-
-	clusterRouter, err = util.GetK8sClusterRouter()
-	if err != nil {
-		return err
-	}
-
-	_, stderr, err = util.RunOVNNbctl("--may-exist", "lrp-add", clusterRouter, "rtos-"+nodeName, routerMac, routerIPMask)
-	if err != nil {
-		logrus.Errorf("Failed to add logical port to router, stderr: %q, error: %v", stderr, err)
-		return err
-	}
-
-	// Create a logical switch and set its subnet.
-	stdout, stderr, err := util.RunOVNNbctl("--", "--may-exist", "ls-add", nodeName, "--", "set", "logical_switch", nodeName, "other-config:subnet="+localSubnet, "external-ids:gateway_ip="+routerIPMask)
-	if err != nil {
-		logrus.Errorf("Failed to create a logical switch %v, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
-		return err
-	}
-
-	// Connect the switch to the router.
-	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add", nodeName, "stor-"+nodeName, "--", "set", "logical_switch_port", "stor-"+nodeName, "type=router", "options:router-port=rtos-"+nodeName, "addresses="+"\""+routerMac+"\"")
-	if err != nil {
-		logrus.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return err
-	}
-
 	// Make sure br-int is created.
-	stdout, stderr, err = util.RunOVSVsctl("--", "--may-exist", "add-br", "br-int")
+	stdout, stderr, err := util.RunOVSVsctl("--", "--may-exist", "add-br", "br-int")
 	if err != nil {
 		logrus.Errorf("Failed to create br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err
@@ -288,9 +251,10 @@ func CreateManagementPort(nodeName, localSubnet,
 		}
 	}
 
-	// Create the OVN logical port.
+	// Create this node's management logical port on the node switch
 	ip = util.NextIP(ip)
 	portIP := ip.String()
+	n, _ := subnet.Mask.Size()
 	portIPMask := fmt.Sprintf("%s/%d", portIP, n)
 	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add", nodeName, "k8s-"+nodeName, "--", "lsp-set-addresses", "k8s-"+nodeName, macAddress+" "+portIP)
 	if err != nil {
@@ -299,40 +263,5 @@ func CreateManagementPort(nodeName, localSubnet,
 	}
 	err = configureManagementPort(clusterSubnet, clusterServicesSubnet,
 		routerIP, interfaceName, portIPMask)
-	if err != nil {
-		return err
-	}
-
-	// Add the load_balancer to the switch.
-	k8sClusterLbTCP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes")
-	if err != nil {
-		logrus.Errorf("Failed to get k8sClusterLbTCP, stderr: %q, error: %v", stderr, err)
-		return err
-	}
-	if k8sClusterLbTCP == "" {
-		return fmt.Errorf("Failed to get k8sClusterLbTCP")
-	}
-
-	stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch", nodeName, "load_balancer="+k8sClusterLbTCP)
-	if err != nil {
-		logrus.Errorf("Failed to set logical switch %v's loadbalancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
-		return err
-	}
-
-	k8sClusterLbUDP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes")
-	if err != nil {
-		logrus.Errorf("Failed to get k8sClusterLbUDP, stderr: %q, error: %v", stderr, err)
-		return err
-	}
-	if k8sClusterLbUDP == "" {
-		return fmt.Errorf("Failed to get k8sClusterLbUDP")
-	}
-
-	stdout, stderr, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "load_balancer", k8sClusterLbUDP)
-	if err != nil {
-		logrus.Errorf("Failed to add logical switch %v's loadbalancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -8,6 +8,7 @@ import (
 	util "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func (oc *Controller) syncPods(pods []interface{}) {
@@ -181,6 +182,39 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 	return
 }
 
+func (oc *Controller) waitForNodeLogicalSwitch(nodeName string) error {
+	oc.lsMutex.Lock()
+	ok := oc.logicalSwitchCache[nodeName]
+	oc.lsMutex.Unlock()
+	// Fast return if we already have the node switch in our cache
+	if ok {
+		return nil
+	}
+
+	// Otherwise wait for the node logical switch to be created by the ClusterController.
+	// The node switch will be created very soon after startup so we should
+	// only be waiting here once per node at most.
+	if err := wait.PollImmediate(500*time.Millisecond, 30*time.Second, func() (bool, error) {
+		if _, _, err := util.RunOVNNbctl("get", "logical_switch", nodeName, "other-config"); err != nil {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		logrus.Errorf("timed out waiting for node %q logical switch: %v", nodeName, err)
+		return err
+	}
+
+	oc.lsMutex.Lock()
+	defer oc.lsMutex.Unlock()
+	if !oc.logicalSwitchCache[nodeName] {
+		if err := oc.addAllowACLFromNode(nodeName); err != nil {
+			return err
+		}
+		oc.logicalSwitchCache[nodeName] = true
+	}
+	return nil
+}
+
 func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 	var out, stderr string
 	var err error
@@ -195,12 +229,9 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		return
 	}
 
-	oc.lsMutex.Lock()
-	if !oc.logicalSwitchCache[logicalSwitch] {
-		oc.logicalSwitchCache[logicalSwitch] = true
-		oc.addAllowACLFromNode(logicalSwitch)
+	if err = oc.waitForNodeLogicalSwitch(pod.Spec.NodeName); err != nil {
+		return
 	}
-	oc.lsMutex.Unlock()
 
 	portName := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
 	logrus.Debugf("Creating logical port for %s on switch %s", portName, logicalSwitch)

--- a/go-controller/pkg/testing/testing.go
+++ b/go-controller/pkg/testing/testing.go
@@ -29,6 +29,7 @@ type ExpectedCmd struct {
 func AddFakeCmd(fakeCmds []fakeexec.FakeCommandAction, expected *ExpectedCmd) []fakeexec.FakeCommandAction {
 	return append(fakeCmds, func(cmd string, args ...string) kexec.Cmd {
 		parts := strings.Split(expected.Cmd, " ")
+		gomega.Expect(len(parts)).To(gomega.BeNumerically(">=", 2))
 		gomega.Expect(cmd).To(gomega.Equal("/fake-bin/" + parts[0]))
 		gomega.Expect(strings.Join(args, " ")).To(gomega.Equal(strings.Join(parts[1:], " ")))
 		return &fakeexec.FakeCmd{

--- a/go-controller/pkg/util/gateway-cleanup.go
+++ b/go-controller/pkg/util/gateway-cleanup.go
@@ -7,8 +7,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// RemoveNode removes all the NB DB objects created for that node.
-func RemoveNode(nodeName string) error {
+// GatewayCleanup removes all the NB DB objects created for a node's gateway
+func GatewayCleanup(nodeName string) error {
 	// Get the cluster router
 	clusterRouter, err := GetK8sClusterRouter()
 	if err != nil {

--- a/go-controller/pkg/util/remove-node.go
+++ b/go-controller/pkg/util/remove-node.go
@@ -15,13 +15,6 @@ func RemoveNode(nodeName string) error {
 		return fmt.Errorf("failed to get cluster router")
 	}
 
-	// Remove the logical switch associated with nodeName
-	_, stderr, err := RunOVNNbctl("--if-exist", "ls-del", nodeName)
-	if err != nil {
-		return fmt.Errorf("Failed to delete logical switch %s, "+
-			"stderr: %q, error: %v", nodeName, stderr, err)
-	}
-
 	gatewayRouter := fmt.Sprintf("GR_%s", nodeName)
 
 	// Get the gateway router port's IP address (connected to join switch)
@@ -72,13 +65,6 @@ func RemoveNode(nodeName string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to delete logical switch port jtor-%s, "+
 			"stderr: %q, error: %v", gatewayRouter, stderr, err)
-	}
-
-	// Remove the patch port that connects distributed router to node's logical switch
-	_, stderr, err = RunOVNNbctl("--if-exist", "lrp-del", "rtos-"+nodeName)
-	if err != nil {
-		return fmt.Errorf("Failed to delete logical router port rtos-%s, "+
-			"stderr: %q, error: %v", nodeName, stderr, err)
 	}
 
 	// Remove any gateway routers associated with nodeName


### PR DESCRIPTION
Node logical switches and their associated connections to the cluster router
are now created in the master on Kube API node add events, and cleaned up
from the master on node delete events.

Fixes: https://github.com/openvswitch/ovn-kubernetes/issues/531

@squeed @danwinship @openvswitch/ovn-kubernetes-team 