### PR TITLE
cluster: src-ip based routes take precedence and breaks NodePort

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -141,6 +141,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + eth0MAC + "\"",
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 " + eth0GWIP + " rtoe-" + gwRouter,
 			"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat " + eth0IP + " " + clusterCIDR,
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
 			"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
 		})
@@ -354,6 +355,7 @@ func spareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + eth0MAC + "\"",
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 " + eth0GWIP + " rtoe-" + gwRouter,
 			"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat " + eth0IP + " " + clusterCIDR,
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
 			"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
 		})
@@ -516,6 +518,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 rtoe-" + gwRouter,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
 				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
 			})

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -419,6 +419,18 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 		if err != nil {
 			return err
 		}
+
+		// We need to add a /32 route to the Gateway router's IP, on the
+		// cluster router, to ensure that the return traffic goes back
+		// to the same gateway router
+		stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
+			k8sClusterRouter, routerIPByte.String(), routerIPByte.String())
+		if err != nil {
+			return fmt.Errorf("Failed to add /32 route to Gateway router's IP of %q "+
+				"on the distributed router, stdout: %q, stderr: %q, error: %v",
+				routerIPByte.String(), stdout, stderr, err)
+		}
+
 		stdout, stderr, err = RunOVNNbctl("set", "logical_router",
 			gatewayRouter, "options:lb_force_snat_ip="+routerIPByte.String())
 		if err != nil {


### PR DESCRIPTION
The packets to a POD on a K8s node that is an endpoint for a NodePort
service is forced-SNAT'ed to L3 Gateway's IP address. The intent is to
make the reply packets from the POD to exit out through the same L3
gateway. However, the reply packets from the POD matches a
longest-prefix src-ip based static route on OVN cluster router and gets
forwarded to a different L3 gateway.

The fix is to add /32 specific route for each of the GR router's IP.

Fixes #647

Signed-off-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>