### PR TITLE
gateway: br-localnet really should be br-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ uses the hostname.  kubelet allows this name to be overridden with
  -cluster-subnet="$CLUSTER_IP_SUBNET" \
  -service-cluster-ip-range=$SERVICE_IP_SUBNET \
  -nodeport \
- -init-gateways -gateway-localnet \
+ -init-gateways -gateway-local \
  -k8s-token="$TOKEN" \
  -nb-address="tcp://$CENTRAL_IP:6641" \
  -sb-address="tcp://$CENTRAL_IP:6642" 2>&1 &

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -114,7 +114,7 @@ ovn_controller_opts=${OVN_CONTROLLER_OPTS:-""}
 ovnkube_loglevel=${OVNKUBE_LOGLEVEL:-4}
 
 #OVN_GATEWAY_OPTS=""
-ovn_gateway_opts=${OVN_GATEWAY_OPTS:-"--gateway-localnet"}
+ovn_gateway_opts=${OVN_GATEWAY_OPTS:-"--gateway-local"}
 
 net_cidr=${OVN_NET_CIDR:-10.128.0.0/14/23}
 svc_cidr=${OVN_SVC_CIDR:-172.30.0.0/16}
@@ -678,7 +678,7 @@ ovn-node () {
 
   echo "=============== ovn-node   --init-node"
   # TEMP HACK - WORKAROUND
-  # --init-gateways --gateway-localnet works around a problem that
+  # --init-gateways --gateway-local works around a problem that
   # results in loss of network connectivity when docker is
   # restarted or ovs daemonset is deleted.
   # TEMP HACK - WORKAROUND
@@ -770,7 +770,7 @@ start_ovn () {
   # ovn-node - all nodes
   echo  "=============== start ovn-node"
   # TEMP HACK - WORKAROUND
-  # --init-gateways --gateway-localnet works around a problem that
+  # --init-gateways --gateway-local works around a problem that
   # results in loss of network connectivity when docker is
   # restarted or ovs daemonset is deleted.
   # TEMP HACK - WORKAROUND

--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -58,10 +58,11 @@ If true, assumes that "gateway-interface" provided can be exclusively
 used for the OVN gateway.  When true, only OVNrelated traffic can flow
 through this interface.
 .TP
-\fB\--gateway-localnet\fR
-If true, creates a localnet gateway to let traffic reach host network
-and also exit host with iptables NAT. A localnet gateway will have
-a IP address of 169.254.33.2.
+\fB\--gateway-local\fR
+If true, creates a local gateway (br-local) to let traffic reach host network
+and also exit host with iptables NAT. A br-local gateway will have
+a IP address of 169.254.33.2 and it will have a port br-nexthop with a IP
+address of 169.254.33.1.
 .TP
 \fB\--nodeport\fR
 Setup nodeport based entries in OVN gateways for ingress into the k8s cluster.

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -198,7 +198,7 @@ func runOvnKube(ctx *cli.Context) error {
 		clusterController.GatewayIntf = ctx.String("gateway-interface")
 		clusterController.GatewayNextHop = ctx.String("gateway-nexthop")
 		clusterController.GatewaySpareIntf = ctx.Bool("gateway-spare-interface")
-		clusterController.LocalnetGateway = ctx.Bool("gateway-localnet")
+		clusterController.LocalnetGateway = ctx.Bool("gateway-local")
 		clusterController.GatewayVLANID = ctx.Uint("gateway-vlanid")
 		clusterController.OvnHA = ctx.Bool("ha")
 

--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -471,10 +471,10 @@ var _ = Describe("Gateway Init Operations", func() {
 			)
 
 			fakeCmds := ovntest.AddFakeCmdsNoOutputNoError(nil, []string{
-				"ovs-vsctl --timeout=15 --may-exist add-br br-localnet",
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + util.PhysicalNetworkName + ":br-localnet",
-				"ip link set br-localnet up",
-				"ovs-vsctl --timeout=15 --may-exist add-port br-localnet br-nexthop -- set interface br-nexthop type=internal",
+				"ovs-vsctl --timeout=15 --may-exist add-br br-local",
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + util.PhysicalNetworkName + ":br-local",
+				"ip link set br-local up",
+				"ovs-vsctl --timeout=15 --may-exist add-port br-local br-nexthop -- set interface br-nexthop type=internal",
 				"ip link set br-nexthop up",
 				"ip addr flush dev br-nexthop",
 				"ip addr add 169.254.33.1/24 dev br-nexthop",
@@ -508,12 +508,12 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 --may-exist ls-add ext_" + nodeName,
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface br-localnet mac_in_use",
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface br-local mac_in_use",
 				Output: brLocalnetMAC,
 			})
 			fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
-				"ovs-vsctl --timeout=15 set bridge br-localnet other-config:hwaddr=" + brLocalnetMAC,
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " br-localnet_" + nodeName + " -- lsp-set-addresses br-localnet_" + nodeName + " unknown -- lsp-set-type br-localnet_" + nodeName + " localnet -- lsp-set-options br-localnet_" + nodeName + " network_name=" + util.PhysicalNetworkName,
+				"ovs-vsctl --timeout=15 set bridge br-local other-config:hwaddr=" + brLocalnetMAC,
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " br-local_" + nodeName + " -- lsp-set-addresses br-local_" + nodeName + " unknown -- lsp-set-type br-local_" + nodeName + " localnet -- lsp-set-options br-local_" + nodeName + " network_name=" + util.PhysicalNetworkName,
 				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + gwRouter + " rtoe-" + gwRouter + " " + brLocalnetMAC + " 169.254.33.2/24 -- set logical_router_port rtoe-" + gwRouter + " external-ids:gateway-physical-ip=yes",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 rtoe-" + gwRouter,

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -97,7 +97,7 @@ func initLocalnetGateway(nodeName string, clusterIPSubnet []string,
 func initLocalnetGatewayInternal(nodeName string, clusterIPSubnet []string,
 	subnet string, ipt util.IPTablesHelper, nodePortEnable bool) error {
 	// Create a localnet OVS bridge.
-	localnetBridgeName := "br-localnet"
+	localnetBridgeName := "br-local"
 	_, stderr, err := util.RunOVSVsctl("--may-exist", "add-br",
 		localnetBridgeName)
 	if err != nil {

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -446,8 +446,8 @@ var OVNGatewayFlags = []cli.Flag{
 			"related traffic can flow through this interface",
 	},
 	cli.BoolFlag{
-		Name: "gateway-localnet",
-		Usage: "If true, creates a localnet gateway to let traffic reach " +
+		Name: "gateway-local",
+		Usage: "If true, creates a local gateway (br-local) to let traffic reach " +
 			"host network and also exit host with iptables NAT",
 	},
 	cli.UintFlag{

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -214,7 +214,7 @@ if [ "$DAEMONSET" != "true" ]; then
    -nodeport \
    -nb-address="$ovn_nb" \
    -sb-address="$ovn_sb" \
-   -init-gateways -gateway-localnet \
+   -init-gateways -gateway-local \
    ${SSL_ARGS} 2>&1 &
 else
   # Daemonset is enabled.


### PR DESCRIPTION
`localnet` is a very well known concept in OVN, so br-localnet gives
a wrong idea to someone who is starting new with ovn-kubernetes. So,
br-localnet should be renamed to br-local (it is similar to what
br-local does in OpenStack).

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>