### PR TITLE
[Ansible][contrib] Add workaround for lineinfile concurrency issues

### DIFF
--- a/contrib/ovn-kubernetes-cluster.yml
+++ b/contrib/ovn-kubernetes-cluster.yml
@@ -40,6 +40,16 @@
         name: linux/ovn-kubernetes
     - import_role:
         name: linux/kubernetes
+
+# TODO(alinbalutoiu): Move the hosts file update above once ansible fixes
+# lineinfile concurrency issues https://github.com/ansible/ansible/issues/30413
+- hosts: kube-minions-linux
+  any_errors_fatal: true
+  gather_facts: true
+  become: true
+  serial: 1
+  tasks:
+    - include_tasks: roles/linux/kubernetes/tasks/set_ip_facts.yml
     - name: Ensure /etc/hosts is updated on kube-master
       lineinfile:
         path: /etc/hosts
@@ -85,6 +95,18 @@
         name: windows/ovn-kubernetes
     - import_role:
         name: windows/kubernetes
+
+# TODO(alinbalutoiu): Move the hosts file update above once ansible fixes
+# lineinfile concurrency issues https://github.com/ansible/ansible/issues/30413
+- hosts: kube-minions-windows
+  remote_user: Administrator
+  gather_facts: true
+  become_method: runas
+  any_errors_fatal: true
+  serial: 1
+  tasks:
+    - include_vars: roles/windows/kubernetes/vars/{{ ansible_os_family|lower }}.yml
+    - include_tasks: roles/windows/kubernetes/tasks/set_ip_facts.yml
     - name: Ensure /etc/hosts is updated on kube-master
       become: true
       become_method: sudo


### PR DESCRIPTION
Ansible will try to manage all of the machines
referenced in a play in parallel by default.

The module lineinfile has conccurency issues
when multiple hosts are delegating to the
same host and the same file. This issue
is tracked upstream in ansible:
https://github.com/ansible/ansible/issues/30413

As a temporary workaround, the hosts file will
be updated by all the nodes one by one instead
of doing it in parallel.

Fixes issue #637

Signed-off-by: Alin Balutoiu <alinbalutoiu@gmail.com>