### PR TITLE
Add k8s_apiserver to ovn-config configmap

### DIFF
--- a/dist/ansible/ovn-playbook.yaml
+++ b/dist/ansible/ovn-playbook.yaml
@@ -71,6 +71,11 @@
     template: src=../templates/ovnkube-master.yaml.j2 dest=/root/ovn/yaml/ovnkube-master.yaml
   - name: Copy ovnkube-node.yaml
     template: src=../templates/ovnkube-node.yaml.j2 dest=/root/ovn/yaml/ovnkube-node.yaml
+
+  - name: Get the k8s_apiserver
+    shell: grep server /etc/origin/node/node.kubeconfig | awk '{ print $2 }'
+    register: k8s_apisvr
+  - set_fact: k8s_apiserver={{ k8s_apisvr }}
   - name: Set up ovn
     template: src=../templates/ovn-setup.yaml.j2 dest=/root/ovn/yaml/ovn-setup.yaml
 

--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -134,4 +134,4 @@ metadata:
 data:
   net_cidr:      "{{ net_cidr | default('10.128.0.0/14/23') }}"
   svc_cidr:      "{{ svc_cidr | default('172.30.0.0/16') }}"
-
+  k8s_apiserver: "{{ k8s_apiserver.stdout }}"


### PR DESCRIPTION
As of PR 605 - k8s_apiserver is required in the ovn-config configmap
PR 605 didn't set the k8s_apiserver in the config map. This change
fixes that and allows ovn to again work on openshift.

Signed-off-by: Phil Cameron <pcameron@redhat.com>