### PR TITLE
daemonset: fix logic error in pid_ready and pid_health

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -224,7 +224,7 @@ pid_ready () {
   pidfile=/var/run/openvswitch/${1}
   if [[ -f ${pidfile} ]] ; then
     pid=$(cat ${pidfile})
-    pidTest=$(ps ax | awk '{ print $1 }' | grep "${pid:-XX}")
+    pidTest=$(ps ax | awk '{ print $1 }' | grep "^${pid:-XX}$")
     if [[ ${pid:-XX} == ${pidTest} ]] ; then
       return 0
     fi
@@ -239,7 +239,7 @@ pid_ready () {
 pid_health () {
   pid=$(cat $1)
   while true; do
-    pidTest=$(ps ax | awk '{ print $1 }' | grep "${pid:-XX}")
+    pidTest=$(ps ax | awk '{ print $1 }' | grep "^${pid:-XX}$")
     if [[ ${pid:-XX} != ${pidTest} ]] ; then
       echo "=============== pid ${pid} terminated ========== "
       # kill the tail -f


### PR DESCRIPTION
There is an issue in pid_ready() and pid_health() where in the PID from
the respective daemon's pidfile is not compared for the exact match in
the `ps` output.

This results in pid_health() abnormally terminating a daemon and
causing a container restart or pid_read() will never see the daemon to
be up and waits till it timesout and restarts the process

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>