### PR TITLE
ovn/service: handle headless service in Add/Delete Endpoints

### DIFF
--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -25,6 +25,11 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 			ep.Name, ep.Namespace)
 		return nil
 	}
+	if !util.IsServiceIPSet(svc) {
+		logrus.Debugf("Skipping service %s due to clusterIP = %q",
+			svc.Name, svc.Spec.ClusterIP)
+		return nil
+	}
 	tcpPortMap := make(map[string]lbEndpoints)
 	udpPortMap := make(map[string]lbEndpoints)
 	for _, s := range ep.Subsets {
@@ -141,6 +146,9 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 		// will fail.
 		logrus.Debugf("no service found for endpoint %s in namespace %s",
 			ep.Name, ep.Namespace)
+		return nil
+	}
+	if !util.IsServiceIPSet(svc) {
 		return nil
 	}
 	for _, svcPort := range svc.Spec.Ports {

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -2,14 +2,11 @@ package ovn
 
 import (
 	"fmt"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	"net"
 )
-
-func isServiceIPSet(service *kapi.Service) bool {
-	return service.Spec.ClusterIP != kapi.ClusterIPNone && service.Spec.ClusterIP != ""
-}
 
 func (ovn *Controller) syncServices(services []interface{}) {
 	// For all clusterIP in k8s, we will populate the below slice with
@@ -43,7 +40,7 @@ func (ovn *Controller) syncServices(services []interface{}) {
 			continue
 		}
 
-		if !isServiceIPSet(service) {
+		if !util.IsServiceIPSet(service) {
 			logrus.Debugf("Skipping service %s due to clusterIP = %q",
 				service.Name, service.Spec.ClusterIP)
 			continue
@@ -170,7 +167,7 @@ func (ovn *Controller) syncServices(services []interface{}) {
 }
 
 func (ovn *Controller) deleteService(service *kapi.Service) {
-	if !isServiceIPSet(service) || len(service.Spec.Ports) == 0 {
+	if !util.IsServiceIPSet(service) || len(service.Spec.Ports) == 0 {
 		return
 	}
 

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	kapi "k8s.io/api/core/v1"
 	"os/exec"
 	"strings"
 
@@ -30,4 +31,9 @@ func FetchIfMacWindows(interfaceName string) (string, error) {
 	macAddress := strings.Replace(strings.TrimSpace(fmt.Sprintf("%s", stdoutStderr)), "-", ":", -1)
 
 	return strings.ToLower(macAddress), nil
+}
+
+// IsServiceIPSet checks if the service is an headless service or not
+func IsServiceIPSet(service *kapi.Service) bool {
+	return service.Spec.ClusterIP != kapi.ClusterIPNone && service.Spec.ClusterIP != ""
 }


### PR DESCRIPTION
Currently, we are seeing following errors

2019-03-06T12:30:50.983Z|01361|ovn_northd|WARN|Dropped 23 log messages in last 21950 seconds (most recently, 21950 seconds ago) due to excessive rate
2019-03-06T12:30:50.983Z|01362|ovn_northd|WARN|bad ip address or port for load balancer key None:6642

since we are not handling headless service in Add/Delete Endponts.

Signed-off-by: Yun Zhou yunz@nvidia.com
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>