### PR TITLE
Move iptable port 664[12] open to ovnkube.sh

### DIFF
--- a/dist/ansible/ovn-playbook.yaml
+++ b/dist/ansible/ovn-playbook.yaml
@@ -23,26 +23,6 @@
       state: absent
       name: /var/lib/openvswitch/ovnsb_db.db
 
-  # iptables -I INPUT -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
-  - name: iptables allow 6641
-    iptables:
-      action: insert
-      chain: INPUT
-      ctstate: NEW
-      destination_port: 6641
-      jump: ACCEPT
-      protocol: tcp
-
-  # iptables -I INPUT -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
-  - name: iptables allow 6642
-    iptables:
-      action: insert
-      chain: INPUT
-      ctstate: NEW
-      destination_port: 6642
-      jump: ACCEPT
-      protocol: tcp
-
   # copy yaml files to master
   - name: Make dirctory /root/ovn/yaml
     file:


### PR DESCRIPTION
This simplifies the install by moving the iptables rules
that open the ovn database ports (6641 and 6642) from the install
to ovnkube.sh

SDN-313 Put iptable rules for ovn db access into image
https://jira.coreos.com/browse/SDN-313

Signed-off-by: Phil Cameron <pcameron@redhat.com>