### PR TITLE
iptables: issues with usage of append() and iptable rules ordering

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -549,8 +549,8 @@ var _ = Describe("Gateway Init Operations", func() {
 						"-i br-nexthop -m comment --comment from OVN to localhost -j ACCEPT",
 					},
 					"FORWARD": []string{
-						"-i br-nexthop -j ACCEPT",
 						"-o br-nexthop -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
+						"-i br-nexthop -j ACCEPT",
 					},
 				},
 				"nat": {

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -131,11 +131,11 @@ func (f *FakeIPTables) Insert(tableName, chainName string, pos int, rulespec ...
 	}
 	rule := strings.Join(rulespec, " ")
 	chain, _ := table.getChain(chainName)
-	if pos >= len(chain) {
+	if pos > len(chain) {
 		(*table)[chainName] = append(chain, rule)
 	} else {
-		first := append(chain[:pos-1], rule)
-		(*table)[chainName] = append(first, chain[pos-1:]...)
+		last := append([]string{rule}, chain[pos-1:]...)
+		(*table)[chainName] = append(chain[:pos-1], last...)
 	}
 	return nil
 }


### PR DESCRIPTION
Per append() documentation if the slice has sufficient capacity, then it
would reslice the 1st argument to accommodate the new elements. This
was causing a logic error in how the iptable rules were getting inserted
at position 1 in a chain.

Also, the rule ordering was incorrect if the chain already had one
rule in it.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>