### PR TITLE
PODs on K8s nodes access to host IP when using Shared Gateway Interface

### DIFF
--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -37,3 +37,12 @@ func FetchIfMacWindows(interfaceName string) (string, error) {
 func IsServiceIPSet(service *kapi.Service) bool {
 	return service.Spec.ClusterIP != kapi.ClusterIPNone && service.Spec.ClusterIP != ""
 }
+
+// GetK8sMgmtIntfName returns the correct length interface name to be used
+// as an OVS internal port on the node
+func GetK8sMgmtIntfName(nodeName string) string {
+	if len(nodeName) > 11 {
+		return "k8s-" + (nodeName[:11])
+	}
+	return "k8s-" + nodeName
+}


### PR DESCRIPTION
We have a significant drawback while deploying K8s cluster using OVN-K8s
CNI in Shared gateway interface mode. In this mode,

1. one cannot deploy a POD on the K8s Master node. The PODs requiring
   K8s API Server access ends up in CrashLoopBackOff as it cannot reach
   K8s API Server through the kubernetes Service IP (10.96.0.1:443).
   This happens because 10.96.0.1 is translated to the K8s Master host
   IP and this IP cannot be accessed from the OVN logical topology since
   this same IP address is used by OVN L3 gateway.

2. an another issue is that a POD on a host cannot access any service
   on that host itself. For example: a metrics-server POD on a host H1
   that wants to access the stats from kubelet running on that host at
   port 10250, will fail

This is because the packets from the POD meant for the host on which it
resides gets dropped in lr_in_unsnat table in the L3 gateway router
pipeline.

The solution to this problem is to add an host route to the OVN cluster
router (ovn_cluster_router) for every host through its management port.
These routes should allow the packets meant for the host to exit out
through the management logical switch port on that logical_switch. This
should solve the issues (1) and (2) above.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>