### PR TITLE
ovn: Handle multiple addresses correctly.

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -93,22 +93,31 @@ const (
 func dialNB() (*ovsdb.OVSDB, *dbcache.Cache) {
 	var addrList [][]string
 
-	addr := strings.SplitN(config.OvnNorth.ClientAuth.OvnAddressForClient, ":", 2)
+	addresses := strings.Split(config.OvnNorth.ClientAuth.OvnAddressForClient,
+		",")
 
 	var options map[string]interface{}
+	var useSSL bool
+	for _, address := range addresses {
+		addr := strings.SplitN(address, ":", 2)
 
-	if addr[0] == "ssl" {
-		addr = append(addr, config.OvnNorth.ClientAuth.Cert)
-		addr = append(addr, config.OvnNorth.ClientAuth.PrivKey)
-		addr = append(addr, config.OvnNorth.ClientAuth.CACert)
+		if addr[0] == "ssl" {
+			addr = append(addr, config.OvnNorth.ClientAuth.Cert)
+			addr = append(addr, config.OvnNorth.ClientAuth.PrivKey)
+			addr = append(addr, config.OvnNorth.ClientAuth.CACert)
 
+			useSSL = true
+
+		}
+		addrList = append(addrList, addr)
+	}
+
+	if useSSL {
 		options = map[string]interface{}{
 			"ServerName":         "ovnnb id:ac380054-0a6b-4a3c-9f2d-16a9eb55a89f",
 			"InsecureSkipVerify": true,
 		}
 	}
-
-	addrList = append(addrList, addr)
 
 	nbCache := new(dbcache.Cache)
 	db := ovsdb.Dial(addrList, func(db *ovsdb.OVSDB) error {


### PR DESCRIPTION
The address provided is of the form:
"tcp://10.10.0.11:6641,tcp://10.10.0.12:6641,tcp://10.10.0.13:6641".
We are currently not splitting it.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>