### PR TITLE
[Ansible] Small bash script cleanup

### DIFF
--- a/contrib/roles/linux/common/tasks/k8s_client_certs.yml
+++ b/contrib/roles/linux/common/tasks/k8s_client_certs.yml
@@ -73,9 +73,6 @@
           cert_group=kube-cert
           cert_dir="{{ k8s_client_certs.directory }}"
 
-          mkdir -p "$cert_dir"
-          rm -rf "$cert_dir/*"
-
           pem_ca=$cert_dir/ca.pem
           pem_ca_key=$cert_dir/ca-key.pem
 

--- a/contrib/roles/linux/kubernetes/tasks/generate_certs_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/generate_certs_master.yml
@@ -34,8 +34,8 @@
       [ $(getent group $cert_group) ] || groupadd -r $cert_group
 
       # Generate TLS artifacts
-      mkdir -p "$cert_dir"
-      rm -rf "$cert_dir/*"
+      rm -rf $cert_dir
+      mkdir -p $cert_dir
 
       openssl genrsa -out $pem_ca_key 2048
       openssl req -x509 -new -nodes -key $pem_ca_key -days 10000 -out $pem_ca -subj "/CN=kube-ca"


### PR DESCRIPTION
The `mkdir` and `rm -rf` calls are not necessary from the `k8s_client_certs.yml` `make-certs` bash script:

* The K8s certs directory is previously created via an Ansible task, so the `mkdir -p "$cert_dir"` is useless.
* The `rm -rf` has `"$cert_dir/*"` (enclosed in double quotes), and the file with the exact name `*` is tried to be removed from the `$cert_dir` directory. But it doesn't exist, so this call does nothing:

  ```
  root@k8s-04:/home/ionut# cert_dir="/etc/kubernetes/tls"

  root@k8s-04:/home/ionut# ls -l $cert_dir
  total 8
  -rw-r--r-- 1 root root 1675 Mar 26 16:26 ca-key.pem
  -rw-r--r-- 1 root root 1090 Mar 26 16:26 ca.pem

  root@k8s-04:/home/ionut# rm -rf "$cert_dir/*"

  root@k8s-04:/home/ionut# ls -l $cert_dir
  total 8
  -rw-r--r-- 1 root root 1675 Mar 26 16:26 ca-key.pem
  -rw-r--r-- 1 root root 1090 Mar 26 16:26 ca.pem

  root@k8s-04:/home/ionut# ls -l "$cert_dir/*"
  ls: cannot access '/etc/kubernetes/tls/*': No such file or directory
  ```

  However, this causes confusion, because the script will fail if `rm -rf "$cert_dir/*"` will try and remove every file from the `$cert_dir` directory.

Additionally, the `$certs_dir` directory creation for the K8s master node was fixed.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>