### PR TITLE
daemonset: wait for ovs to be ready before starting ovnkube-master

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -600,6 +600,10 @@ ovn-master () {
   wait_for_event pid_ready ovn-northd.pid
   sleep 5
 
+  # wait for ovs-servers to start since ovn-master sets some fields in OVS DB
+  echo "=============== ovn-master - (wait for ovs)"
+  wait_for_event ovs_ready
+
   echo "=============== ovn-master ========== MASTER ONLY"
   /usr/bin/ovnkube \
     --init-master ${ovn_pod_host} --net-controller \


### PR DESCRIPTION
ovnkube-master container sets few fields in OVS DB and this fails if
ovs-servers is not ready by that time. This patch fixes that issue.
Otherwise, we will see panics like this below in ovnkube-master.log.

{"log":"panic: Error setting OVS external ID
  'ovn-nb=\"tcp:10.10.0.11:6641\"': exit status 1\n","stream":"stderr",
   "time":"2019-04-05T17:14:08.569185599Z"}

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>