### PR TITLE
vagrant: Use dkms kernel module for daemonsets too.

### DIFF
--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -107,10 +107,10 @@ kubectl taint nodes --all node-role.kubernetes.io/master-
 sudo apt-get build-dep dkms
 sudo apt-get install python-six openssl python-pip -y
 sudo apt-get install openvswitch-common libopenvswitch -y
+sudo apt-get install openvswitch-datapath-dkms -y
 
 if [ "$DAEMONSET" != "true" ]; then
   ## Install OVS and OVN components
-  sudo apt-get install openvswitch-datapath-dkms -y
   sudo apt-get install openvswitch-switch
   sudo apt-get install ovn-central ovn-common ovn-host -y
 fi

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -76,10 +76,10 @@ sudo service docker start
 sudo apt-get build-dep dkms
 sudo apt-get install python-six openssl -y
 sudo apt-get install openvswitch-common libopenvswitch -y
+sudo apt-get install openvswitch-datapath-dkms -y
 
 if [ "$DAEMONSET" != "true" ]; then
   ## Install OVS and OVN components
-  sudo apt-get install openvswitch-datapath-dkms -y
   sudo apt-get install openvswitch-switch
   sudo apt-get install ovn-common ovn-host -y
 fi


### PR DESCRIPTION
This gets us the latest kernel module and makes it easy
to test the latest OVS.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>