### PR TITLE
[Ansible][contrib] Fix ansible gateway interface for subsequent runs

### DIFF
--- a/contrib/roles/linux/kubernetes/tasks/init_gateway.yml
+++ b/contrib/roles/linux/kubernetes/tasks/init_gateway.yml
@@ -30,7 +30,7 @@
         -service-cluster-ip-range "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
         -nodeport \
         -init-gateways \
-        -gateway-interface={{interface_name}} \
+        -gateway-interface={{physical_interface_name}} \
         -gateway-nexthop="{{gateway_next_hop}}" \
         -nb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6641 \
         -sb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6642


### PR DESCRIPTION
The OVN Gateway Helper service requires the physical
interface name as an argument. On subsequent playbook
runs, it will pass the bridge name instead of the
physical interface name. It should use the variable
physical_interface_name instead of interface_name when
creating the service.

Found by inspection.

Signed-off-by: Alin Balutoiu <alinbalutoiu@gmail.com>